### PR TITLE
Add checks and errors for codegen

### DIFF
--- a/mobx_codegen/lib/src/errors.dart
+++ b/mobx_codegen/lib/src/errors.dart
@@ -1,0 +1,122 @@
+R Function(T) withIndex<R, T>(R Function(T, int) action, {int start = 0}) =>
+    (T value) => action(value, start++);
+
+abstract class CodegenError {
+  bool get hasErrors;
+  String get message;
+}
+
+class StoreClassCodegenErrors implements CodegenError {
+  StoreClassCodegenErrors(this.name) {
+    _errorCategories = [
+      staticObservables,
+      staticActions,
+      finalObservables,
+      asyncActions
+    ];
+  }
+
+  final String name;
+
+  final PropertyErrors finalObservables = FinalObservableFields();
+  final PropertyErrors staticObservables = StaticObservableFields();
+  final PropertyErrors staticActions = StaticActionMethods();
+  final PropertyErrors asyncActions = AsyncActionMethods();
+
+  List<CodegenError> _errorCategories;
+
+  String get message {
+    final errors = _errorCategories
+        .where((category) => category.hasErrors)
+        .map(withIndex((category, i) => '  $i. ${category.message}', start: 1))
+        .join('\n');
+
+    return 'Could not make class "$name" observable. Changes needed:\n$errors';
+  }
+
+  bool get hasErrors => _errorCategories.any((category) => category.hasErrors);
+}
+
+abstract class PropertyErrors implements CodegenError {
+  final NameList _properties = NameList();
+
+  bool addIf(bool condition, String propertyName) {
+    if (condition) {
+      _properties.add(propertyName);
+    }
+    return condition;
+  }
+
+  String get propertyList => _properties.toString();
+
+  Pluralize propertyPlural = const Pluralize('the field', 'fields');
+
+  String get property => propertyPlural(_properties.length);
+
+  @override
+  bool get hasErrors => _properties.isNotEmpty;
+}
+
+class FinalObservableFields extends PropertyErrors {
+  @override
+  String get message => 'Remove final modifier from $property $propertyList';
+}
+
+class StaticObservableFields extends PropertyErrors {
+  @override
+  String get message => 'Remove static modifier from $property $propertyList';
+}
+
+class AsyncActionMethods extends PropertyErrors {
+  @override
+  Pluralize propertyPlural = const Pluralize('the method', 'methods');
+
+  @override
+  String get message => 'Remove async modifier from $property $propertyList';
+}
+
+class StaticActionMethods extends PropertyErrors {
+  @override
+  Pluralize propertyPlural = const Pluralize('the method', 'methods');
+
+  @override
+  String get message => 'Remove static modifier from $property $propertyList';
+}
+
+class NameList {
+  final List<String> _names = [];
+
+  void add(String name) => _names.add(name);
+
+  int get length => _names.length;
+
+  bool get isNotEmpty => _names.isNotEmpty;
+
+  @override
+  String toString() {
+    if (_names.length == 1) {
+      return '"${_names[0]}"';
+    }
+
+    final buf = StringBuffer();
+    for (int i = 0; i < _names.length; i++) {
+      final name = _names[i];
+      buf.write('"$name"');
+      if (i < _names.length - 2) {
+        buf.write(', ');
+      } else if (i == _names.length - 2) {
+        buf.write(' and ');
+      }
+    }
+    return buf.toString();
+  }
+}
+
+class Pluralize {
+  const Pluralize(this._single, this._multiple);
+
+  final String _single;
+  final String _multiple;
+
+  String call(int count) => count == 1 ? _single : _multiple;
+}

--- a/mobx_codegen/lib/src/mobx_codegen_base.dart
+++ b/mobx_codegen/lib/src/mobx_codegen_base.dart
@@ -80,7 +80,7 @@ class StoreMixinVisitor extends SimpleElementVisitor {
       return null;
     }
 
-    if (_checkFieldErrors(element)) {
+    if (_fieldIsNotValid(element)) {
       return null;
     }
 
@@ -94,7 +94,7 @@ class StoreMixinVisitor extends SimpleElementVisitor {
     return null;
   }
 
-  bool _checkFieldErrors(FieldElement element) => any([
+  bool _fieldIsNotValid(FieldElement element) => any([
         _errors.staticObservables.addIf(element.isStatic, element.name),
         _errors.finalObservables.addIf(element.isFinal, element.name)
       ]);
@@ -120,7 +120,7 @@ class StoreMixinVisitor extends SimpleElementVisitor {
       return null;
     }
 
-    if (_checkMethodErrors(element)) {
+    if (_methodIsNotValid(element)) {
       return null;
     }
 
@@ -158,7 +158,7 @@ class StoreMixinVisitor extends SimpleElementVisitor {
     return null;
   }
 
-  bool _checkMethodErrors(MethodElement element) => any([
+  bool _methodIsNotValid(MethodElement element) => any([
         _errors.staticActions.addIf(element.isStatic, element.name),
         _errors.asyncActions.addIf(element.isAsynchronous, element.name),
       ]);

--- a/mobx_codegen/lib/src/mobx_codegen_base.dart
+++ b/mobx_codegen/lib/src/mobx_codegen_base.dart
@@ -45,10 +45,8 @@ class StoreGenerator extends Generator {
 }
 
 class StoreMixinVisitor extends SimpleElementVisitor {
-  StoreMixinVisitor(String parentName, String name,
-      [void Function(String message) logSevere])
-      : _logSevere = logSevere ?? log.severe,
-        _errors = StoreClassCodegenErrors(name) {
+  StoreMixinVisitor(String parentName, String name)
+      : _errors = StoreClassCodegenErrors(name) {
     _storeTemplate = StoreTemplate()
       ..parentName = parentName
       ..mixinName = '_\$$name';
@@ -64,11 +62,9 @@ class StoreMixinVisitor extends SimpleElementVisitor {
 
   final StoreClassCodegenErrors _errors;
 
-  final void Function(String message) _logSevere;
-
   String get source {
     if (_errors.hasErrors) {
-      _logSevere(_errors.message);
+      log.severe(_errors.message);
       return '';
     }
     return _storeTemplate.toString();

--- a/mobx_codegen/lib/src/mobx_codegen_base.dart
+++ b/mobx_codegen/lib/src/mobx_codegen_base.dart
@@ -4,6 +4,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/visitor.dart';
 import 'package:build/build.dart';
 import 'package:build/src/builder/build_step.dart';
+import 'package:mobx_codegen/src/errors.dart';
 import 'package:mobx_codegen/src/template/action.dart';
 import 'package:mobx_codegen/src/template/computed.dart';
 import 'package:mobx_codegen/src/template/observable.dart';
@@ -37,18 +38,20 @@ class StoreGenerator extends Generator {
 
   String generateStoreClassCode(
       LibraryReader library, ClassElement baseClass, ClassElement mixedClass) {
-    final visitor =
-        new StoreMixinVisitor(baseClass.name, '_\$${mixedClass.name}');
+    final visitor = new StoreMixinVisitor(baseClass.name, mixedClass.name);
     baseClass.visitChildren(visitor);
     return visitor.source;
   }
 }
 
 class StoreMixinVisitor extends SimpleElementVisitor {
-  StoreMixinVisitor(String parentName, String name) {
+  StoreMixinVisitor(String parentName, String name,
+      [void Function(String message) logSevere])
+      : _logSevere = logSevere ?? log.severe,
+        _errors = StoreClassCodegenErrors(name) {
     _storeTemplate = StoreTemplate()
       ..parentName = parentName
-      ..name = name;
+      ..mixinName = '_\$$name';
   }
 
   final _observableChecker = TypeChecker.fromRuntime(MakeObservable);
@@ -59,69 +62,108 @@ class StoreMixinVisitor extends SimpleElementVisitor {
 
   StoreTemplate _storeTemplate;
 
-  String get source => _storeTemplate.toString();
+  final StoreClassCodegenErrors _errors;
 
-  @override
-  visitFieldElement(FieldElement element) async {
-    if (!element.isFinal && _observableChecker.hasAnnotationOfExact(element)) {
-      final template = ObservableTemplate()
-        ..storeTemplate = _storeTemplate
-        ..atomName = '_\$${element.name}Atom'
-        ..type = element.type.displayName
-        ..name = element.name;
+  final void Function(String message) _logSevere;
 
-      _storeTemplate.observables.add(template);
+  String get source {
+    if (_errors.hasErrors) {
+      _logSevere(_errors.message);
+      return '';
     }
-    return null;
+    return _storeTemplate.toString();
   }
 
   @override
-  visitPropertyAccessorElement(PropertyAccessorElement element) {
-    if (element.isGetter && _computedChecker.hasAnnotationOfExact(element)) {
-      final template = ComputedTemplate()
-        ..computedName = '_\$${element.name}Computed'
-        ..name = element.name
-        ..type = element.returnType.displayName;
-      _storeTemplate.computeds.add(template);
+  visitFieldElement(FieldElement element) async {
+    if (!_observableChecker.hasAnnotationOfExact(element)) {
+      return null;
     }
+
+    if (_checkFieldErrors(element)) {
+      return null;
+    }
+
+    final template = ObservableTemplate()
+      ..storeTemplate = _storeTemplate
+      ..atomName = '_\$${element.name}Atom'
+      ..type = element.type.displayName
+      ..name = element.name;
+
+    _storeTemplate.observables.add(template);
+    return null;
+  }
+
+  bool _checkFieldErrors(FieldElement element) => any([
+        _errors.staticObservables.addIf(element.isStatic, element.name),
+        _errors.finalObservables.addIf(element.isFinal, element.name)
+      ]);
+
+  @override
+  visitPropertyAccessorElement(PropertyAccessorElement element) {
+    if (!element.isGetter || !_computedChecker.hasAnnotationOfExact(element)) {
+      return null;
+    }
+
+    final template = ComputedTemplate()
+      ..computedName = '_\$${element.name}Computed'
+      ..name = element.name
+      ..type = element.returnType.displayName;
+    _storeTemplate.computeds.add(template);
+
     return null;
   }
 
   @override
   visitMethodElement(MethodElement element) {
-    if (!element.isAsynchronous &&
-        _actionChecker.hasAnnotationOfExact(element)) {
-      final typeParam = (TypeParameterElement elem) => TypeParamTemplate()
-        ..name = elem.name
-        ..bound = elem.bound?.displayName;
-
-      final param = (ParameterElement elem) => ParamTemplate()
-        ..name = elem.name
-        ..type = elem.type.displayName
-        ..defaultValue = elem.defaultValueCode;
-
-      final positionalParams = element.parameters
-          .where((param) => param.isPositional && !param.isOptionalPositional)
-          .toList();
-
-      final optionalParams = element.parameters
-          .where((param) => param.isOptionalPositional)
-          .toList();
-
-      final namedParams =
-          element.parameters.where((param) => param.isNamed).toList();
-
-      final template = ActionTemplate()
-        ..storeTemplate = _storeTemplate
-        ..name = element.name
-        ..returnType = element.returnType.displayName
-        ..typeParams = element.typeParameters.map(typeParam)
-        ..positionalParams = positionalParams.map(param)
-        ..optionalParams = optionalParams.map(param)
-        ..namedParams = namedParams.map(param);
-
-      _storeTemplate.actions.add(template);
+    if (!_actionChecker.hasAnnotationOfExact(element)) {
+      return null;
     }
-    return super.visitMethodElement(element);
+
+    if (_checkMethodErrors(element)) {
+      return null;
+    }
+
+    final typeParam = (TypeParameterElement elem) => TypeParamTemplate()
+      ..name = elem.name
+      ..bound = elem.bound?.displayName;
+
+    final param = (ParameterElement elem) => ParamTemplate()
+      ..name = elem.name
+      ..type = elem.type.displayName
+      ..defaultValue = elem.defaultValueCode;
+
+    final positionalParams = element.parameters
+        .where((param) => param.isPositional && !param.isOptionalPositional)
+        .toList();
+
+    final optionalParams = element.parameters
+        .where((param) => param.isOptionalPositional)
+        .toList();
+
+    final namedParams =
+        element.parameters.where((param) => param.isNamed).toList();
+
+    final template = ActionTemplate()
+      ..storeTemplate = _storeTemplate
+      ..name = element.name
+      ..returnType = element.returnType.displayName
+      ..typeParams = element.typeParameters.map(typeParam)
+      ..positionalParams = positionalParams.map(param)
+      ..optionalParams = optionalParams.map(param)
+      ..namedParams = namedParams.map(param);
+
+    _storeTemplate.actions.add(template);
+
+    return null;
   }
+
+  bool _checkMethodErrors(MethodElement element) => any([
+        _errors.staticActions.addIf(element.isStatic, element.name),
+        _errors.asyncActions.addIf(element.isAsynchronous, element.name),
+      ]);
 }
+
+bool any(List<bool> list) => list.any(identity);
+
+T identity<T>(T value) => value;

--- a/mobx_codegen/lib/src/template/store.dart
+++ b/mobx_codegen/lib/src/template/store.dart
@@ -4,7 +4,7 @@ import 'package:mobx_codegen/src/template/observable.dart';
 import 'package:mobx_codegen/src/template/rows.dart';
 
 class StoreTemplate {
-  String name;
+  String mixinName;
   String parentName;
 
   final Rows<ObservableTemplate> observables = Rows();
@@ -21,7 +21,7 @@ class StoreTemplate {
 
   @override
   String toString() => """
-  mixin $name on $parentName, Store {
+  mixin $mixinName on $parentName, Store {
     $computeds
 
     $observables

--- a/mobx_codegen/test/all.dart
+++ b/mobx_codegen/test/all.dart
@@ -1,7 +1,9 @@
 import './templates_test.dart' as templates_test;
 import './mobx_codegen_test.dart' as mobx_codegen_test;
+import './errors_test.dart' as errors_test;
 
 void main() {
   templates_test.main();
   mobx_codegen_test.main();
+  errors_test.main();
 }

--- a/mobx_codegen/test/errors_test.dart
+++ b/mobx_codegen/test/errors_test.dart
@@ -1,0 +1,170 @@
+import 'package:mobx_codegen/src/errors.dart';
+import 'package:test/test.dart';
+
+class TestFieldErrors extends PropertyErrors {
+  @override
+  String get message => 'test $property $propertyList';
+}
+
+void main() {
+  group('Pluralize', () {
+    test('Pluralize.call returns single string when count is 1', () {
+      expect(Pluralize('the item', 'items').call(1), 'the item');
+    });
+
+    test('Pluralize.call returns multiple string when count is not 1', () {
+      expect(Pluralize('the item', 'items').call(2), 'items');
+    });
+  });
+
+  group('NameList', () {
+    test('toString returns one quoted name if has single name added', () {
+      expect((NameList()..add('myField')).toString(), equals('"myField"'));
+    });
+
+    test('toString returns two quoted fields with and between', () {
+      expect((NameList()..add('myField1')..add('myField2')).toString(),
+          equals('"myField1" and "myField2"'));
+    });
+
+    test(
+        'toString returns three quoted fields with a comma between first two and "and" between last two',
+        () {
+      expect(
+          (NameList()..add('myField1')..add('myField2')..add('myField3'))
+              .toString(),
+          equals('"myField1", "myField2" and "myField3"'));
+    });
+
+    test('length returns the count of added names', () {
+      expect((NameList()..add('myField1')..add('myField2')).length, equals(2));
+    });
+
+    test('isEmpty returns false if items are added', () {
+      final names = NameList();
+      expect(names.isNotEmpty, equals(false));
+
+      names.add('myField');
+      expect(names.isNotEmpty, equals(true));
+    });
+  });
+
+  group('PropertyErrors', () {
+    test('hasErrors returns true if a name is added successfully', () {
+      final errors = TestFieldErrors();
+      expect(errors.hasErrors, isFalse);
+
+      expect(errors.addIf(false, 'testField1'), isFalse);
+      expect(errors.hasErrors, isFalse);
+
+      expect(errors.addIf(true, 'testField2'), isTrue);
+      expect(errors.hasErrors, isTrue);
+    });
+
+    test(
+        'returns a formatted message when a field is added and the condition is true',
+        () {
+      final errors = TestFieldErrors();
+      errors.addIf(true, 'testField');
+      expect(errors.message, equals('test the field "testField"'));
+    });
+
+    test(
+        'returns a formatted message when multiple fields are added and the condition is true',
+        () {
+      final errors = TestFieldErrors();
+      errors.addIf(true, 'testField1');
+      errors.addIf(true, 'testField2');
+      expect(
+          errors.message, equals('test fields "testField1" and "testField2"'));
+    });
+
+    test('does not add field if condition is false', () {
+      final errors = TestFieldErrors();
+      errors.addIf(true, 'testField1');
+      errors.addIf(false, 'testField2');
+      expect(errors.message, equals('test the field "testField1"'));
+    });
+
+    test(
+        ".property returns singular property string if there's only one item added",
+        () {
+      final errors = TestFieldErrors();
+      errors.addIf(true, 'testField');
+      expect(errors.property, equals('the field'));
+    });
+
+    test(
+        ".property returns plural property string if there's more than one item added",
+        () {
+      final errors = TestFieldErrors();
+      errors.addIf(true, 'testField1');
+      errors.addIf(true, 'testField2');
+      expect(errors.property, equals('fields'));
+    });
+  });
+
+  group('FinalObservableFields', () {
+    test('message returns singular message with one field added', () {
+      final fields = FinalObservableFields()..addIf(true, 'testField');
+      expect(
+          fields.message, 'Remove final modifier from the field "testField"');
+    });
+
+    test('message returns plural message with multiple fields added', () {
+      final fields = FinalObservableFields()
+        ..addIf(true, 'testField1')
+        ..addIf(true, 'testField2');
+      expect(fields.message,
+          'Remove final modifier from fields "testField1" and "testField2"');
+    });
+  });
+
+  group('StaticObservableFields', () {
+    test('message returns singular message with one field added', () {
+      final fields = StaticObservableFields()..addIf(true, 'testField');
+      expect(
+          fields.message, 'Remove static modifier from the field "testField"');
+    });
+
+    test('message returns plural message with multiple fields added', () {
+      final fields = StaticObservableFields()
+        ..addIf(true, 'testField1')
+        ..addIf(true, 'testField2');
+      expect(fields.message,
+          'Remove static modifier from fields "testField1" and "testField2"');
+    });
+  });
+
+  group('AsyncActionMethods', () {
+    test('message returns singular message with one field added', () {
+      final fields = AsyncActionMethods()..addIf(true, 'testMethod');
+      expect(
+          fields.message, 'Remove async modifier from the method "testMethod"');
+    });
+
+    test('message returns plural message with multiple fields added', () {
+      final fields = AsyncActionMethods()
+        ..addIf(true, 'testMethod1')
+        ..addIf(true, 'testMethod2');
+      expect(fields.message,
+          'Remove async modifier from methods "testMethod1" and "testMethod2"');
+    });
+  });
+
+  group('StaticActionMethods', () {
+    test('message returns singular message with one field added', () {
+      final fields = StaticActionMethods()..addIf(true, 'testMethod');
+      expect(fields.message,
+          'Remove static modifier from the method "testMethod"');
+    });
+
+    test('message returns plural message with multiple fields added', () {
+      final fields = StaticActionMethods()
+        ..addIf(true, 'testMethod1')
+        ..addIf(true, 'testMethod2');
+      expect(fields.message,
+          'Remove static modifier from methods "testMethod1" and "testMethod2"');
+    });
+  });
+}


### PR DESCRIPTION
Added some validations for the codegen.

final/static `@observable` fields, and static/async `@action` methods generate a warning in the console and prevent code generation.

Needs more in the future, but this is a start.