### PR TITLE
Inject ReactiveContext as constructor argument

### DIFF
--- a/lib/src/api/action.dart
+++ b/lib/src/api/action.dart
@@ -35,21 +35,21 @@ import 'package:mobx/src/core/context.dart';
 /// can also be nested inside, in which case the change notification will propagate when
 /// the top-level action completes.
 Action action(Function fn, {String name, ReactiveContext context}) =>
-    Action(context ?? mobxContext, fn, name: name);
+    Action(context ?? currentContext, fn, name: name);
 
 Action runInAction(Function fn, {String name, ReactiveContext context}) =>
-    Action(context ?? mobxContext, fn, name: name)();
+    Action(context ?? currentContext, fn, name: name)();
 
 /// Untracked ensures there is no tracking derivation while the given action runs.
 /// This is useful in cases where no observers should be linked to a running (tracking) derivation.
 T untracked<T>(T Function() action, {ReactiveContext context}) =>
-    (context ?? mobxContext).untracked(action);
+    (context ?? currentContext).untracked(action);
 
 /// During a transaction, no derivations (Reaction or ComputedValue<T>) will be run
 /// and will be deferred until the end of the transaction (batch). Transactions can
 /// be nested, in which case, no derivation will be run until the top-most batch completes
 T transaction<T>(T Function() action, {ReactiveContext context}) {
-  final ctx = context ?? mobxContext
+  final ctx = context ?? currentContext
     ..startBatch();
   try {
     return action();

--- a/lib/src/api/context.dart
+++ b/lib/src/api/context.dart
@@ -1,0 +1,4 @@
+import 'package:mobx/src/core/context.dart';
+
+/// Global Mobx context.
+final ReactiveContext mobxContext = ReactiveContext();

--- a/lib/src/api/context.dart
+++ b/lib/src/api/context.dart
@@ -1,4 +1,6 @@
 import 'package:mobx/src/core/context.dart';
 
-/// Global Mobx context.
-final ReactiveContext mobxContext = ReactiveContext();
+/// Current Mobx context.
+/// At the moment it is a singleton, but in the future
+/// it might be replaced with a Zone specific value.
+final ReactiveContext currentContext = ReactiveContext();

--- a/lib/src/api/observable.dart
+++ b/lib/src/api/observable.dart
@@ -1,3 +1,4 @@
+import 'package:mobx/src/api/context.dart';
 import 'package:mobx/src/core/atom.dart';
 import 'package:mobx/src/core/computed.dart';
 import 'package:mobx/src/core/context.dart';
@@ -17,8 +18,9 @@ import 'package:mobx/src/core/observable.dart';
 ///
 /// print('x = ${x.value}'); // read an observable's value
 /// ```
-ObservableValue<T> observable<T>(T initialValue, {String name}) =>
-    ObservableValue(initialValue, name: name);
+ObservableValue<T> observable<T>(T initialValue,
+        {String name, ReactiveContext context}) =>
+    ObservableValue(context ?? mobxContext, initialValue, name: name);
 
 /// Creates a computed value with an optional [name].
 ///
@@ -47,8 +49,9 @@ ObservableValue<T> observable<T>(T initialValue, {String name}) =>
 /// A computed value is _cached_ and it recomputes only when the dependent observables actually
 /// change. This makes them fast and you are free to use them throughout your application. Internally
 /// MobX uses a 2-phase change propagation that ensures no unnecessary computations are performed.
-ComputedValue<T> computed<T>(T Function() fn, {String name}) =>
-    ComputedValue(fn, name: name);
+ComputedValue<T> computed<T>(T Function() fn,
+        {String name, ReactiveContext context}) =>
+    ComputedValue(context ?? mobxContext, fn, name: name);
 
 /// Creates a simple Atom for tracking its usage in a reactive context. This is useful when
 /// you don't need the value but instead a way of knowing when it becomes active and inactive
@@ -56,6 +59,8 @@ ComputedValue<T> computed<T>(T Function() fn, {String name}) =>
 ///
 /// Use the [onObserved] and [onUnobserved] handlers to know when the atom is active and inactive
 /// respectively. Use a debug [name] to identify easily.
-Atom createAtom({String name, Function onObserved, Function onUnobserved}) =>
-    Atom(name ?? 'Atom@${ctx.nextId}',
-        onObserve: onObserved, onUnobserve: onUnobserved);
+Atom createAtom({String name, Function onObserved, Function onUnobserved}) {
+  final context = mobxContext;
+  return Atom(context,
+      name: name, onObserve: onObserved, onUnobserve: onUnobserved);
+}

--- a/lib/src/api/observable.dart
+++ b/lib/src/api/observable.dart
@@ -20,7 +20,7 @@ import 'package:mobx/src/core/observable.dart';
 /// ```
 ObservableValue<T> observable<T>(T initialValue,
         {String name, ReactiveContext context}) =>
-    ObservableValue(context ?? mobxContext, initialValue, name: name);
+    ObservableValue(context ?? currentContext, initialValue, name: name);
 
 /// Creates a computed value with an optional [name].
 ///
@@ -51,7 +51,7 @@ ObservableValue<T> observable<T>(T initialValue,
 /// MobX uses a 2-phase change propagation that ensures no unnecessary computations are performed.
 ComputedValue<T> computed<T>(T Function() fn,
         {String name, ReactiveContext context}) =>
-    ComputedValue(context ?? mobxContext, fn, name: name);
+    ComputedValue(context ?? currentContext, fn, name: name);
 
 /// Creates a simple Atom for tracking its usage in a reactive context. This is useful when
 /// you don't need the value but instead a way of knowing when it becomes active and inactive
@@ -60,7 +60,7 @@ ComputedValue<T> computed<T>(T Function() fn,
 /// Use the [onObserved] and [onUnobserved] handlers to know when the atom is active and inactive
 /// respectively. Use a debug [name] to identify easily.
 Atom createAtom({String name, Function onObserved, Function onUnobserved}) {
-  final context = mobxContext;
+  final context = currentContext;
   return Atom(context,
       name: name, onObserve: onObserved, onUnobserve: onUnobserved);
 }

--- a/lib/src/api/observable.dart
+++ b/lib/src/api/observable.dart
@@ -59,8 +59,10 @@ ComputedValue<T> computed<T>(T Function() fn,
 ///
 /// Use the [onObserved] and [onUnobserved] handlers to know when the atom is active and inactive
 /// respectively. Use a debug [name] to identify easily.
-Atom createAtom({String name, Function onObserved, Function onUnobserved}) {
-  final context = currentContext;
-  return Atom(context,
-      name: name, onObserve: onObserved, onUnobserve: onUnobserved);
-}
+Atom createAtom(
+        {String name,
+        Function onObserved,
+        Function onUnobserved,
+        ReactiveContext context}) =>
+    Atom(context ?? currentContext,
+        name: name, onObserve: onObserved, onUnobserve: onUnobserved);

--- a/lib/src/api/reaction.dart
+++ b/lib/src/api/reaction.dart
@@ -30,7 +30,7 @@ import 'package:mobx/src/core/reaction.dart';
 
 ReactionDisposer autorun(Function(Reaction) fn,
         {String name, int delay, ReactiveContext context}) =>
-    createAutorun(context ?? mobxContext, fn, name: name, delay: delay);
+    createAutorun(context ?? currentContext, fn, name: name, delay: delay);
 
 /// Executes the [predicate] function and tracks the observables used in it. Returns
 /// a function to dispose the reaction.
@@ -49,7 +49,7 @@ ReactionDisposer reaction<T>(
         int delay,
         bool fireImmediately,
         ReactiveContext context}) =>
-    createReaction(context ?? mobxContext, predicate, effect,
+    createReaction(context ?? currentContext, predicate, effect,
         name: name, delay: delay, fireImmediately: fireImmediately);
 
 /// A one-time reaction that auto-disposes when the [predicate] becomes true. It also
@@ -64,7 +64,8 @@ ReactionDisposer when(
   String name,
   ReactiveContext context,
 }) =>
-    createWhenReaction(context ?? mobxContext, predicate, effect, name: name);
+    createWhenReaction(context ?? currentContext, predicate, effect,
+        name: name);
 
 /// A variant of [when()] which returns a Future. The Future completes when the [predicate()] turns true.
 /// Note that there is no effect function here. Typically you would await on the Future and execute the
@@ -76,4 +77,4 @@ ReactionDisposer when(
 /// ```
 Future<void> asyncWhen(bool Function() predicate,
         {String name, ReactiveContext context}) =>
-    createAsyncWhenReaction(context ?? mobxContext, predicate, name: name);
+    createAsyncWhenReaction(context ?? currentContext, predicate, name: name);

--- a/lib/src/api/reaction.dart
+++ b/lib/src/api/reaction.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 
+import 'package:mobx/src/api/context.dart';
 import 'package:mobx/src/api/reaction_helper.dart';
+import 'package:mobx/src/core/context.dart';
 import 'package:mobx/src/core/reaction.dart';
 
 /// Executes the specified [fn], whenever the dependent observables change. It returns
@@ -26,8 +28,9 @@ import 'package:mobx/src/core/reaction.dart';
 /// x.value = 30; // Will not cause autorun() to re-trigger as it's disposed.
 /// ```
 
-ReactionDisposer autorun(Function(Reaction) fn, {String name, int delay}) =>
-    createAutorun(fn, name: name, delay: delay);
+ReactionDisposer autorun(Function(Reaction) fn,
+        {String name, int delay, ReactiveContext context}) =>
+    createAutorun(context ?? mobxContext, fn, name: name, delay: delay);
 
 /// Executes the [predicate] function and tracks the observables used in it. Returns
 /// a function to dispose the reaction.
@@ -42,8 +45,11 @@ ReactionDisposer autorun(Function(Reaction) fn, {String name, int delay}) =>
 /// the [predicate] to change its value.
 ReactionDisposer reaction<T>(
         T Function(Reaction) predicate, void Function(T) effect,
-        {String name, int delay, bool fireImmediately}) =>
-    createReaction(predicate, effect,
+        {String name,
+        int delay,
+        bool fireImmediately,
+        ReactiveContext context}) =>
+    createReaction(context ?? mobxContext, predicate, effect,
         name: name, delay: delay, fireImmediately: fireImmediately);
 
 /// A one-time reaction that auto-disposes when the [predicate] becomes true. It also
@@ -56,8 +62,9 @@ ReactionDisposer when(
   bool Function() predicate,
   void Function() effect, {
   String name,
+  ReactiveContext context,
 }) =>
-    createWhenReaction(predicate, effect, name: name);
+    createWhenReaction(context ?? mobxContext, predicate, effect, name: name);
 
 /// A variant of [when()] which returns a Future. The Future completes when the [predicate()] turns true.
 /// Note that there is no effect function here. Typically you would await on the Future and execute the
@@ -67,5 +74,6 @@ ReactionDisposer when(
 /// await asyncWhen(() => x.value > 10);
 /// // ... execute the effect ...
 /// ```
-Future<void> asyncWhen(bool Function() predicate, {String name}) =>
-    createAsyncWhenReaction(predicate, name: name);
+Future<void> asyncWhen(bool Function() predicate,
+        {String name, ReactiveContext context}) =>
+    createAsyncWhenReaction(context ?? mobxContext, predicate, name: name);

--- a/lib/src/api/reaction_helper.dart
+++ b/lib/src/api/reaction_helper.dart
@@ -39,7 +39,7 @@ ReactionDisposer createAutorun(
     {String name, int delay}) {
   Reaction rxn;
 
-  final rxnName = name ?? context.name('Autorun');
+  final rxnName = name ?? context.nameFor('Autorun');
 
   if (delay == null) {
     // Use a sync-scheduler.
@@ -82,7 +82,7 @@ ReactionDisposer createReaction<T>(ReactiveContext context,
     {String name, int delay, bool fireImmediately}) {
   Reaction rxn;
 
-  final rxnName = name ?? context.name('Reaction');
+  final rxnName = name ?? context.nameFor('Reaction');
 
   final effectAction =
       action((T value) => effect(value), name: '$rxnName-effect');
@@ -153,7 +153,7 @@ ReactionDisposer createWhenReaction(
   void Function() effect, {
   String name,
 }) {
-  final rxnName = name ?? context.name('When');
+  final rxnName = name ?? context.nameFor('When');
   final effectAction = action(effect, name: '$rxnName-effect');
 
   return createAutorun(context, (reaction) {

--- a/lib/src/core/action.dart
+++ b/lib/src/core/action.dart
@@ -3,7 +3,7 @@ import 'package:mobx/src/core/derivation.dart';
 
 class Action {
   Action(this._context, this._fn, {String name})
-      : name = name ?? _context.name('Action');
+      : name = name ?? _context.nameFor('Action');
 
   final ReactiveContext _context;
 

--- a/lib/src/core/atom.dart
+++ b/lib/src/core/atom.dart
@@ -8,7 +8,7 @@ enum _ListenerKind {
 
 class Atom {
   Atom(this._context, {String name, Function onObserve, Function onUnobserve})
-      : name = name ?? _context.name('Atom') {
+      : name = name ?? _context.nameFor('Atom') {
     if (onObserve != null) {
       onBecomeObserved(onObserve);
     }

--- a/lib/src/core/atom.dart
+++ b/lib/src/core/atom.dart
@@ -7,7 +7,8 @@ enum _ListenerKind {
 }
 
 class Atom {
-  Atom(this.name, {Function onObserve, Function onUnobserve}) {
+  Atom(this._context, {String name, Function onObserve, Function onUnobserve})
+      : name = name ?? _context.name('Atom') {
     if (onObserve != null) {
       onBecomeObserved(onObserve);
     }
@@ -17,7 +18,9 @@ class Atom {
     }
   }
 
-  String name;
+  final ReactiveContext _context;
+
+  final String name;
 
   bool isPendingUnobservation = false;
 
@@ -30,11 +33,11 @@ class Atom {
   final Map<_ListenerKind, Set<Function()>> _observationListeners = {};
 
   void reportObserved() {
-    ctx.reportObserved(this);
+    _context.reportObserved(this);
   }
 
   void reportChanged() {
-    ctx
+    _context
       ..startBatch()
       ..propagateChanged(this)
       ..endBatch();
@@ -51,7 +54,7 @@ class Atom {
   void removeObserver(Derivation d) {
     observers.removeWhere((ob) => ob == d);
     if (observers.isEmpty) {
-      ctx.enqueueForUnobservation(this);
+      _context.enqueueForUnobservation(this);
     }
   }
 

--- a/lib/src/core/computed.dart
+++ b/lib/src/core/computed.dart
@@ -5,7 +5,7 @@ import 'package:mobx/src/core/derivation.dart';
 
 class ComputedValue<T> extends Atom implements Derivation {
   ComputedValue(this._context, this._fn, {String name})
-      : super(_context, name: name ?? _context.name('Computed'));
+      : super(_context, name: name ?? _context.nameFor('Computed'));
 
   final ReactiveContext _context;
 

--- a/lib/src/core/context.dart
+++ b/lib/src/core/context.dart
@@ -19,7 +19,7 @@ class ReactiveContext {
 
   int get nextId => ++_state.nextIdCounter;
 
-  String name(String prefix) {
+  String nameFor(String prefix) {
     assert(prefix != null);
     assert(prefix.isNotEmpty);
     return '$prefix@$nextId';

--- a/lib/src/core/context.dart
+++ b/lib/src/core/context.dart
@@ -1,4 +1,3 @@
-import 'package:mobx/src/core/action.dart';
 import 'package:mobx/src/core/atom.dart';
 import 'package:mobx/src/core/computed.dart';
 import 'package:mobx/src/core/derivation.dart';
@@ -19,6 +18,12 @@ class ReactiveContext {
   final _ReactiveState _state = _ReactiveState();
 
   int get nextId => ++_state.nextIdCounter;
+
+  String name(String prefix) {
+    assert(prefix != null);
+    assert(prefix.isNotEmpty);
+    return '$prefix@$nextId';
+  }
 
   void startBatch() {
     _state.batch++;
@@ -256,6 +261,15 @@ class ReactiveContext {
   void untrackedEnd(Derivation prevDerivation) {
     _state.trackingDerivation = prevDerivation;
   }
+
+  T untracked<T>(T Function() action) {
+    final prevDerivation = untrackedStart();
+    try {
+      return action();
+    } finally {
+      untrackedEnd(prevDerivation);
+    }
+  }
 }
 
 class MobXException implements Exception {
@@ -263,5 +277,3 @@ class MobXException implements Exception {
 
   String message;
 }
-
-final ReactiveContext ctx = ReactiveContext();

--- a/lib/src/core/derivation.dart
+++ b/lib/src/core/derivation.dart
@@ -24,7 +24,7 @@ enum DerivationState {
 }
 
 abstract class Derivation {
-  String name;
+  String get name;
   Set<Atom> observables;
   Set<Atom> newObservables;
 

--- a/lib/src/core/observable.dart
+++ b/lib/src/core/observable.dart
@@ -5,10 +5,8 @@ import 'package:mobx/src/listenable.dart';
 
 class ObservableValue<T> extends Atom
     implements Listenable<T>, Interceptable<T> {
-  ObservableValue(T value, {String name}) : super(name) {
-    this.name = name ?? 'Observable@${ctx.nextId}';
-    _value = value;
-  }
+  ObservableValue(ReactiveContext context, this._value, {String name})
+      : super(context, name: name ?? context.name('Observable'));
 
   T _value;
 

--- a/lib/src/core/observable.dart
+++ b/lib/src/core/observable.dart
@@ -6,7 +6,7 @@ import 'package:mobx/src/listenable.dart';
 class ObservableValue<T> extends Atom
     implements Listenable<T>, Interceptable<T> {
   ObservableValue(ReactiveContext context, this._value, {String name})
-      : super(context, name: name ?? context.name('Observable'));
+      : super(context, name: name ?? context.nameFor('Observable'));
 
   T _value;
 

--- a/lib/src/core/reaction.dart
+++ b/lib/src/core/reaction.dart
@@ -3,10 +3,11 @@ import 'package:mobx/src/core/context.dart';
 import 'package:mobx/src/core/derivation.dart';
 
 class Reaction implements Derivation {
-  Reaction(onInvalidate, {this.name}) {
+  Reaction(this._context, Function() onInvalidate, {this.name}) {
     _onInvalidate = onInvalidate;
   }
 
+  final ReactiveContext _context;
   void Function() _onInvalidate;
   bool _isScheduled = false;
   bool _isDisposed = false;
@@ -32,17 +33,17 @@ class Reaction implements Derivation {
   }
 
   void track(void Function() fn) {
-    ctx.startBatch();
+    _context.startBatch();
 
     _isRunning = true;
-    ctx.trackDerivation(this, fn);
+    _context.trackDerivation(this, fn);
     _isRunning = false;
 
     if (_isDisposed) {
-      ctx.clearObservables(this);
+      _context.clearObservables(this);
     }
 
-    ctx.endBatch();
+    _context.endBatch();
   }
 
   void run() {
@@ -50,15 +51,15 @@ class Reaction implements Derivation {
       return;
     }
 
-    ctx.startBatch();
+    _context.startBatch();
 
     _isScheduled = false;
 
-    if (ctx.shouldCompute(this)) {
+    if (_context.shouldCompute(this)) {
       _onInvalidate();
     }
 
-    ctx.endBatch();
+    _context.endBatch();
   }
 
   void dispose() {
@@ -72,7 +73,7 @@ class Reaction implements Derivation {
       return;
     }
 
-    ctx
+    _context
       ..startBatch()
       ..clearObservables(this)
       ..endBatch();
@@ -84,7 +85,7 @@ class Reaction implements Derivation {
     }
 
     _isScheduled = true;
-    ctx
+    _context
       ..addPendingReaction(this)
       ..runReactions();
   }

--- a/lib/src/interceptable.dart
+++ b/lib/src/interceptable.dart
@@ -1,4 +1,4 @@
-import 'package:mobx/src/core/action.dart';
+import 'package:mobx/src/api/action.dart';
 import 'package:mobx/src/core/atom.dart';
 
 typedef Interceptor<T> = Function(WillChangeNotification<T>);

--- a/lib/src/listenable.dart
+++ b/lib/src/listenable.dart
@@ -1,4 +1,4 @@
-import 'package:mobx/src/core/action.dart';
+import 'package:mobx/src/api/action.dart';
 import 'package:mobx/src/core/atom.dart';
 
 abstract class Listenable<T> {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ author: Pavan Podila <pavan@pixelingene.com>
 homepage: https://github.com/mobxjs/mobx.dart
 
 environment:
-  sdk: '>=2.1.0 <3.0.0'
+  sdk: '>=2.1.0-dev <3.0.0'
 
 dev_dependencies:
   test: ^1.5.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,3 +11,4 @@ environment:
 dev_dependencies:
   test: ^1.5.1
   fake_async: ^1.0.1
+  mockito: ^4.0.0

--- a/test/action_test.dart
+++ b/test/action_test.dart
@@ -1,7 +1,11 @@
 import 'package:mobx/src/api/action.dart';
 import 'package:mobx/src/api/observable.dart';
 import 'package:mobx/src/api/reaction.dart';
+import 'package:mobx/src/core/action.dart';
+import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
+
+import 'shared_mocks.dart';
 
 void main() {
   test('Action basics work', () {
@@ -179,5 +183,18 @@ void main() {
     expect(total, equals(300));
 
     d();
+  });
+
+  test('action uses provided context', () {
+    final context = MockContext();
+    void fn() {}
+    final action = Action(context, fn);
+    action();
+
+    verify(context.nameFor('Action'));
+    verify(context.untrackedStart());
+    verify(context.startBatch());
+    verify(context.endBatch());
+    verify(context.untrackedEnd(null));
   });
 }

--- a/test/action_test.dart
+++ b/test/action_test.dart
@@ -1,7 +1,6 @@
 import 'package:mobx/src/api/action.dart';
 import 'package:mobx/src/api/observable.dart';
 import 'package:mobx/src/api/reaction.dart';
-import 'package:mobx/src/core/action.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
@@ -188,8 +187,9 @@ void main() {
   test('action uses provided context', () {
     final context = MockContext();
     void fn() {}
-    final action = Action(context, fn);
-    action();
+    final act = action(fn, context: context);
+
+    act();
 
     verify(context.nameFor('Action'));
     verify(context.untrackedStart());

--- a/test/action_test.dart
+++ b/test/action_test.dart
@@ -1,7 +1,6 @@
 import 'package:mobx/src/api/action.dart';
 import 'package:mobx/src/api/observable.dart';
 import 'package:mobx/src/api/reaction.dart';
-import 'package:mobx/src/core/action.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test/computed_test.dart
+++ b/test/computed_test.dart
@@ -1,7 +1,7 @@
 import 'package:mobx/src/api/action.dart';
+import 'package:mobx/src/api/context.dart';
 import 'package:mobx/src/api/observable.dart';
 import 'package:mobx/src/api/reaction.dart';
-import 'package:mobx/src/core/context.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -14,7 +14,7 @@ void main() {
     y.value = 20;
     expect(c.value, equals(50));
 
-    expect(ctx.isComputingDerivation(), isFalse);
+    expect(mobxContext.isComputingDerivation(), isFalse);
   });
 
   test('Computed value hierarchy', () {
@@ -64,7 +64,7 @@ void main() {
     expect(c1ComputationCount, equals(3));
     expect(c3ComputationCount, equals(2));
 
-    expect(ctx.isComputingDerivation(), isFalse);
+    expect(mobxContext.isComputingDerivation(), isFalse);
 
     d();
   });

--- a/test/computed_test.dart
+++ b/test/computed_test.dart
@@ -1,8 +1,10 @@
-import 'package:mobx/src/api/action.dart';
 import 'package:mobx/src/api/context.dart';
-import 'package:mobx/src/api/observable.dart';
-import 'package:mobx/src/api/reaction.dart';
+import 'package:mobx/src/core/computed.dart';
+import 'package:mockito/mockito.dart';
+import 'package:mobx/mobx.dart' hide when;
 import 'package:test/test.dart';
+
+import 'shared_mocks.dart';
 
 void main() {
   test('Computed value', () {
@@ -90,5 +92,15 @@ void main() {
     x.value = 100; // should not invoke observe
 
     expect(executionCount, equals(1));
+  });
+
+  test('computed uses provided context', () {
+    final context = MockContext();
+    int fn() => 1;
+
+    final value = ComputedValue(context, fn)..computeValue(track: true);
+
+    verify(context.nameFor('Computed'));
+    verify(context.trackDerivation(value, fn));
   });
 }

--- a/test/computed_test.dart
+++ b/test/computed_test.dart
@@ -14,7 +14,7 @@ void main() {
     y.value = 20;
     expect(c.value, equals(50));
 
-    expect(mobxContext.isComputingDerivation(), isFalse);
+    expect(currentContext.isComputingDerivation(), isFalse);
   });
 
   test('Computed value hierarchy', () {
@@ -64,7 +64,7 @@ void main() {
     expect(c1ComputationCount, equals(3));
     expect(c3ComputationCount, equals(2));
 
-    expect(mobxContext.isComputingDerivation(), isFalse);
+    expect(currentContext.isComputingDerivation(), isFalse);
 
     d();
   });

--- a/test/computed_test.dart
+++ b/test/computed_test.dart
@@ -1,5 +1,4 @@
 import 'package:mobx/src/api/context.dart';
-import 'package:mobx/src/core/computed.dart';
 import 'package:mockito/mockito.dart';
 import 'package:mobx/mobx.dart' hide when;
 import 'package:test/test.dart';
@@ -98,7 +97,7 @@ void main() {
     final context = MockContext();
     int fn() => 1;
 
-    final value = ComputedValue(context, fn)..computeValue(track: true);
+    final value = computed(fn, context: context)..computeValue(track: true);
 
     verify(context.nameFor('Computed'));
     verify(context.trackDerivation(value, fn));

--- a/test/observable_test.dart
+++ b/test/observable_test.dart
@@ -1,4 +1,5 @@
 import 'package:mobx/mobx.dart';
+import 'package:mobx/src/api/context.dart';
 import 'package:mobx/src/api/observable.dart';
 import 'package:mobx/src/core/observable.dart';
 import 'package:test/test.dart';
@@ -23,15 +24,15 @@ void main() {
   });
 
   test('Raw observables', () {
-    final x = ObservableValue(1000);
+    final x = ObservableValue(mobxContext, 1000);
     expect(x is ObservableValue<int>, isTrue);
 
     expect(x.value, equals(1000));
 
-    final x1 = ObservableValue<int>(null);
+    final x1 = ObservableValue<int>(mobxContext, null);
     expect(x1.value, isNull);
 
-    final y = ObservableValue('Hello', name: 'greeting');
+    final y = ObservableValue(mobxContext, 'Hello', name: 'greeting');
     expect(y.value, equals('Hello'));
     expect(y.name, equals('greeting'));
   });

--- a/test/observable_test.dart
+++ b/test/observable_test.dart
@@ -24,15 +24,15 @@ void main() {
   });
 
   test('Raw observables', () {
-    final x = ObservableValue(mobxContext, 1000);
+    final x = ObservableValue(currentContext, 1000);
     expect(x is ObservableValue<int>, isTrue);
 
     expect(x.value, equals(1000));
 
-    final x1 = ObservableValue<int>(mobxContext, null);
+    final x1 = ObservableValue<int>(currentContext, null);
     expect(x1.value, isNull);
 
-    final y = ObservableValue(mobxContext, 'Hello', name: 'greeting');
+    final y = ObservableValue(currentContext, 'Hello', name: 'greeting');
     expect(y.value, equals('Hello'));
     expect(y.name, equals('greeting'));
   });

--- a/test/observable_test.dart
+++ b/test/observable_test.dart
@@ -69,7 +69,7 @@ void main() {
 
   test('observable uses provided context', () {
     final context = MockContext();
-    final value = ObservableValue(context, 0)..value += 1;
+    final value = observable(0, context: context)..value += 1;
 
     verify(context.startBatch());
     verify(context.propagateChanged(value));

--- a/test/observable_test.dart
+++ b/test/observable_test.dart
@@ -2,7 +2,10 @@ import 'package:mobx/mobx.dart';
 import 'package:mobx/src/api/context.dart';
 import 'package:mobx/src/api/observable.dart';
 import 'package:mobx/src/core/observable.dart';
+import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
+
+import 'shared_mocks.dart';
 
 void main() {
   test('Basic observable<T>', () {
@@ -62,5 +65,14 @@ void main() {
     final a = createAtom();
 
     expect(a.name, startsWith('Atom@'));
+  });
+
+  test('observable uses provided context', () {
+    final context = MockContext();
+    final value = ObservableValue(context, 0)..value += 1;
+
+    verify(context.startBatch());
+    verify(context.propagateChanged(value));
+    verify(context.endBatch());
   });
 }

--- a/test/reaction_test.dart
+++ b/test/reaction_test.dart
@@ -1,7 +1,10 @@
 import 'package:fake_async/fake_async.dart';
-import 'package:mobx/src/api/observable.dart';
-import 'package:mobx/src/api/reaction.dart';
+import 'package:mobx/src/core/reaction.dart';
+import 'package:mobx/mobx.dart' hide when;
+import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
+
+import 'shared_mocks.dart';
 
 void main() {
   test('Reaction basics', () {
@@ -116,5 +119,19 @@ void main() {
     expect(executed, isTrue);
     expect(d.$mobx.isDisposed, isTrue);
     d();
+  });
+
+  test('Reaction uses provided context', () {
+    final context = MockContext();
+    void onInvalidate() {}
+    final reaction = Reaction(context, onInvalidate);
+
+    void trackingFn() {}
+
+    reaction.track(trackingFn);
+
+    verify(context.startBatch());
+    verify(context.trackDerivation(reaction, trackingFn));
+    verify(context.endBatch());
   });
 }

--- a/test/reaction_test.dart
+++ b/test/reaction_test.dart
@@ -123,15 +123,12 @@ void main() {
 
   test('Reaction uses provided context', () {
     final context = MockContext();
-    void onInvalidate() {}
-    final reaction = Reaction(context, onInvalidate);
+    int trackingFn(Reaction reaction) => 1;
+    void onInvalidate(int i) {}
+    final rx = reaction(trackingFn, onInvalidate, context: context);
 
-    void trackingFn() {}
-
-    reaction.track(trackingFn);
-
-    verify(context.startBatch());
-    verify(context.trackDerivation(reaction, trackingFn));
-    verify(context.endBatch());
+    verify(context.nameFor('Reaction'));
+    verify(context.addPendingReaction(rx.$mobx));
+    verify(context.runReactions());
   });
 }

--- a/test/shared_mocks.dart
+++ b/test/shared_mocks.dart
@@ -1,0 +1,4 @@
+import 'package:mobx/src/core/context.dart';
+import 'package:mockito/mockito.dart';
+
+class MockContext extends Mock implements ReactiveContext {}


### PR DESCRIPTION
Made the ReactiveContext an explicit argument for classes that need it.

Builder functions provide the global context if it's not provided for them as an optional named argument.

I tried to implement the Zone local value for the context, but it did not work properly with tests. I don't know why exactly. It can be implemented in the future by changing `mobxContext` global to a getter that finds the current Zones context.