### PR TITLE
Remove dart:mirrors usage

### DIFF
--- a/lib/src/api/reaction.dart
+++ b/lib/src/api/reaction.dart
@@ -44,7 +44,8 @@ ReactionDisposer autorun(Function(Reaction) fn, {String name, int delay}) {
 /// You can also pass in an optional [name], a debouncing [delay] in milliseconds. Use
 /// [fireImmediately] if you want to invoke the effect immediately without waiting for
 /// the [predicate] to change its value.
-ReactionDisposer reaction<T>(Function predicate, void Function(T) effect,
+ReactionDisposer reaction<T>(
+    T Function(Reaction) predicate, void Function(T) effect,
     {String name, int delay, bool fireImmediately}) {
   return createReaction(predicate, effect,
       name: name, delay: delay, fireImmediately: fireImmediately);

--- a/lib/src/api/reaction_helper.dart
+++ b/lib/src/api/reaction_helper.dart
@@ -33,12 +33,11 @@ class ReactionDisposer {
   call() => $mobx.dispose();
 }
 
-ReactionDisposer createAutorun(Function(Reaction) fn,
+ReactionDisposer createAutorun(Function(Reaction) trackingFn,
     {String name, int delay}) {
   Reaction rxn;
 
   var rxnName = name ?? 'Autorun@${ctx.nextId}';
-  var trackingFn = prepareTrackingFunction(fn);
 
   if (delay == null) {
     // Use a sync-scheduler.
@@ -76,12 +75,12 @@ ReactionDisposer createAutorun(Function(Reaction) fn,
   return ReactionDisposer(rxn);
 }
 
-ReactionDisposer createReaction<T>(Function predicate, void Function(T) effect,
+ReactionDisposer createReaction<T>(
+    T Function(Reaction) predicate, void Function(T) effect,
     {String name, int delay, bool fireImmediately}) {
   Reaction rxn;
 
   var rxnName = name ?? 'Reaction@${ctx.nextId}';
-  var trackingPredicateFn = prepareTrackingFunction(predicate);
 
   var effectAction =
       action((T value) => effect(value), name: '${rxnName}-effect');
@@ -100,7 +99,7 @@ ReactionDisposer createReaction<T>(Function predicate, void Function(T) effect,
     var changed = false;
 
     rxn.track(() {
-      var nextValue = trackingPredicateFn(rxn);
+      var nextValue = predicate(rxn);
       changed = firstTime || (nextValue != value);
       value = nextValue;
     });

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,7 +1,4 @@
 import 'dart:async';
-import 'dart:mirrors';
-
-import 'package:mobx/src/core/reaction.dart';
 
 const ms = const Duration(milliseconds: 1);
 
@@ -9,20 +6,4 @@ Timer Function(Function) createDelayedScheduler(int delayMs) {
   return (Function fn) {
     return Timer(ms * delayMs, fn);
   };
-}
-
-Function(Reaction) prepareTrackingFunction(Function fn) {
-  var mirror = reflect(fn);
-  if (mirror is ClosureMirror) {
-    if (mirror.function.parameters.length >= 1) {
-      var param = mirror.function.parameters.first;
-      if (param.type.reflectedType == Reaction) {
-        return (Reaction rxn) {
-          return fn(rxn);
-        };
-      }
-    }
-  }
-
-  return (Reaction rxn) => fn();
 }

--- a/test/reaction_test.dart
+++ b/test/reaction_test.dart
@@ -8,7 +8,7 @@ void main() {
   test('Reaction basics', () {
     var executed = false;
     var x = observable(10);
-    var d = reaction(() {
+    var d = reaction((_) {
       return x.value > 10;
     }, (isGreaterThan10) {
       executed = true;
@@ -34,7 +34,7 @@ void main() {
     var x = observable(10);
     var executed = false;
 
-    var d = reaction(() {
+    var d = reaction((_) {
       return x.value > 10;
     }, (isGreaterThan10) {
       executed = true;
@@ -58,7 +58,7 @@ void main() {
     var x = observable(10);
     var executed = false;
 
-    var d = reaction(() {
+    var d = reaction((_) {
       return x.value > 10;
     }, (isGreaterThan10) {
       executed = true;
@@ -72,7 +72,7 @@ void main() {
     var x = observable(10);
     var executed = false;
 
-    var d = reaction(() {
+    var d = reaction((_) {
       return x.value > 10;
     }, (isGreaterThan10) {
       executed = true;


### PR DESCRIPTION
Mirrors are not supported in Flutter or recommended on the web platform, as reflection makes tree shaking the code impossible. (see https://www.dartlang.org/articles/server/reflection-with-mirrors).

I just removed the "overload" of reaction, as the parameter can easily be ignored by using `_` as the name.
