### PR TITLE
ObservableStream

### DIFF
--- a/flutter_mobx/example/pubspec.yaml
+++ b/flutter_mobx/example/pubspec.yaml
@@ -20,13 +20,13 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2
-  mobx: ^0.0.34
+  mobx: ^0.0.35
   flutter_mobx:
     path: ../
 
 dev_dependencies:
   build_runner: ^1.0.0
-  mobx_codegen: ^0.0.4
+  mobx_codegen: ^0.0.5
   flutter_test:
     sdk: flutter
 

--- a/flutter_mobx/pubspec.yaml
+++ b/flutter_mobx/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=2.1.0-dev <3.0.0'
 
 dependencies:
-  mobx: ^0.0.34
+  mobx: ^0.0.35
   flutter:
     sdk: flutter
 

--- a/mobx/example/pubspec.yaml
+++ b/mobx/example/pubspec.yaml
@@ -8,11 +8,11 @@ environment:
   sdk: '>=2.0.0-dev.68.0 <3.0.0'
 
 dependencies:
-  mobx: ^0.0.34
+  mobx: ^0.0.35
 
 dev_dependencies:
   build_runner: ^1.0.0
-  mobx_codegen: ^0.0.4
+  mobx_codegen: ^0.0.5
 
 dependency_overrides:
   mobx:

--- a/mobx/lib/mobx.dart
+++ b/mobx/lib/mobx.dart
@@ -44,6 +44,8 @@ export 'package:mobx/src/api/action.dart';
 export 'package:mobx/src/api/context.dart';
 export 'package:mobx/src/api/observable_future.dart'
     show ObservableFuture, FutureStatus;
+export 'package:mobx/src/api/observable_stream.dart'
+    show ObservableStream, StreamStatus;
 export 'package:mobx/src/api/observable_collections.dart'
     show ObservableList, ObservableMap;
 export 'package:mobx/src/api/reaction.dart';

--- a/mobx/lib/src/api/observable_future.dart
+++ b/mobx/lib/src/api/observable_future.dart
@@ -7,7 +7,6 @@ import 'package:mobx/src/core.dart';
 @experimental
 enum FutureStatus { pending, rejected, fulfilled }
 
-///
 @experimental
 class ObservableFuture<T> implements Future<T> {
   /// Create a new observable future that tracks the state of the provided future.

--- a/mobx/lib/src/api/observable_stream.dart
+++ b/mobx/lib/src/api/observable_stream.dart
@@ -1,0 +1,244 @@
+import 'dart:async';
+
+import 'package:meta/meta.dart';
+import 'package:mobx/src/api/context.dart';
+import 'package:mobx/src/core.dart';
+
+@experimental
+enum StreamStatus { waiting, value, done, error }
+
+enum _ValueType { value, error }
+
+@experimental
+class ObservableStream<T> implements Stream<T> {
+  ObservableStream(Stream<T> stream,
+      {T initialValue, bool cancelOnError, ReactiveContext context})
+      : this._(context ?? mainContext, stream.asBroadcastStream(), initialValue,
+            cancelOnError);
+
+  ObservableStream._(
+      ReactiveContext context, this._stream, T initialValue, bool cancelOnError)
+      : _status = Observable(
+            initialValue == null ? StreamStatus.waiting : StreamStatus.value,
+            context: context),
+        _actions = ActionController(
+            name: context.nameFor('ObservableStream<$T>'), context: context),
+        _data = Observable(initialValue, context: context) {
+    _stream.listen(_onData,
+        onDone: _onDone, onError: _onError, cancelOnError: cancelOnError);
+  }
+
+  final ActionController _actions;
+  final Observable<StreamStatus> _status;
+  _ValueType _valueType = _ValueType.value;
+  final Observable _data;
+  final Stream<T> _stream;
+
+  // Current value or error if failed.
+  dynamic get data => _data.value;
+
+  /// Current value or null if no initialValue and stream hasn't provided a new value yet.
+  T get value => _status.value == StreamStatus.error ? null : _data.value;
+
+  /// Current error or null if not failed.
+  dynamic get error => _status.value == StreamStatus.error ? _data.value : null;
+
+  /// Current stream status.
+  StreamStatus get status => _status.value;
+
+  /// Maps the current status and value or error into a value.
+  ///
+  /// Returns null if a callback is not provided for the active status.
+  /// If [done] is null, [value] and [error] are used instead.
+  R match<R>(
+      {R Function() waiting,
+      R Function(T) value,
+      // ignore:avoid_annotating_with_dynamic
+      R Function(dynamic) error,
+      // ignore:avoid_annotating_with_dynamic
+      R Function(dynamic) done}) {
+    final data = _data.value;
+    final status = _status.value;
+
+    if (status == StreamStatus.waiting) {
+      return waiting == null ? null : waiting();
+    } else if (status == StreamStatus.value ||
+        (status == StreamStatus.done &&
+            _valueType == _ValueType.value &&
+            done == null)) {
+      return value == null ? null : value(data);
+    } else if (status == StreamStatus.error ||
+        (status == StreamStatus.done &&
+            _valueType == _ValueType.error &&
+            done == null)) {
+      return error == null ? null : error(data);
+    }
+    return done(data);
+  }
+
+  void _onData(T data) {
+    final prevDerivation = _actions.startAction();
+    try {
+      _status.value = StreamStatus.value;
+      _valueType = _ValueType.value;
+      _data.value = data;
+    } finally {
+      _actions.endAction(prevDerivation);
+    }
+  }
+
+  void _onDone() {
+    final prevDerivation = _actions.startAction();
+    try {
+      _status.value = StreamStatus.done;
+    } finally {
+      _actions.endAction(prevDerivation);
+    }
+  }
+
+  void _onError(error) {
+    final prevDerivation = _actions.startAction();
+    try {
+      _status.value = StreamStatus.error;
+      _valueType = _ValueType.error;
+      _data.value = error;
+    } finally {
+      _actions.endAction(prevDerivation);
+    }
+  }
+
+  // Delegated methods
+
+  @override
+  Future<bool> any(bool Function(T element) test) => _stream.any(test);
+
+  @override
+  Stream<T> asBroadcastStream(
+          {void Function(StreamSubscription<T> subscription) onListen,
+          void Function(StreamSubscription<T> subscription) onCancel}) =>
+      _stream.asBroadcastStream(onListen: onListen, onCancel: onCancel);
+
+  @override
+  Stream<E> asyncExpand<E>(Stream<E> Function(T event) convert) =>
+      _stream.asyncExpand(convert);
+
+  @override
+  Stream<E> asyncMap<E>(FutureOr<E> Function(T event) convert) =>
+      _stream.asyncMap(convert);
+
+  @override
+  Stream<R> cast<R>() => _stream.cast();
+
+  @override
+  Future<bool> contains(Object needle) => _stream.contains(needle);
+
+  @override
+  Stream<T> distinct([bool Function(T previous, T next) equals]) =>
+      _stream.distinct(equals);
+
+  @override
+  Future<E> drain<E>([E futureValue]) => _stream.drain(futureValue);
+
+  @override
+  Future<T> elementAt(int index) => _stream.elementAt(index);
+
+  @override
+  Future<bool> every(bool Function(T element) test) => _stream.every(test);
+
+  @override
+  Stream<S> expand<S>(Iterable<S> Function(T element) convert) =>
+      _stream.expand(convert);
+
+  @override
+  Future<T> get first => _stream.first;
+
+  @override
+  Future<T> firstWhere(bool Function(T element) test, {T Function() orElse}) =>
+      _stream.firstWhere(test, orElse: orElse);
+
+  @override
+  Future<S> fold<S>(
+          S initialValue, S Function(S previous, T element) combine) =>
+      _stream.fold(initialValue, combine);
+
+  @override
+  Future forEach(void Function(T element) action) => _stream.forEach(action);
+
+  @override
+  Stream<T> handleError(Function onError,
+          // ignore:avoid_annotating_with_dynamic
+          {bool Function(dynamic) test}) =>
+      _stream.handleError(onError, test: test);
+
+  @override
+  bool get isBroadcast => _stream.isBroadcast;
+
+  @override
+  Future<bool> get isEmpty => _stream.isEmpty;
+
+  @override
+  Future<String> join([String separator = '']) => _stream.join(separator);
+
+  @override
+  Future<T> get last => _stream.last;
+
+  @override
+  Future<T> lastWhere(bool Function(T element) test, {T Function() orElse}) =>
+      _stream.lastWhere(test, orElse: orElse);
+
+  @override
+  Future<int> get length => _stream.length;
+
+  @override
+  StreamSubscription<T> listen(void Function(T event) onData,
+          {Function onError, void Function() onDone, bool cancelOnError}) =>
+      _stream.listen(onData,
+          onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+
+  @override
+  Stream<S> map<S>(S Function(T event) convert) => _stream.map(convert);
+
+  @override
+  Future pipe(StreamConsumer<T> streamConsumer) => _stream.pipe(streamConsumer);
+
+  @override
+  Future<T> reduce(T Function(T previous, T element) combine) =>
+      _stream.reduce(combine);
+
+  @override
+  Future<T> get single => _stream.single;
+
+  @override
+  Future<T> singleWhere(bool Function(T element) test, {T Function() orElse}) =>
+      _stream.singleWhere(test, orElse: orElse);
+
+  @override
+  Stream<T> skip(int count) => _stream.skip(count);
+
+  @override
+  Stream<T> skipWhile(bool Function(T element) test) => _stream.skipWhile(test);
+
+  @override
+  Stream<T> take(int count) => _stream.take(count);
+
+  @override
+  Stream<T> takeWhile(bool Function(T element) test) => _stream.takeWhile(test);
+
+  @override
+  Stream<T> timeout(Duration timeLimit,
+          {void Function(EventSink<T> sink) onTimeout}) =>
+      _stream.timeout(timeLimit, onTimeout: onTimeout);
+
+  @override
+  Future<List<T>> toList() => _stream.toList();
+
+  @override
+  Future<Set<T>> toSet() => _stream.toSet();
+
+  @override
+  Stream<S> transform<S>(StreamTransformer<T, S> streamTransformer) =>
+      _stream.transform(streamTransformer);
+
+  @override
+  Stream<T> where(bool Function(T event) test) => _stream.where(test);
+}

--- a/mobx/pubspec.yaml
+++ b/mobx/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mobx
-version: 0.0.34
+version: 0.0.35
 description: "MobX is a library for reactively managing the state of your applications. Use the power of observables, actions, and reactions
 to supercharge your Dart and Flutter apps."
 author: Pavan Podila <pavan@pixelingene.com>

--- a/mobx/test/all.dart
+++ b/mobx/test/all.dart
@@ -8,6 +8,7 @@ import 'listenable_test.dart' as listenable_test;
 import 'observable_future_test.dart' as observable_future_test;
 import 'observable_list_test.dart' as observable_list_test;
 import 'observable_map_test.dart' as observable_map_test;
+import 'observable_stream_test.dart' as observable_stream_test;
 import 'observable_test.dart' as observable_test;
 import 'observe_test.dart' as observe_test;
 import 'reaction_test.dart' as reaction_test;
@@ -19,6 +20,7 @@ void main() {
   observable_future_test.main();
   observable_list_test.main();
   observable_map_test.main();
+  observable_stream_test.main();
   computed_test.main();
 
   action_test.main();

--- a/mobx/test/observable_stream_test.dart
+++ b/mobx/test/observable_stream_test.dart
@@ -1,0 +1,87 @@
+import 'dart:async';
+
+import 'package:mobx/src/api/observable_stream.dart';
+import 'package:mobx/src/api/reaction.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ObservableStream', () {
+    test('match works', () async {
+      // ignore:close_sinks
+      final ctrl = StreamController<int>.broadcast();
+      final stream = ObservableStream(ctrl.stream);
+
+      String getValue() => stream.match(
+            waiting: () => 'waiting',
+            value: (i) => 'value',
+            done: (_) => 'done',
+            error: (err) => 'error',
+          );
+
+      expect(getValue(), equals('waiting'));
+
+      ctrl.add(1);
+      await asyncWhen((_) => stream.value == 1);
+      expect(getValue(), equals('value'));
+
+      ctrl.addError('ERROR');
+      await asyncWhen((_) => stream.error == 'ERROR');
+      expect(getValue(), equals('error'));
+
+      await ctrl.close();
+      expect(getValue(), equals('done'));
+    });
+
+    test('omitting done in match uses value instead for values', () async {
+      // ignore:close_sinks
+      final ctrl = StreamController<int>.broadcast();
+      final stream = ObservableStream(ctrl.stream);
+
+      String getValue() => stream.match(
+            value: (i) => 'value/done',
+          );
+
+      ctrl.add(1);
+      await asyncWhen((_) => stream.value == 1);
+      expect(getValue(), equals('value/done'));
+
+      await ctrl.close();
+      expect(getValue(), equals('value/done'));
+    });
+
+    test('omitting done in match uses error instead for errors', () async {
+      // ignore:close_sinks
+      final ctrl = StreamController<int>.broadcast();
+      final stream = ObservableStream(ctrl.stream);
+
+      String getValue() => stream.match(
+            error: (i) => 'error/done',
+          );
+
+      ctrl.addError('ERROR');
+      await asyncWhen((_) => stream.error == 'ERROR');
+      expect(getValue(), equals('error/done'));
+
+      await ctrl.close();
+      expect(getValue(), equals('error/done'));
+    });
+
+    test('providing no initialValue sets initial status to waiting', () async {
+      final stream = ObservableStream(() async* {
+        yield 1;
+      }());
+
+      expect(stream.status, equals(StreamStatus.waiting));
+      expect(stream.value, equals(null));
+    });
+
+    test('providing initialValue sets initial status to value', () async {
+      final stream = ObservableStream(() async* {
+        yield 1;
+      }(), initialValue: 0);
+
+      expect(stream.status, equals(StreamStatus.value));
+      expect(stream.value, equals(0));
+    });
+  });
+}

--- a/mobx_codegen/example/lib/src/generator_example.dart
+++ b/mobx_codegen/example/lib/src/generator_example.dart
@@ -39,7 +39,12 @@ abstract class AdminBase extends User implements Store {
   ObservableList<String> accessRights = ObservableList();
 
   @observable
-  Future<String> loadPrivileges() async {
-    return 'adsfadsf';
+  Future<String> loadPrivileges([String foo]) async {
+    return foo;
+  }
+
+  @observable
+  Stream<T> loadStuff<T>(String arg1, {T value}) async* {
+    yield value;
   }
 }

--- a/mobx_codegen/example/lib/src/generator_example.g.dart
+++ b/mobx_codegen/example/lib/src/generator_example.g.dart
@@ -84,8 +84,14 @@ mixin _$Admin on AdminBase, Store {
   }
 
   @override
-  ObservableFuture<String> loadPrivileges() {
-    final _$future = super.loadPrivileges();
+  ObservableFuture<String> loadPrivileges([String foo]) {
+    final _$future = super.loadPrivileges(foo);
     return ObservableFuture<String>(_$future);
+  }
+
+  @override
+  ObservableStream<T> loadStuff<T>(String arg1, {T value}) {
+    final _$stream = super.loadStuff<T>(arg1, value: value);
+    return ObservableStream<T>(_$stream);
   }
 }

--- a/mobx_codegen/example/pubspec.yaml
+++ b/mobx_codegen/example/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   sdk: '>=2.1.0-dev <3.0.0'
 
 dependencies:
-  mobx: ^0.0.34
-  mobx_codegen: ^0.0.4
+  mobx: ^0.0.35
+  mobx_codegen: ^0.0.5
 
 dependency_overrides:
   mobx:

--- a/mobx_codegen/lib/src/errors.dart
+++ b/mobx_codegen/lib/src/errors.dart
@@ -83,7 +83,7 @@ class NonAsyncMethods extends PropertyErrors {
 
   @override
   String get message =>
-      'Add async modifier or return a Future from $property $propertyList';
+      'Return a Future or a Stream from $property $propertyList';
 }
 
 class InvalidStaticMethods extends PropertyErrors {

--- a/mobx_codegen/lib/src/mobx_codegen_base.dart
+++ b/mobx_codegen/lib/src/mobx_codegen_base.dart
@@ -10,6 +10,7 @@ import 'package:mobx_codegen/src/template/computed.dart';
 import 'package:mobx_codegen/src/template/method_override.dart';
 import 'package:mobx_codegen/src/template/observable.dart';
 import 'package:mobx_codegen/src/template/observable_future.dart';
+import 'package:mobx_codegen/src/template/observable_stream.dart';
 import 'package:mobx_codegen/src/template/store.dart';
 import 'package:mobx_codegen/src/template/util.dart';
 import 'package:source_gen/source_gen.dart';
@@ -60,6 +61,8 @@ class StoreMixinVisitor extends SimpleElementVisitor {
   final _computedChecker = TypeChecker.fromRuntime(ComputedMethod);
 
   final _actionChecker = TypeChecker.fromRuntime(MakeAction);
+
+  final _asyncChecker = AsyncMethodChecker();
 
   StoreTemplate _storeTemplate;
 
@@ -125,21 +128,32 @@ class StoreMixinVisitor extends SimpleElementVisitor {
 
       _storeTemplate.actions.add(template);
     } else if (_observableChecker.hasAnnotationOfExact(element)) {
-      if (_observableFutureIsNotValid(element)) {
+      if (_asyncObservableIsNotValid(element)) {
         return null;
       }
-      final template = ObservableFutureTemplate()
-        ..method = MethodOverrideTemplate.fromElement(element);
 
-      _storeTemplate.observableFutures.add(template);
+      if (_asyncChecker.returnsFuture(element)) {
+        final template = ObservableFutureTemplate()
+          ..method = MethodOverrideTemplate.fromElement(element);
+
+        _storeTemplate.observableFutures.add(template);
+      } else if (_asyncChecker.returnsStream(element)) {
+        final template = ObservableStreamTemplate()
+          ..method = MethodOverrideTemplate.fromElement(element);
+
+        _storeTemplate.observableStreams.add(template);
+      }
     }
 
     return null;
   }
 
-  bool _observableFutureIsNotValid(MethodElement element) => any([
-        _errors.staticMethods.addIf(element.isStatic, element.name),
-        _errors.nonAsyncMethods.addIf(!returnsFuture(element), element.name)
+  bool _asyncObservableIsNotValid(MethodElement method) => any([
+        _errors.staticMethods.addIf(method.isStatic, method.name),
+        _errors.nonAsyncMethods.addIf(
+            !_asyncChecker.returnsFuture(method) &&
+                !_asyncChecker.returnsStream(method),
+            method.name),
       ]);
 
   bool _actionIsNotValid(MethodElement element) => any([

--- a/mobx_codegen/lib/src/template/observable_stream.dart
+++ b/mobx_codegen/lib/src/template/observable_stream.dart
@@ -1,0 +1,13 @@
+import 'package:mobx_codegen/src/template/method_override.dart';
+
+class ObservableStreamTemplate {
+  MethodOverrideTemplate method;
+
+  @override
+  String toString() => """
+  @override
+  ObservableStream${method.returnTypeArgs} ${method.name}${method.typeParams}(${method.params}) {
+    final _\$stream = super.${method.name}${method.typeArgs}(${method.args});
+    return ObservableStream${method.returnTypeArgs}(_\$stream);
+  }""";
+}

--- a/mobx_codegen/lib/src/template/store.dart
+++ b/mobx_codegen/lib/src/template/store.dart
@@ -2,6 +2,7 @@ import 'package:mobx_codegen/src/template/action.dart';
 import 'package:mobx_codegen/src/template/computed.dart';
 import 'package:mobx_codegen/src/template/observable.dart';
 import 'package:mobx_codegen/src/template/observable_future.dart';
+import 'package:mobx_codegen/src/template/observable_stream.dart';
 import 'package:mobx_codegen/src/template/rows.dart';
 
 class StoreTemplate {
@@ -12,6 +13,7 @@ class StoreTemplate {
   final Rows<ComputedTemplate> computeds = Rows();
   final Rows<ActionTemplate> actions = Rows();
   final Rows<ObservableFutureTemplate> observableFutures = Rows();
+  final Rows<ObservableStreamTemplate> observableStreams = Rows();
 
   String _actionControllerName;
   String get actionControllerName =>
@@ -29,6 +31,8 @@ class StoreTemplate {
     $observables
 
     $observableFutures
+
+    $observableStreams
 
     $_actionControllerField
 

--- a/mobx_codegen/lib/src/template/util.dart
+++ b/mobx_codegen/lib/src/template/util.dart
@@ -1,11 +1,29 @@
 import 'package:analyzer/dart/element/element.dart';
+import 'package:source_gen/source_gen.dart';
 
 String surroundNonEmpty(String prefix, String suffix, dynamic content) {
   final contentStr = content.toString();
   return contentStr.isEmpty ? '' : '$prefix$contentStr$suffix';
 }
 
-bool returnsFuture(MethodElement method) =>
-    method.returnType.isDartAsyncFuture ||
-    method.returnType.isDartAsyncFutureOr ||
-    (method.isAsynchronous && !method.returnType.isVoid && !method.isGenerator);
+final _streamChecker = TypeChecker.fromRuntime(Stream);
+
+class AsyncMethodChecker {
+  AsyncMethodChecker([TypeChecker checkStream]) {
+    this._checkStream = checkStream ?? _streamChecker;
+  }
+
+  TypeChecker _checkStream;
+
+  bool returnsFuture(MethodElement method) =>
+      method.returnType.isDartAsyncFuture ||
+      (method.isAsynchronous &&
+          !method.isGenerator &&
+          method.returnType.isDynamic);
+
+  bool returnsStream(MethodElement method) =>
+      _checkStream.isAssignableFromType(method.returnType) ||
+      (method.isAsynchronous &&
+          method.isGenerator &&
+          method.returnType.isDynamic);
+}

--- a/mobx_codegen/pubspec.yaml
+++ b/mobx_codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobx_codegen
 description: Code generator for MobX that adds support for annotating your code with @observable, @computed, @action and also creating Store classes.
-version: 0.0.4
+version: 0.0.5
 author: Joni Katajamäki <joni.katajamaki@gmail.com>
 homepage: https://github.com/mobxjs/mobx.dart
 
@@ -10,7 +10,7 @@ environment:
 dependencies:
   path: ^1.4.1
   source_gen: ^0.9.4
-  mobx: ^0.0.34
+  mobx: ^0.0.35
   build: ^1.1.0
   analyzer: ^0.34.2
 

--- a/mobx_codegen/test/errors_test.dart
+++ b/mobx_codegen/test/errors_test.dart
@@ -172,7 +172,7 @@ void main() {
     test('message returns singular message with one field added', () {
       final fields = NonAsyncMethods()..addIf(true, 'testMethod');
       expect(fields.message,
-          'Add async modifier or return a Future from the method "testMethod"');
+          'Return a Future or a Stream from the method "testMethod"');
     });
 
     test('message returns plural message with multiple fields added', () {
@@ -180,7 +180,7 @@ void main() {
         ..addIf(true, 'testMethod1')
         ..addIf(true, 'testMethod2');
       expect(fields.message,
-          'Add async modifier or return a Future from methods "testMethod1" and "testMethod2"');
+          'Return a Future or a Stream from methods "testMethod1" and "testMethod2"');
     });
   });
 }

--- a/mobx_codegen/test/mobx_codegen_test.dart
+++ b/mobx_codegen/test/mobx_codegen_test.dart
@@ -38,6 +38,11 @@ abstract class UserBase implements Store {
   Future<String> foobar() async {
     return 'foobar';
   }
+
+  @observable
+  Stream<T> loadStuff<T>(String arg1, {T value}) async* {
+    yield value;
+  }
 }
 """;
 
@@ -81,6 +86,12 @@ mixin _\$User on UserBase, Store {
   ObservableFuture<String> foobar() {
     final _\$future = super.foobar();
     return ObservableFuture<String>(_\$future);
+  }
+
+  @override
+  ObservableStream<T> loadStuff<T>(String arg1, {T value}) {
+    final _\$stream = super.loadStuff<T>(arg1, value: value);
+    return ObservableStream<T>(_\$stream);
   }
 
   final _\$UserBaseActionController = ActionController(name: 'UserBase');
@@ -135,6 +146,11 @@ abstract class UserBase implements Store {
 
   @action
   static UserBase getUser(int id) async {}
+
+  @observable
+  String nonAsyncObservableMethod() {
+    return 'nonAsyncObservableMethod';
+  }
 }
 """;
 
@@ -143,7 +159,8 @@ Could not make class "User" observable. Changes needed:
   1. Remove static modifier from the field "foobar"
   2. Remove static modifier from the method "getUser"
   3. Remove final modifier from fields "id" and "firstName"
-  4. Remove async modifier from methods "updateUserFromDb" and "getUser\"""";
+  4. Remove async modifier from methods "updateUserFromDb" and "getUser\"
+  5. Return a Future or a Stream from the method "nonAsyncObservableMethod\"""";
 
 void main() {
   group('generator', () {


### PR DESCRIPTION
Stream wrapper class that can be observed synchronously like ObservableFuture.

Codegen support for `async*` and Stream returning methods with the `@observable` annotation.

I had to manually delegate all Stream methods to the wrapped Stream, and I didn't see the need to test those, so coverage will take a hit.