### PR TITLE
Make Interceptable use composition

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -4,3 +4,5 @@ const Duration ms = Duration(milliseconds: 1);
 
 Timer Function(void Function()) createDelayedScheduler(int delayMs) =>
     (fn) => Timer(ms * delayMs, fn);
+
+typedef Dispose = void Function();

--- a/test/autorun_test.dart
+++ b/test/autorun_test.dart
@@ -1,7 +1,10 @@
 import 'package:fake_async/fake_async.dart';
 import 'package:mobx/src/api/observable.dart';
 import 'package:mobx/src/api/reaction.dart';
+import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
+
+import 'shared_mocks.dart';
 
 void main() {
   test('autorun', () {
@@ -108,5 +111,11 @@ void main() {
     x.value = 11;
     expect(d.$mobx.isDisposed, isTrue);
     d();
+  });
+
+  test('autorun uses provided context', () {
+    final context = MockContext();
+    autorun((_) {}, context: context);
+    verify(context.runReactions());
   });
 }

--- a/test/intercept_test.dart
+++ b/test/intercept_test.dart
@@ -1,5 +1,10 @@
 import 'package:mobx/mobx.dart';
+import 'package:mobx/src/core/atom.dart';
+import 'package:mobx/src/interceptable.dart';
+import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
+
+import 'shared_mocks.dart';
 
 void main() {
   test('intercept', () {
@@ -72,5 +77,14 @@ void main() {
     dispose1();
     dispose2();
     dispose3();
+  });
+
+  test('Interceptors uses provided context', () {
+    final context = MockContext();
+    Interceptors(context)
+      ..intercept((_) {})
+      ..interceptChange(WillChangeNotification());
+
+    verify(context.untracked(any));
   });
 }

--- a/test/when_test.dart
+++ b/test/when_test.dart
@@ -1,6 +1,9 @@
 import 'package:mobx/src/api/observable.dart';
 import 'package:mobx/src/api/reaction.dart';
+import 'package:mockito/mockito.dart' hide when;
 import 'package:test/test.dart';
+
+import 'shared_mocks.dart';
 
 void main() {
   test('When', () {
@@ -38,5 +41,11 @@ void main() {
     });
 
     x.value = 11;
+  });
+
+  test('when uses provided context', () {
+    final context = MockContext();
+    when(() => true, () {}, context: context);
+    verify(context.runReactions());
   });
 }


### PR DESCRIPTION
The Interceptable made too many things public and the code was a bit javascripty, so I decided to refactor it a bit. Tried to add all functions into the mixin, but then all the mixin methods would be public in ObservableValue. I think composition made it cleaner.

I'll do the same thing to Listenable if this looks ok to you @pavanpodila 