### PR TITLE
Relax codegen mixin rules

### DIFF
--- a/example/lib/src/generator_example.dart
+++ b/example/lib/src/generator_example.dart
@@ -25,7 +25,9 @@ abstract class UserBase implements Store {
   }
 }
 
-class Admin = AdminBase with _$Admin;
+class Admin extends AdminBase with _$Admin {
+  Admin(int id) : super(id);
+}
 
 abstract class AdminBase extends User implements Store {
   AdminBase(int id) : super(id);

--- a/example/lib/src/generator_example.dart
+++ b/example/lib/src/generator_example.dart
@@ -32,4 +32,7 @@ abstract class AdminBase extends User implements Store {
 
   @observable
   String userName = 'admin';
+
+  @observable
+  ObservableList<String> accessRights = ObservableList();
 }

--- a/example/lib/src/generator_example.g.dart
+++ b/example/lib/src/generator_example.g.dart
@@ -68,4 +68,18 @@ mixin _$Admin on AdminBase, Store {
     super.userName = value;
     _$userNameAtom.reportChanged();
   }
+
+  final _$accessRightsAtom = Atom(name: 'AdminBase.accessRights');
+
+  @override
+  ObservableList<String> get accessRights {
+    _$accessRightsAtom.reportObserved();
+    return super.accessRights;
+  }
+
+  @override
+  set accessRights(ObservableList<String> value) {
+    super.accessRights = value;
+    _$accessRightsAtom.reportChanged();
+  }
 }

--- a/mobx_codegen/lib/src/mobx_codegen_base.dart
+++ b/mobx_codegen/lib/src/mobx_codegen_base.dart
@@ -68,7 +68,7 @@ class StoreMixinVisitor extends SimpleElementVisitor {
       final template = ObservableTemplate()
         ..storeTemplate = _storeTemplate
         ..atomName = '_\$${element.name}Atom'
-        ..type = element.type.name
+        ..type = element.type.displayName
         ..name = element.name;
 
       _storeTemplate.observables.add(template);
@@ -82,7 +82,7 @@ class StoreMixinVisitor extends SimpleElementVisitor {
       final template = ComputedTemplate()
         ..computedName = '_\$${element.name}Computed'
         ..name = element.name
-        ..type = element.returnType.name;
+        ..type = element.returnType.displayName;
       _storeTemplate.computeds.add(template);
     }
     return null;
@@ -94,11 +94,11 @@ class StoreMixinVisitor extends SimpleElementVisitor {
         _actionChecker.hasAnnotationOfExact(element)) {
       final typeParam = (TypeParameterElement elem) => TypeParamTemplate()
         ..name = elem.name
-        ..bound = elem.bound?.name;
+        ..bound = elem.bound?.displayName;
 
       final param = (ParameterElement elem) => ParamTemplate()
         ..name = elem.name
-        ..type = elem.type.name
+        ..type = elem.type.displayName
         ..defaultValue = elem.defaultValueCode;
 
       final positionalParams = element.parameters
@@ -115,7 +115,7 @@ class StoreMixinVisitor extends SimpleElementVisitor {
       final template = ActionTemplate()
         ..storeTemplate = _storeTemplate
         ..name = element.name
-        ..returnType = element.returnType.name
+        ..returnType = element.returnType.displayName
         ..typeParams = element.typeParameters.map(typeParam)
         ..positionalParams = positionalParams.map(param)
         ..optionalParams = optionalParams.map(param)

--- a/mobx_codegen/lib/src/mobx_codegen_base.dart
+++ b/mobx_codegen/lib/src/mobx_codegen_base.dart
@@ -21,7 +21,6 @@ class StoreGenerator extends Generator {
   FutureOr<String> generate(LibraryReader library, BuildStep buildStep) {
     final generate = (baseClass) sync* {
       final mixedClass = library.classes
-          .where((c) => c.isMixinApplication)
           .firstWhere((c) => c.supertype == baseClass.type, orElse: () => null);
       if (mixedClass != null) {
         yield generateStoreClassCode(library, baseClass, mixedClass);


### PR DESCRIPTION
Allows you to write codegen like this (the `class Admin = AdminBase with _$Admin` syntax still works):

```dart
class Admin extends AdminBase with _$Admin {
  Admin(int id) : super(id);
}

abstract class AdminBase extends User implements Store {
  AdminBase(int id) : super(id);

  @observable
  String userName = 'admin';

  @observable
  ObservableList<String> accessRights = ObservableList();
}
```

Makes you reimplement base class constructor signature, but should work better with `json_serializable`