### PR TITLE
fix ActionController throwing null exception with null context/name

### DIFF
--- a/mobx/lib/src/core/action.dart
+++ b/mobx/lib/src/core/action.dart
@@ -71,8 +71,10 @@ class Action {
 ///
 class ActionController {
   ActionController({ReactiveContext context, String name})
-      : _context = context ?? mainContext,
-        name = name ?? context.nameFor('Action');
+      : this._(context ?? mainContext, name: name);
+
+  ActionController._(this._context, {String name})
+      : name = name ?? _context.nameFor('Action');
 
   final ReactiveContext _context;
   final String name;

--- a/mobx/test/action_controller_test.dart
+++ b/mobx/test/action_controller_test.dart
@@ -8,6 +8,9 @@ class MockDerivation extends Mock implements Derivation {}
 
 void main() {
   group('ActionController', () {
+    test('can be created with both null context and name', () {
+      ActionController();
+    });
     test(
         'startAction calls startUntracked, startBatch and startAllowStateChanges',
         () {


### PR DESCRIPTION
`ActionController` used to throw when both `context` and `name` were omitted. 

This PR fixes the issue