### PR TITLE
fix observable list notifications and improve test coverage

### DIFF
--- a/mobx/lib/src/api/observable_collections/observable_list.dart
+++ b/mobx/lib/src/api/observable_collections/observable_list.dart
@@ -88,17 +88,17 @@ class ObservableList<T>
   @override
   void add(T element) {
     _context.checkIfStateModificationsAreAllowed(_atom);
-
+    final index = _list.length;
     _list.add(element);
-    _notifyListUpdate(_list.length, [element], null);
+    _notifyListUpdate(index, [element], null);
   }
 
   @override
   void addAll(Iterable<T> iterable) {
     _context.checkIfStateModificationsAreAllowed(_atom);
-
+    final index = _list.length;
     _list.addAll(iterable);
-    _notifyListUpdate(0, iterable.toList(growable: false), null);
+    _notifyListUpdate(index, iterable.toList(growable: false), null);
   }
 
   @override
@@ -242,9 +242,9 @@ class ObservableList<T>
   @override
   void replaceRange(int start, int end, Iterable<T> newContents) {
     _context.checkIfStateModificationsAreAllowed(_atom);
-
+    final oldContents = _list.sublist(start, end);
     _list.replaceRange(start, end, newContents);
-    _notifyListUpdate(start, null, null);
+    _notifyListUpdate(start, newContents, oldContents);
   }
 
   @override

--- a/mobx/test/observable_list_test.dart
+++ b/mobx/test/observable_list_test.dart
@@ -73,6 +73,126 @@ void main() {
       expect(count, equals(1));
     });
 
+    test('observe insert item works', () {
+      final list = ObservableList.of([1]);
+
+      var index = -1;
+      var addedValues = <int>[];
+      var removedValues = <int>[];
+
+      list
+        ..observe((change) {
+          index = change.index;
+          addedValues = change.added;
+          removedValues = change.removed;
+        })
+        ..insert(0, 0);
+      expect(index, equals(0));
+      expect(addedValues, equals([0]));
+      expect(removedValues, equals(null));
+    });
+
+    test('observe add item works', () {
+      final list = ObservableList.of([0]);
+
+      var index = -1;
+      var addedValues = <int>[];
+      var removedValues = <int>[];
+
+      list
+        ..observe((change) {
+          index = change.index;
+          addedValues = change.added;
+          removedValues = change.removed;
+        })
+        ..add(1);
+
+      expect(index, equals(1));
+      expect(addedValues, equals([1]));
+      expect(removedValues, equals(null));
+    });
+
+    test('observe addAll items works', () {
+      final list = ObservableList.of([0]);
+
+      var index = -1;
+      var addedValues = <int>[];
+      var removedValues = <int>[];
+
+      list
+        ..observe((change) {
+          index = change.index;
+          addedValues = change.added;
+          removedValues = change.removed;
+        })
+        ..addAll([1, 2]);
+
+      expect(index, equals(1));
+      expect(addedValues, equals([1, 2]));
+      expect(removedValues, equals(null));
+      print('final size ${list.length}');
+    });
+
+    test('observe remove works', () {
+      final list = ObservableList.of([0, 1]);
+
+      var index = -1;
+      var addedValues = <int>[];
+      var removedValues = <int>[];
+
+      list
+        ..observe((change) {
+          index = change.index;
+          addedValues = change.added;
+          removedValues = change.removed;
+        })
+        ..remove(1);
+
+      expect(index, equals(1));
+      expect(addedValues, equals(null));
+      expect(removedValues, equals([1]));
+    });
+
+    test('observe removeAt works', () {
+      final list = ObservableList.of([0, 1]);
+
+      var index = -1;
+      var addedValues = <int>[];
+      var removedValues = <int>[];
+
+      list
+        ..observe((change) {
+          index = change.index;
+          addedValues = change.added;
+          removedValues = change.removed;
+        })
+        ..removeAt(0);
+
+      expect(index, equals(0));
+      expect(addedValues, equals(null));
+      expect(removedValues, equals([0]));
+    });
+    test('observe replaceRange works', () {
+      final list = ObservableList<int>.of([0, -1, -2, 3]);
+
+      var index = -1;
+      var addedValues = <int>[];
+      var removedValues = <int>[];
+      final replacement = [1, 2];
+
+      list
+        ..observe((change) {
+          index = change.index;
+          addedValues = change.added;
+          removedValues = change.removed;
+        })
+        ..replaceRange(1, 3, replacement);
+
+      expect(index, equals(1));
+      expect(addedValues, equals(replacement));
+      expect(removedValues, equals([-1, -2]));
+    });
+
     test('asMap returns an observable and unmodifiable view to the list', () {
       final list = ObservableList.of([1, 2, 3]);
       final map = list.asMap();


### PR DESCRIPTION
This should fix #193. As part of this, it looked like the `addAll` and `replaceRange` had similar issues so made some changes there. Added in some extra tests to improve the test coverage as well