### PR TITLE
Update provider example to 2.0

### DIFF
--- a/docs/src/guides/organizing-stores.mdx
+++ b/docs/src/guides/organizing-stores.mdx
@@ -134,12 +134,10 @@ Using the [provider][1] package on pub, you can setup a repository of stores at 
 In the example below, we are setting up a store at the app-level:
 
 ```
-final MultiCounterStore store = MultiCounterStore();
-
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) => Provider<MultiCounterStore>(
-      value: store,
+      builder: (_) => MultiCounterStore(),
       child: MaterialApp(
         initialRoute: '/',
         theme: ThemeData(
@@ -178,8 +176,8 @@ class CounterListPage extends StatelessWidget {
 
 There are multiple types of `Providers` available in the [provider][1] package. The ones most relevant and useful to MobX are:
 
-- `Provider` for single values, known before hand
-- `StatefulProvider` for constructing and disposing values on the fly. This is good when the value has a fixed lifetime.
+- `Provider` for constructing and disposing values on the fly. This is good when the value has a fixed lifetime.
+- `Provider.value`, a `Provider` constructor for single values, known before hand
 - `MultiProvider` for passing multiple values
 
 [1]: https://pub.dartlang.org/packages/provider

--- a/mobx_examples/lib/main.dart
+++ b/mobx_examples/lib/main.dart
@@ -9,7 +9,7 @@ final MultiCounterStore store = MultiCounterStore();
 
 class MyApp extends StatelessWidget {
   @override
-  Widget build(BuildContext context) => Provider<MultiCounterStore>(
+  Widget build(BuildContext context) => Provider<MultiCounterStore>.value(
       value: store,
       child: MaterialApp(
         initialRoute: '/',

--- a/mobx_examples/lib/multi_counter/multi_counter_widgets.dart
+++ b/mobx_examples/lib/multi_counter/multi_counter_widgets.dart
@@ -14,7 +14,7 @@ class _MultiCounterExampleState extends State<MultiCounterExample> {
   final MultiCounterStore store = MultiCounterStore();
 
   @override
-  Widget build(BuildContext context) => Provider<MultiCounterStore>(
+  Widget build(BuildContext context) => Provider<MultiCounterStore>.value(
         value: store,
         child: Scaffold(
           appBar: AppBar(

--- a/mobx_examples/pubspec.yaml
+++ b/mobx_examples/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   validators:
   hnpwa_client:
   url_launcher:
-  provider:
+  provider: ^2.0.0-dev
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
With the 2.0-dev version of `provider`, `StatefulProvider` and `Provider` fused.

This PR reflects this change.