### PR TITLE
Fixed incorrect building of todo items in example

### DIFF
--- a/flutter_mobx/example/lib/todos/todos.dart
+++ b/flutter_mobx/example/lib/todos/todos.dart
@@ -120,7 +120,7 @@ class TodoListView extends StatelessWidget {
             child: ListView.builder(
                 itemCount: list.visibleTodos.length,
                 itemBuilder: (_, index) {
-                  final todo = list.todos[index];
+                  final todo = list.visibleTodos[index];
                   return Observer(
                       builder: (_) => CheckboxListTile(
                             value: todo.done,


### PR DESCRIPTION
`itemBuilder` should be pulling todos from `list.visibleTodos`, not `list.todos`