### PR TITLE
Don't allow FutureOr in future methods

### DIFF
--- a/mobx_codegen/lib/src/template/util.dart
+++ b/mobx_codegen/lib/src/template/util.dart
@@ -7,5 +7,4 @@ String surroundNonEmpty(String prefix, String suffix, dynamic content) {
 
 bool returnsFuture(MethodElement method) =>
     method.returnType.isDartAsyncFuture ||
-    method.returnType.isDartAsyncFutureOr ||
     (method.isAsynchronous && !method.returnType.isVoid && !method.isGenerator);

--- a/mobx_codegen/test/util_test.dart
+++ b/mobx_codegen/test/util_test.dart
@@ -41,10 +41,11 @@ void main() {
       expect(returnsFuture(method), isTrue);
     });
 
-    test('should return true if element.returnType.isDartAsyncFutureOr is true',
+    test(
+        'should return false if element.returnType.isDartAsyncFutureOr is true',
         () {
       final method = mockMethod(returnsFutureOr: true);
-      expect(returnsFuture(method), isTrue);
+      expect(returnsFuture(method), isFalse);
     });
 
     test('should return true if element is async and not a generator', () {


### PR DESCRIPTION
Remove FutureOr support in `@observable` async methods. Doesn't really work right now, and wrapping FutureOr with ObservableFuture would remove the advantage of FutureOr anyways.