### PR TITLE
Codegen support for generic stores

### DIFF
--- a/mobx_codegen/example/lib/src/generator_example.dart
+++ b/mobx_codegen/example/lib/src/generator_example.dart
@@ -25,12 +25,12 @@ abstract class _User implements Store {
   }
 }
 
-class Admin extends AdminBase with _$Admin {
+class Admin extends _Admin with _$Admin {
   Admin(int id) : super(id);
 }
 
-abstract class AdminBase extends User implements Store {
-  AdminBase(int id) : super(id);
+abstract class _Admin extends User implements Store {
+  _Admin(int id) : super(id);
 
   @observable
   String userName = 'admin';
@@ -57,4 +57,11 @@ abstract class AdminBase extends User implements Store {
       accessRights.add(item);
     }
   }
+}
+
+class Item<A> = _Item<A> with _$Item<A>;
+
+abstract class _Item<T> implements Store {
+  @observable
+  T value;
 }

--- a/mobx_codegen/example/lib/src/generator_example.g.dart
+++ b/mobx_codegen/example/lib/src/generator_example.g.dart
@@ -60,8 +60,8 @@ mixin _$User on _User, Store {
 
 // ignore_for_file: non_constant_identifier_names, unnecessary_lambdas, prefer_expression_function_bodies
 
-mixin _$Admin on AdminBase, Store {
-  final _$userNameAtom = Atom(name: 'AdminBase.userName');
+mixin _$Admin on _Admin, Store {
+  final _$userNameAtom = Atom(name: '_Admin.userName');
 
   @override
   String get userName {
@@ -76,7 +76,7 @@ mixin _$Admin on AdminBase, Store {
     _$userNameAtom.reportChanged();
   }
 
-  final _$accessRightsAtom = Atom(name: 'AdminBase.accessRights');
+  final _$accessRightsAtom = Atom(name: '_Admin.accessRights');
 
   @override
   ObservableList<String> get accessRights {
@@ -109,5 +109,24 @@ mixin _$Admin on AdminBase, Store {
   ObservableFuture<void> loadAccessRights() {
     return ObservableFuture<void>(
         _$loadAccessRightsAsyncAction.run(() => super.loadAccessRights()));
+  }
+}
+
+// ignore_for_file: non_constant_identifier_names, unnecessary_lambdas, prefer_expression_function_bodies
+
+mixin _$Item<T> on _Item<T>, Store {
+  final _$valueAtom = Atom(name: '_Item.value');
+
+  @override
+  T get value {
+    _$valueAtom.reportObserved();
+    return super.value;
+  }
+
+  @override
+  set value(T value) {
+    mainContext.checkIfStateModificationsAreAllowed(_$valueAtom);
+    super.value = value;
+    _$valueAtom.reportChanged();
   }
 }

--- a/mobx_codegen/example/pubspec.yaml
+++ b/mobx_codegen/example/pubspec.yaml
@@ -8,9 +8,13 @@ environment:
 
 dependencies:
   mobx: ^0.0.37
-  mobx_codegen: ^0.0.8
+  mobx_codegen: ^0.0.9
 
 dev_dependencies:
   build_runner: 1.2.6
   test_coverage: ^0.2.0
   test: ^1.0.0
+
+dependency_overrides:
+  mobx_codegen:
+    path: ../

--- a/mobx_codegen/lib/src/mobx_codegen_base.dart
+++ b/mobx_codegen/lib/src/mobx_codegen_base.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/dart/element/visitor.dart';
 import 'package:build/build.dart';
 import 'package:build/src/builder/build_step.dart';

--- a/mobx_codegen/lib/src/template/method_override.dart
+++ b/mobx_codegen/lib/src/template/method_override.dart
@@ -1,15 +1,13 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:mobx_codegen/src/template/comma_list.dart';
+import 'package:mobx_codegen/src/template/params.dart';
+import 'package:mobx_codegen/src/template/util.dart';
 
 class MethodOverrideTemplate {
   MethodOverrideTemplate();
 
   MethodOverrideTemplate.fromElement(MethodElement method) {
-    final typeParam = (TypeParameterElement elem) => TypeParamTemplate()
-      ..name = elem.name
-      ..bound = elem.bound?.displayName;
-
     final param = (ParameterElement elem) => ParamTemplate()
       ..name = elem.name
       ..type = elem.type.displayName
@@ -33,7 +31,7 @@ class MethodOverrideTemplate {
     this
       ..name = method.name
       ..returnType = method.returnType.displayName
-      ..setTypeParams(method.typeParameters.map(typeParam))
+      ..setTypeParams(method.typeParameters.map(typeParamTemplate))
       ..positionalParams = positionalParams.map(param)
       ..optionalParams = optionalParams.map(param)
       ..namedParams = namedParams.map(param)
@@ -84,35 +82,4 @@ class MethodOverrideTemplate {
   SurroundedCommaList<TypeParamTemplate> get typeParams => _typeParams;
 
   SurroundedCommaList<String> get typeArgs => _typeArgs;
-}
-
-class ParamTemplate {
-  String name;
-  String type;
-  String defaultValue;
-
-  String get asArgument => name;
-
-  NamedArgTemplate get asNamedArgument => NamedArgTemplate()..name = name;
-
-  @override
-  String toString() =>
-      defaultValue == null ? '$type $name' : '$type $name = $defaultValue';
-}
-
-class TypeParamTemplate {
-  String name;
-  String bound;
-
-  String get asArgument => name;
-
-  @override
-  String toString() => bound == null ? name : '$name extends $bound';
-}
-
-class NamedArgTemplate {
-  String name;
-
-  @override
-  String toString() => '$name: $name';
 }

--- a/mobx_codegen/lib/src/template/params.dart
+++ b/mobx_codegen/lib/src/template/params.dart
@@ -1,0 +1,30 @@
+class ParamTemplate {
+  String name;
+  String type;
+  String defaultValue;
+
+  String get asArgument => name;
+
+  NamedArgTemplate get asNamedArgument => NamedArgTemplate()..name = name;
+
+  @override
+  String toString() =>
+      defaultValue == null ? '$type $name' : '$type $name = $defaultValue';
+}
+
+class TypeParamTemplate {
+  String name;
+  String bound;
+
+  String get asArgument => name;
+
+  @override
+  String toString() => bound == null ? name : '$name extends $bound';
+}
+
+class NamedArgTemplate {
+  String name;
+
+  @override
+  String toString() => '$name: $name';
+}

--- a/mobx_codegen/lib/src/template/store.dart
+++ b/mobx_codegen/lib/src/template/store.dart
@@ -1,12 +1,18 @@
 import 'package:mobx_codegen/src/template/action.dart';
 import 'package:mobx_codegen/src/template/async_action.dart';
+import 'package:mobx_codegen/src/template/comma_list.dart';
 import 'package:mobx_codegen/src/template/computed.dart';
 import 'package:mobx_codegen/src/template/observable.dart';
 import 'package:mobx_codegen/src/template/observable_future.dart';
 import 'package:mobx_codegen/src/template/observable_stream.dart';
+import 'package:mobx_codegen/src/template/params.dart';
 import 'package:mobx_codegen/src/template/rows.dart';
 
 class StoreTemplate {
+  final SurroundedCommaList<TypeParamTemplate> typeParams =
+      new SurroundedCommaList('<', '>', []);
+  final SurroundedCommaList<String> typeArgs =
+      new SurroundedCommaList('<', '>', []);
   String mixinName;
   String parentName;
 
@@ -29,7 +35,7 @@ class StoreTemplate {
   String toString() => """
   // ignore_for_file: non_constant_identifier_names, unnecessary_lambdas, prefer_expression_function_bodies
 
-  mixin $mixinName on $parentName, Store {
+  mixin $mixinName$typeParams on $parentName$typeArgs, Store {
     $computeds
 
     $observables

--- a/mobx_codegen/lib/src/template/util.dart
+++ b/mobx_codegen/lib/src/template/util.dart
@@ -1,4 +1,5 @@
 import 'package:analyzer/dart/element/element.dart';
+import 'package:mobx_codegen/src/template/params.dart';
 import 'package:source_gen/source_gen.dart';
 
 String surroundNonEmpty(String prefix, String suffix, dynamic content) {
@@ -27,3 +28,8 @@ class AsyncMethodChecker {
           method.isGenerator &&
           method.returnType.isDynamic);
 }
+
+TypeParamTemplate typeParamTemplate(TypeParameterElement param) =>
+    TypeParamTemplate()
+      ..name = param.name
+      ..bound = param.bound?.displayName;

--- a/mobx_codegen/test/templates_test.dart
+++ b/mobx_codegen/test/templates_test.dart
@@ -4,6 +4,7 @@ import 'package:mobx_codegen/src/template/computed.dart';
 import 'package:mobx_codegen/src/template/method_override.dart';
 import 'package:mobx_codegen/src/template/observable.dart';
 import 'package:mobx_codegen/src/template/observable_future.dart';
+import 'package:mobx_codegen/src/template/params.dart';
 import 'package:mobx_codegen/src/template/rows.dart';
 import 'package:mobx_codegen/src/template/store.dart';
 import 'package:mobx_codegen/src/template/util.dart';


### PR DESCRIPTION
Support codegen for generic stores:

```dart
class Item<A> = _Item<A> with _$Item<A>;

abstract class _Item<T> implements Store {
  @observable
  T value;
}
```

Fixes #118 