### PR TITLE
Codegen template refactor

### DIFF
--- a/example/lib/src/generator_example.dart
+++ b/example/lib/src/generator_example.dart
@@ -2,8 +2,7 @@ import 'package:mobx/mobx.dart';
 
 part 'generator_example.g.dart';
 
-@observable
-abstract class User {
+abstract class User implements Store {
   User._();
   factory User() = _$User;
 

--- a/example/lib/src/generator_example.g.dart
+++ b/example/lib/src/generator_example.g.dart
@@ -3,7 +3,7 @@
 part of 'generator_example.dart';
 
 // **************************************************************************
-// ObservableGenerator
+// StoreGenerator
 // **************************************************************************
 
 class _$User extends User {

--- a/example/lib/src/generator_example.g.dart
+++ b/example/lib/src/generator_example.g.dart
@@ -8,8 +8,13 @@ part of 'generator_example.dart';
 
 class _$User extends User {
   _$User() : super._() {
-    _$fullNameComputed = Computed(() => super.fullName);
+    _$fullNameComputed = Computed<String>(() => super.fullName);
   }
+
+  Computed<String> _$fullNameComputed;
+
+  @override
+  String get fullName => _$fullNameComputed.value;
 
   final _$firstNameAtom = Atom(name: 'User.firstName');
 
@@ -38,11 +43,6 @@ class _$User extends User {
     super.lastName = value;
     _$lastNameAtom.reportChanged();
   }
-
-  Computed<String> _$fullNameComputed;
-
-  @override
-  String get fullName => _$fullNameComputed.value;
 
   final _$UserActionController = ActionController(name: 'User');
 

--- a/mobx/lib/mobx.dart
+++ b/mobx/lib/mobx.dart
@@ -39,7 +39,7 @@ export 'package:mobx/src/core.dart'
         DerivationState;
 
 export 'package:mobx/src/api/annotations.dart'
-    show action, computed, observable;
+    show action, computed, observable, Store;
 export 'package:mobx/src/api/action.dart';
 export 'package:mobx/src/api/context.dart';
 export 'package:mobx/src/api/observable_list.dart' hide wrapInObservableList;

--- a/mobx/lib/src/api/annotations.dart
+++ b/mobx/lib/src/api/annotations.dart
@@ -15,3 +15,5 @@ class MakeAction {
 }
 
 const MakeAction action = MakeAction._();
+
+abstract class Store {}

--- a/mobx_codegen/build.yaml
+++ b/mobx_codegen/build.yaml
@@ -6,10 +6,10 @@ targets:
 
 builders:
   todo_reporter:
-    target: ':observable_generator'
+    target: ':store_generator'
     import: 'package:mobx_codegen/builder.dart'
-    builder_factories: ['observableGenerator']
-    build_extensions: { '.dart': ['.observable.g.part'] }
+    builder_factories: ['storeGenerator']
+    build_extensions: { '.dart': ['.store.g.part'] }
     auto_apply: dependents
     build_to: cache
     applies_builders: ['source_gen|combining_builder']

--- a/mobx_codegen/lib/builder.dart
+++ b/mobx_codegen/lib/builder.dart
@@ -2,5 +2,5 @@ import 'package:build/build.dart';
 import 'package:mobx_codegen/mobx_codegen.dart';
 import 'package:source_gen/source_gen.dart';
 
-Builder observableGenerator(BuilderOptions options) =>
-    SharedPartBuilder([ObservableGenerator()], 'observable_generator');
+Builder storeGenerator(BuilderOptions options) =>
+    SharedPartBuilder([StoreGenerator()], 'store_generator');

--- a/mobx_codegen/lib/mobx_codegen.dart
+++ b/mobx_codegen/lib/mobx_codegen.dart
@@ -1,6 +1,3 @@
-/// Support for doing something awesome.
-///
-/// More dartdocs go here.
 library mobx_codegen;
 
 export 'src/mobx_codegen_base.dart';

--- a/mobx_codegen/lib/src/mobx_codegen_base.dart
+++ b/mobx_codegen/lib/src/mobx_codegen_base.dart
@@ -10,7 +10,7 @@ import 'package:mobx/mobx.dart' show Store;
 import 'package:mobx/src/api/annotations.dart'
     show ComputedMethod, MakeAction, MakeObservable;
 
-class ObservableGenerator extends Generator {
+class StoreGenerator extends Generator {
   final _storeChecker = TypeChecker.fromRuntime(Store);
 
   @override
@@ -24,14 +24,14 @@ class ObservableGenerator extends Generator {
   }
 
   String generateStoreClassCode(ClassElement storeClass) {
-    final visitor = new ObservableClassVisitor(storeClass.name);
+    final visitor = new StoreClassVisitor(storeClass.name);
     storeClass.visitChildren(visitor);
     return visitor.source;
   }
 }
 
-class ObservableClassVisitor extends SimpleElementVisitor {
-  ObservableClassVisitor(this._parentName) : _className = '_\$$_parentName';
+class StoreClassVisitor extends SimpleElementVisitor {
+  StoreClassVisitor(this._parentName) : _className = '_\$$_parentName';
 
   final String _parentName;
   final String _className;

--- a/mobx_codegen/lib/src/mobx_codegen_base.dart
+++ b/mobx_codegen/lib/src/mobx_codegen_base.dart
@@ -4,6 +4,9 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/visitor.dart';
 import 'package:build/build.dart';
 import 'package:build/src/builder/build_step.dart';
+import 'package:mobx_codegen/src/template/action.dart';
+import 'package:mobx_codegen/src/template/observable.dart';
+import 'package:mobx_codegen/src/template/store.dart';
 import 'package:source_gen/source_gen.dart';
 import 'package:mobx/mobx.dart' show Store;
 
@@ -31,32 +34,11 @@ class StoreGenerator extends Generator {
 }
 
 class StoreClassVisitor extends SimpleElementVisitor {
-  StoreClassVisitor(this._parentName) : _className = '_\$$_parentName';
-
-  final String _parentName;
-  final String _className;
-
-  final List<String> _observableFields = [];
-
-  final List<ComputedMethodData> _computedMethods = [];
-
-  final List<String> _actionOverrides = [];
-
-  String get source => """
-  class $_className extends $_parentName {
-    $_className() : super._() {
-      ${_computedMethods.map((m) => m.initComputed).join('\n')}
-    }
-
-    ${_observableFields.join('\n')}
-
-    ${_computedMethods.map((m) => m.code).join('\n')}
-
-    ${_actionControllerField}
-
-    ${_actionOverrides.join('\n')}
+  StoreClassVisitor(String parentName) {
+    _storeTemplate = StoreTemplate()
+      ..parentName = parentName
+      ..name = '_\$$parentName';
   }
-  """;
 
   final _observableChecker = TypeChecker.fromRuntime(MakeObservable);
 
@@ -64,34 +46,20 @@ class StoreClassVisitor extends SimpleElementVisitor {
 
   final _actionChecker = TypeChecker.fromRuntime(MakeAction);
 
-  String get _actionControllerField => _actionOverrides.isEmpty
-      ? ''
-      : "final $_actionControllerName = ActionController(name: '$_parentName');";
+  StoreTemplate _storeTemplate;
 
-  String get _actionControllerName => '_\$${_parentName}ActionController';
+  String get source => _storeTemplate.toString();
 
   @override
   visitFieldElement(FieldElement element) async {
     if (!element.isFinal && _observableChecker.hasAnnotationOfExact(element)) {
-      final type = element.type.name;
-      final name = element.name;
-      final privateName = '_\$${name}Atom';
+      final template = ObservableTemplate()
+        ..storeTemplate = _storeTemplate
+        ..atomName = '_\$${element.name}Atom'
+        ..type = element.type.name
+        ..name = element.name;
 
-      _observableFields.add("""
-      final $privateName = Atom(name: '$_parentName.$name');
-
-      @override
-      $type get $name {
-        $privateName.reportObserved();
-        return super.$name;
-      }
-
-      @override
-      set $name($type value) {
-        super.$name = value;
-        $privateName.reportChanged();
-      }
-      """);
+      _storeTemplate.observables.add(template);
     }
     return null;
   }
@@ -99,20 +67,10 @@ class StoreClassVisitor extends SimpleElementVisitor {
   @override
   visitPropertyAccessorElement(PropertyAccessorElement element) {
     if (element.isGetter && _computedChecker.hasAnnotationOfExact(element)) {
-      final type = element.returnType.name;
-      final name = element.name;
-      final privateName = '_\$${name}Computed';
-
-      final initComputed = "$privateName = Computed(() => super.$name);";
-
-      final code = """
-        Computed<$type> $privateName;
-
-        @override
-        $type get $name => $privateName.value;
-      """;
-
-      _computedMethods.add(new ComputedMethodData(initComputed, code));
+      _storeTemplate.addComputed(
+          computedName: '_\$${element.name}Computed',
+          name: element.name,
+          type: element.returnType.name);
     }
     return null;
   }
@@ -121,84 +79,46 @@ class StoreClassVisitor extends SimpleElementVisitor {
   visitMethodElement(MethodElement element) {
     if (!element.isAsynchronous &&
         _actionChecker.hasAnnotationOfExact(element)) {
-      final name = element.name;
-      final returnType = element.returnType.name;
+      final typeParam = (TypeParameterElement elem) => TypeParamTemplate()
+        ..name = elem.name
+        ..bound = elem.bound?.name;
 
-      String surroundNonEmpty(String prefix, String suffix, String str) =>
-          str.isEmpty ? str : '$prefix$str$suffix';
+      final param = (ParameterElement elem) => ParamTemplate()
+        ..name = elem.name
+        ..type = elem.type.name
+        ..defaultValue = elem.defaultValueCode;
 
-      final typeParams = surroundNonEmpty(
-          '<',
-          '>',
-          element.typeParameters.map((param) {
-            if (param.bound == null) {
-              return param.name;
-            } else {
-              return '${param.name} extends ${param.bound}';
-            }
-          }).join(', '));
+      final arg = (ParameterElement elem) => elem.name;
 
-      final typeArgs = surroundNonEmpty('<', '>',
-          element.typeParameters.map((param) => param.name).join(', '));
-
-      String paramCode(ParameterElement param) => param.defaultValueCode == null
-          ? '${param.type.name} ${param.name}'
-          : '${param.type.name} ${param.name} = ${param.defaultValueCode}';
-
-      String argCode(ParameterElement param) => param.name;
+      final namedArg =
+          (ParameterElement elem) => NamedArgTemplate()..name = elem.name;
 
       final positionalParams = element.parameters
           .where((param) => param.isPositional && !param.isOptionalPositional)
           .toList();
-      final positionalParamList = positionalParams.map(paramCode).join(', ');
-      final positionalArgs = positionalParams.map(argCode).join(', ');
 
       final optionalParams = element.parameters
           .where((param) => param.isOptionalPositional)
           .toList();
-      final optionalParamList = optionalParams.map(paramCode).join(', ');
-      final optionalArgs = optionalParams.map(argCode).join(', ');
-
-      String namedArgCode(ParameterElement param) =>
-          '${param.name}: ${param.name}';
 
       final namedParams =
           element.parameters.where((param) => param.isNamed).toList();
-      final namedArgs = namedParams.map(namedArgCode).join(', ');
-      final namedParamList = namedParams.map(paramCode).join(', ');
 
-      final params = [
-        positionalParamList,
-        surroundNonEmpty('[', ']', optionalParamList),
-        surroundNonEmpty('{', '}', namedParamList)
-      ].where((s) => s.isNotEmpty).join(', ');
+      final template = ActionTemplate()
+        ..storeTemplate = _storeTemplate
+        ..name = element.name
+        ..returnType = element.returnType.name
+        ..typeParams = element.typeParameters.map(typeParam)
+        ..typeArgs = element.typeParameters.map((param) => param.name)
+        ..positionalParams = positionalParams.map(param)
+        ..positionalArgs = positionalParams.map(arg)
+        ..optionalParams = optionalParams.map(param)
+        ..optionalArgs = optionalParams.map(arg)
+        ..namedParams = namedParams.map(param)
+        ..namedArgs = namedParams.map(namedArg);
 
-      final args = [positionalArgs, optionalArgs, namedArgs]
-          .where((s) => s.isNotEmpty)
-          .join(', ');
-
-      final code = """
-        @override
-        $returnType $name$typeParams($params) {
-          final _\$prevDerivation = $_actionControllerName.startAction();
-          try {
-            return super.$name$typeArgs($args);
-          } finally {
-            $_actionControllerName.endAction(_\$prevDerivation);
-          }
-        }
-      """;
-
-      _actionOverrides.add(code);
+      _storeTemplate.actions.add(template);
     }
-
     return super.visitMethodElement(element);
   }
-}
-
-class ComputedMethodData {
-  final String initComputed;
-  final String code;
-
-  ComputedMethodData(this.initComputed, this.code);
 }

--- a/mobx_codegen/lib/src/template/action.dart
+++ b/mobx_codegen/lib/src/template/action.dart
@@ -1,0 +1,80 @@
+import 'package:mobx_codegen/src/template/comma_list.dart';
+import 'package:mobx_codegen/src/template/store.dart';
+
+class ActionTemplate {
+  StoreTemplate storeTemplate;
+  String name;
+  String returnType;
+
+  SurroundedCommaList<TypeParamTemplate> _typeParams;
+  SurroundedCommaList<String> _typeArgs;
+
+  CommaList<ParamTemplate> _positionalParams;
+  SurroundedCommaList<ParamTemplate> _optionalParams;
+  SurroundedCommaList<ParamTemplate> _namedParams;
+
+  CommaList<String> _positionalArgs;
+  CommaList<String> _optionalArgs;
+  CommaList<NamedArgTemplate> _namedArgs;
+
+  set typeParams(Iterable<TypeParamTemplate> params) =>
+      _typeParams = SurroundedCommaList('<', '>', params.toList());
+  set positionalParams(Iterable<ParamTemplate> params) =>
+      _positionalParams = CommaList(params.toList());
+  set optionalParams(Iterable<ParamTemplate> params) =>
+      _optionalParams = SurroundedCommaList('[', ']', params.toList());
+  set namedParams(Iterable<ParamTemplate> params) =>
+      _namedParams = SurroundedCommaList('{', '}', params.toList());
+
+  CommaList get _params =>
+      CommaList([_positionalParams, _optionalParams, _namedParams]);
+
+  set typeArgs(Iterable<String> args) =>
+      _typeArgs = SurroundedCommaList('<', '>', args.toList());
+  set positionalArgs(Iterable<String> args) =>
+      _positionalArgs = CommaList(args.toList());
+  set optionalArgs(Iterable<String> args) =>
+      _optionalArgs = CommaList(args.toList());
+  set namedArgs(Iterable<NamedArgTemplate> args) =>
+      _namedArgs = CommaList(args.toList());
+
+  CommaList get _args =>
+      CommaList([_positionalArgs, _optionalArgs, _namedArgs]);
+
+  @override
+  String toString() => """
+    @override
+    $returnType $name$_typeParams($_params) {
+      final _\$prevDerivation = ${storeTemplate.actionControllerName}.startAction();
+      try {
+        return super.$name$_typeArgs($_args);
+      } finally {
+        ${storeTemplate.actionControllerName}.endAction(_\$prevDerivation);
+      }
+    }""";
+}
+
+class ParamTemplate {
+  String name;
+  String type;
+  String defaultValue;
+
+  @override
+  String toString() =>
+      defaultValue == null ? '$type $name' : '$type $name = $defaultValue';
+}
+
+class TypeParamTemplate {
+  String name;
+  String bound;
+
+  @override
+  String toString() => bound == null ? name : '$name extends $bound';
+}
+
+class NamedArgTemplate {
+  String name;
+
+  @override
+  String toString() => '$name: $name';
+}

--- a/mobx_codegen/lib/src/template/comma_list.dart
+++ b/mobx_codegen/lib/src/template/comma_list.dart
@@ -1,0 +1,22 @@
+import 'package:mobx_codegen/src/template/util.dart';
+
+class CommaList<T> {
+  CommaList(this.templates);
+
+  final List<T> templates;
+
+  @override
+  String toString() =>
+      templates.map((t) => t.toString()).where((s) => s.isNotEmpty).join(', ');
+}
+
+class SurroundedCommaList<T> {
+  SurroundedCommaList(this.prefix, this.suffix, this.templates);
+
+  final String prefix;
+  final String suffix;
+  final List<T> templates;
+
+  @override
+  String toString() => surroundNonEmpty(prefix, suffix, CommaList(templates));
+}

--- a/mobx_codegen/lib/src/template/computed.dart
+++ b/mobx_codegen/lib/src/template/computed.dart
@@ -1,0 +1,20 @@
+class ComputedTemplate {
+  String computedName;
+  String type;
+  String name;
+
+  String toString() => """
+  Computed<$type> $computedName;
+
+  @override
+  $type get $name => $computedName.value;""";
+}
+
+class ComputedInitTemplate {
+  String computedName;
+  String type;
+  String name;
+
+  @override
+  String toString() => "$computedName = Computed<$type>(() => super.$name);";
+}

--- a/mobx_codegen/lib/src/template/observable.dart
+++ b/mobx_codegen/lib/src/template/observable.dart
@@ -1,0 +1,24 @@
+import 'package:mobx_codegen/src/template/store.dart';
+
+class ObservableTemplate {
+  StoreTemplate storeTemplate;
+  String atomName;
+  String type;
+  String name;
+
+  @override
+  String toString() => """
+  final $atomName = Atom(name: '${storeTemplate.parentName}.$name');
+
+  @override
+  $type get $name {
+    $atomName.reportObserved();
+    return super.$name;
+  }
+
+  @override
+  set $name($type value) {
+    super.$name = value;
+    $atomName.reportChanged();
+  }""";
+}

--- a/mobx_codegen/lib/src/template/rows.dart
+++ b/mobx_codegen/lib/src/template/rows.dart
@@ -1,0 +1,10 @@
+class Rows<T> {
+  final List<T> _templates = [];
+
+  void add(T template) => _templates.add(template);
+
+  bool get isEmpty => _templates.isEmpty;
+
+  @override
+  String toString() => _templates.join('\n');
+}

--- a/mobx_codegen/lib/src/template/store.dart
+++ b/mobx_codegen/lib/src/template/store.dart
@@ -1,0 +1,54 @@
+import 'package:meta/meta.dart';
+import 'package:mobx_codegen/src/template/action.dart';
+import 'package:mobx_codegen/src/template/computed.dart';
+import 'package:mobx_codegen/src/template/observable.dart';
+import 'package:mobx_codegen/src/template/rows.dart';
+
+class StoreTemplate {
+  String name;
+  String parentName;
+
+  final Rows<ObservableTemplate> observables = Rows();
+  final Rows<ComputedTemplate> _computeds = Rows();
+  final Rows<ComputedInitTemplate> _computedInitializers = Rows();
+  final Rows<ActionTemplate> actions = Rows();
+
+  void addComputed(
+      {@required String computedName,
+      @required String type,
+      @required String name}) {
+    _computeds.add(ComputedTemplate()
+      ..computedName = computedName
+      ..name = name
+      ..type = type);
+
+    _computedInitializers.add(ComputedInitTemplate()
+      ..computedName = computedName
+      ..name = name
+      ..type = type);
+  }
+
+  String _actionControllerName;
+  String get actionControllerName =>
+      _actionControllerName ??= '_\$${parentName}ActionController';
+
+  String get _actionControllerField => actions.isEmpty
+      ? ''
+      : "final $actionControllerName = ActionController(name: '${parentName}');";
+
+  @override
+  String toString() => """
+  class $name extends $parentName {
+    $name() : super._() {
+      $_computedInitializers
+    }
+
+    $_computeds
+
+    $observables
+
+    $_actionControllerField
+
+    $actions
+  }""";
+}

--- a/mobx_codegen/lib/src/template/util.dart
+++ b/mobx_codegen/lib/src/template/util.dart
@@ -1,0 +1,4 @@
+String surroundNonEmpty(String prefix, String suffix, dynamic content) {
+  final contentStr = content.toString();
+  return contentStr.isEmpty ? '' : '$prefix$contentStr$suffix';
+}

--- a/mobx_codegen/test/all.dart
+++ b/mobx_codegen/test/all.dart
@@ -1,0 +1,5 @@
+import './mobx_codegen_test.dart' as mobx_codegen_test;
+
+void main() {
+  mobx_codegen_test.main();
+}

--- a/mobx_codegen/test/mobx_codegen_test.dart
+++ b/mobx_codegen/test/mobx_codegen_test.dart
@@ -112,7 +112,7 @@ final String pkgName = 'pkg';
 
 // Recreate generator for each test because we repeatedly create
 // classes with the same name in the same library, which will clash.
-Builder get builder => new PartBuilder([new ObservableGenerator()], '.g.dart');
+Builder get builder => new PartBuilder([new StoreGenerator()], '.g.dart');
 
 Future<String> generate(String source) async {
   final srcs = {

--- a/mobx_codegen/test/mobx_codegen_test.dart
+++ b/mobx_codegen/test/mobx_codegen_test.dart
@@ -36,8 +36,13 @@ abstract class User implements Store {
 const validOutput = """
 class _\$User extends User {
   _\$User() : super._() {
-    _\$fullNameComputed = Computed(() => super.fullName);
+    _\$fullNameComputed = Computed<String>(() => super.fullName);
   }
+
+  Computed<String> _\$fullNameComputed;
+
+  @override
+  String get fullName => _\$fullNameComputed.value;
 
   final _\$firstNameAtom = Atom(name: 'User.firstName');
 
@@ -66,11 +71,6 @@ class _\$User extends User {
     super.lastName = value;
     _\$lastNameAtom.reportChanged();
   }
-
-  Computed<String> _\$fullNameComputed;
-
-  @override
-  String get fullName => _\$fullNameComputed.value;
 
   final _\$UserActionController = ActionController(name: 'User');
 

--- a/mobx_codegen/test/mobx_codegen_test.dart
+++ b/mobx_codegen/test/mobx_codegen_test.dart
@@ -12,8 +12,7 @@ import 'package:mobx/mobx.dart';
 
 part 'test_user.g.dart';
 
-@observable
-abstract class User {
+abstract class User implements Store {
   User._();
   factory User() = _\$User;
 
@@ -103,7 +102,7 @@ void main() {
       expect(await generate(source), isEmpty);
     });
 
-    test('generates for class with @observer annotation', () async {
+    test('generates for a class that implements Store', () async {
       expect(await generate(validInput), endsWith(validOutput));
     });
   });
@@ -159,9 +158,12 @@ class MakeAction {
 }
 
 const MakeAction action = MakeAction._();
+
+abstract class Store {}
 """;
 
 const fakeMobxSource = """
 library mobx;
+
 export 'package:mobx/src/api/annotations.dart';
 """;


### PR DESCRIPTION
Moved the templating in `src/templates`.

I tried mustache templates but my clumsy fingers couldn't handle not having autocomplete and types. I made my own template classes using Dart template strings and overriding toString. If you really want mustaches someone else can do them 😄.

Built on #49 