### PR TITLE
Adding conditional action wrappers for collection mutating methods

### DIFF
--- a/mobx/CHANGELOG.md
+++ b/mobx/CHANGELOG.md
@@ -1,12 +1,17 @@
 # Changelog
 
-## 0.3.0 - 0.3.2+2
+## 0.3.3
+
+- Wrapping all collection setters in conditional action wrappers. This removes the need to wrap collection mutating methods in explicit actions.
+
+## 0.3.0 - 0.3.2+3
 
 - API changes introduced to the `enforceActions` setting of `ReactiveConfig`. It is now called `writePolicy` and the enum `EnforceActions` has been renamed to `ReactiveWritePolicy`.
 - Also introducing a `readPolicy` setting on `ReactiveConfig`. It is an enumeration with two values:
 - Removing the "strict-mode" text in the exception message when the `ReactiveWritePolicy` is violated. This was a vestige from the `mobx.js` world.
 - Exposing a boolean `isWithinBatch` on `ReactiveContext`, which tells if the current code is running inside a batch. This is used to conditionally apply an action-wrapper for `mobx_codegen`-generated setters.
 - Introduced an action-wrapper called `conditionallyRunInAction()` that runs the given function in an action only when outside a batch.
+- Increasing test coverage
 
 ```dart
 enum ReactiveReadPolicy { always, never }

--- a/mobx/example/lib/counter.g.dart
+++ b/mobx/example/lib/counter.g.dart
@@ -20,11 +20,10 @@ mixin _$Counter on _Counter, Store {
 
   @override
   set value(int value) {
-    // Since we are conditionally wrapping within an Action, there is no need to enforceWritePolicy
     _$valueAtom.context.conditionallyRunInAction(() {
       super.value = value;
       _$valueAtom.reportChanged();
-    }, name: '${_$valueAtom.name}_set');
+    }, _$valueAtom, name: '${_$valueAtom.name}_set');
   }
 
   final _$_CounterActionController = ActionController(name: '_Counter');

--- a/mobx/example/lib/todos.g.dart
+++ b/mobx/example/lib/todos.g.dart
@@ -20,11 +20,10 @@ mixin _$Todo on TodoBase, Store {
 
   @override
   set description(String value) {
-    // Since we are conditionally wrapping within an Action, there is no need to enforceWritePolicy
     _$descriptionAtom.context.conditionallyRunInAction(() {
       super.description = value;
       _$descriptionAtom.reportChanged();
-    }, name: '${_$descriptionAtom.name}_set');
+    }, _$descriptionAtom, name: '${_$descriptionAtom.name}_set');
   }
 
   final _$doneAtom = Atom(name: 'TodoBase.done');
@@ -38,11 +37,10 @@ mixin _$Todo on TodoBase, Store {
 
   @override
   set done(bool value) {
-    // Since we are conditionally wrapping within an Action, there is no need to enforceWritePolicy
     _$doneAtom.context.conditionallyRunInAction(() {
       super.done = value;
       _$doneAtom.reportChanged();
-    }, name: '${_$doneAtom.name}_set');
+    }, _$doneAtom, name: '${_$doneAtom.name}_set');
   }
 }
 
@@ -97,11 +95,10 @@ mixin _$TodoList on TodoListBase, Store {
 
   @override
   set todos(ObservableList<Todo> value) {
-    // Since we are conditionally wrapping within an Action, there is no need to enforceWritePolicy
     _$todosAtom.context.conditionallyRunInAction(() {
       super.todos = value;
       _$todosAtom.reportChanged();
-    }, name: '${_$todosAtom.name}_set');
+    }, _$todosAtom, name: '${_$todosAtom.name}_set');
   }
 
   final _$filterAtom = Atom(name: 'TodoListBase.filter');
@@ -115,11 +112,10 @@ mixin _$TodoList on TodoListBase, Store {
 
   @override
   set filter(VisibilityFilter value) {
-    // Since we are conditionally wrapping within an Action, there is no need to enforceWritePolicy
     _$filterAtom.context.conditionallyRunInAction(() {
       super.filter = value;
       _$filterAtom.reportChanged();
-    }, name: '${_$filterAtom.name}_set');
+    }, _$filterAtom, name: '${_$filterAtom.name}_set');
   }
 
   final _$currentDescriptionAtom =
@@ -135,11 +131,10 @@ mixin _$TodoList on TodoListBase, Store {
 
   @override
   set currentDescription(String value) {
-    // Since we are conditionally wrapping within an Action, there is no need to enforceWritePolicy
     _$currentDescriptionAtom.context.conditionallyRunInAction(() {
       super.currentDescription = value;
       _$currentDescriptionAtom.reportChanged();
-    }, name: '${_$currentDescriptionAtom.name}_set');
+    }, _$currentDescriptionAtom, name: '${_$currentDescriptionAtom.name}_set');
   }
 
   final _$TodoListBaseActionController = ActionController(name: 'TodoListBase');

--- a/mobx/lib/src/api/async/observable_future.dart
+++ b/mobx/lib/src/api/async/observable_future.dart
@@ -6,14 +6,14 @@ enum FutureStatus { pending, rejected, fulfilled }
 class FutureResult<T> {
   FutureResult(ReactiveContext context, Future<T> _future, initialResult,
       FutureStatus initialStatus)
-      : _actions = ActionController(
+      : _axnController = ActionController(
             context: context, name: context.nameFor('ObservableFuture<$T>')),
         _status = Observable(initialStatus),
         _result = Observable(initialResult) {
     _future.then(_fulfill, onError: _reject);
   }
 
-  final ActionController _actions;
+  final ActionController _axnController;
 
   final Observable<FutureStatus> _status;
   FutureStatus get status => _status.value;
@@ -22,22 +22,22 @@ class FutureResult<T> {
   dynamic get result => _result.value;
 
   void _fulfill(T value) {
-    final prevDerivation = _actions.startAction();
+    final prevDerivation = _axnController.startAction();
     try {
       _status.value = FutureStatus.fulfilled;
       _result.value = value;
     } finally {
-      _actions.endAction(prevDerivation);
+      _axnController.endAction(prevDerivation);
     }
   }
 
   void _reject(error) {
-    final prevDerivation = _actions.startAction();
+    final prevDerivation = _axnController.startAction();
     try {
       _status.value = FutureStatus.rejected;
       _result.value = error;
     } finally {
-      _actions.endAction(prevDerivation);
+      _axnController.endAction(prevDerivation);
     }
   }
 }

--- a/mobx/lib/src/api/observable_collections/observable_list.dart
+++ b/mobx/lib/src/api/observable_collections/observable_list.dart
@@ -60,7 +60,7 @@ class ObservableList<T>
     _context.conditionallyRunInAction(() {
       _list.length = value;
       _notifyListUpdate(0, null, null);
-    });
+    }, _atom);
   }
 
   @override
@@ -89,7 +89,7 @@ class ObservableList<T>
         _list[index] = value;
         _notifyChildUpdate(index, value, oldValue);
       }
-    });
+    }, _atom);
   }
 
   @override
@@ -98,7 +98,7 @@ class ObservableList<T>
       final index = _list.length;
       _list.add(element);
       _notifyListUpdate(index, [element], null);
-    });
+    }, _atom);
   }
 
   @override
@@ -107,7 +107,7 @@ class ObservableList<T>
       final index = _list.length;
       _list.addAll(iterable);
       _notifyListUpdate(index, iterable.toList(growable: false), null);
-    });
+    }, _atom);
   }
 
   @override
@@ -171,7 +171,7 @@ class ObservableList<T>
 
       _list.first = value;
       _notifyChildUpdate(0, value, oldValue);
-    });
+    }, _atom);
   }
 
   @override
@@ -180,7 +180,7 @@ class ObservableList<T>
       final oldItems = _list.toList(growable: false);
       _list.clear();
       _notifyListUpdate(0, null, oldItems);
-    });
+    }, _atom);
   }
 
   @override
@@ -193,7 +193,7 @@ class ObservableList<T>
       final newContents = _list.sublist(start, end);
 
       _notifyListUpdate(start, newContents, oldContents);
-    });
+    }, _atom);
   }
 
   @override
@@ -201,7 +201,7 @@ class ObservableList<T>
     _context.conditionallyRunInAction(() {
       _list.insert(index, element);
       _notifyListUpdate(index, [element], null);
-    });
+    }, _atom);
   }
 
   @override
@@ -209,7 +209,7 @@ class ObservableList<T>
     _context.conditionallyRunInAction(() {
       _list.insertAll(index, iterable);
       _notifyListUpdate(index, iterable.toList(growable: false), null);
-    });
+    }, _atom);
   }
 
   @override
@@ -223,7 +223,7 @@ class ObservableList<T>
       if (didRemove) {
         _notifyListUpdate(index, null, element == null ? null : [element]);
       }
-    });
+    }, _atom);
 
     return didRemove;
   }
@@ -235,7 +235,7 @@ class ObservableList<T>
     _context.conditionallyRunInAction(() {
       value = _list.removeAt(index);
       _notifyListUpdate(index, null, value == null ? null : [value]);
-    });
+    }, _atom);
 
     return value;
   }
@@ -249,7 +249,7 @@ class ObservableList<T>
 
       // Index is _list.length as it points to the index before the last element is removed
       _notifyListUpdate(_list.length, null, value == null ? null : [value]);
-    });
+    }, _atom);
 
     return value;
   }
@@ -260,7 +260,7 @@ class ObservableList<T>
       final removedItems = _list.sublist(start, end);
       _list.removeRange(start, end);
       _notifyListUpdate(start, null, removedItems);
-    });
+    }, _atom);
   }
 
   @override
@@ -269,7 +269,7 @@ class ObservableList<T>
       final removedItems = _list.where(test).toList(growable: false);
       _list.removeWhere(test);
       _notifyListUpdate(0, null, removedItems);
-    });
+    }, _atom);
   }
 
   @override
@@ -278,7 +278,7 @@ class ObservableList<T>
       final oldContents = _list.sublist(start, end);
       _list.replaceRange(start, end, newContents);
       _notifyListUpdate(start, newContents, oldContents);
-    });
+    }, _atom);
   }
 
   @override
@@ -288,7 +288,7 @@ class ObservableList<T>
 
       _list.retainWhere(test);
       _notifyListUpdate(0, null, removedItems);
-    });
+    }, _atom);
   }
 
   @override
@@ -296,7 +296,7 @@ class ObservableList<T>
     _context.conditionallyRunInAction(() {
       _list.setAll(index, iterable);
       _notifyListUpdate(index, null, null);
-    });
+    }, _atom);
   }
 
   @override
@@ -304,7 +304,7 @@ class ObservableList<T>
     _context.conditionallyRunInAction(() {
       _list.setRange(start, end, iterable, skipCount);
       _notifyListUpdate(start, null, null);
-    });
+    }, _atom);
   }
 
   @override
@@ -312,7 +312,7 @@ class ObservableList<T>
     _context.conditionallyRunInAction(() {
       _list.shuffle(random);
       _notifyListUpdate(0, null, null);
-    });
+    }, _atom);
   }
 
   @override
@@ -320,7 +320,7 @@ class ObservableList<T>
     _context.conditionallyRunInAction(() {
       _list.sort(compare);
       _notifyListUpdate(0, null, null);
-    });
+    }, _atom);
   }
 
   @override

--- a/mobx/lib/src/api/observable_collections/observable_list.dart
+++ b/mobx/lib/src/api/observable_collections/observable_list.dart
@@ -56,10 +56,11 @@ class ObservableList<T>
 
   @override
   set length(int value) {
-    _context.enforceWritePolicy(_atom);
-
-    _list.length = value;
-    _notifyListUpdate(0, null, null);
+    /// There is no need to enforceWritePolicy since we are conditionally wrapping in an Action.
+    _context.conditionallyRunInAction(() {
+      _list.length = value;
+      _notifyListUpdate(0, null, null);
+    });
   }
 
   @override
@@ -81,30 +82,32 @@ class ObservableList<T>
 
   @override
   void operator []=(int index, T value) {
-    _context.enforceWritePolicy(_atom);
+    _context.conditionallyRunInAction(() {
+      final oldValue = _list[index];
 
-    final oldValue = _list[index];
-
-    if (oldValue != value) {
-      _list[index] = value;
-      _notifyChildUpdate(index, value, oldValue);
-    }
+      if (oldValue != value) {
+        _list[index] = value;
+        _notifyChildUpdate(index, value, oldValue);
+      }
+    });
   }
 
   @override
   void add(T element) {
-    _context.enforceWritePolicy(_atom);
-    final index = _list.length;
-    _list.add(element);
-    _notifyListUpdate(index, [element], null);
+    _context.conditionallyRunInAction(() {
+      final index = _list.length;
+      _list.add(element);
+      _notifyListUpdate(index, [element], null);
+    });
   }
 
   @override
   void addAll(Iterable<T> iterable) {
-    _context.enforceWritePolicy(_atom);
-    final index = _list.length;
-    _list.addAll(iterable);
-    _notifyListUpdate(index, iterable.toList(growable: false), null);
+    _context.conditionallyRunInAction(() {
+      final index = _list.length;
+      _list.addAll(iterable);
+      _notifyListUpdate(index, iterable.toList(growable: false), null);
+    });
   }
 
   @override
@@ -163,153 +166,161 @@ class ObservableList<T>
 
   @override
   set first(T value) {
-    _context.enforceWritePolicy(_atom);
+    _context.conditionallyRunInAction(() {
+      final oldValue = _list.first;
 
-    final oldValue = _list.first;
-
-    _list.first = value;
-    _notifyChildUpdate(0, value, oldValue);
+      _list.first = value;
+      _notifyChildUpdate(0, value, oldValue);
+    });
   }
 
   @override
   void clear() {
-    _context.enforceWritePolicy(_atom);
-
-    final oldItems = _list.toList(growable: false);
-    _list.clear();
-    _notifyListUpdate(0, null, oldItems);
+    _context.conditionallyRunInAction(() {
+      final oldItems = _list.toList(growable: false);
+      _list.clear();
+      _notifyListUpdate(0, null, oldItems);
+    });
   }
 
   @override
   void fillRange(int start, int end, [T fill]) {
-    _context.enforceWritePolicy(_atom);
+    _context.conditionallyRunInAction(() {
+      final oldContents = _list.sublist(start, end);
 
-    final oldContents = _list.sublist(start, end);
+      _list.fillRange(start, end, fill);
 
-    _list.fillRange(start, end, fill);
+      final newContents = _list.sublist(start, end);
 
-    final newContents = _list.sublist(start, end);
-
-    _notifyListUpdate(start, newContents, oldContents);
+      _notifyListUpdate(start, newContents, oldContents);
+    });
   }
 
   @override
   void insert(int index, T element) {
-    _context.enforceWritePolicy(_atom);
-
-    _list.insert(index, element);
-    _notifyListUpdate(index, [element], null);
+    _context.conditionallyRunInAction(() {
+      _list.insert(index, element);
+      _notifyListUpdate(index, [element], null);
+    });
   }
 
   @override
   void insertAll(int index, Iterable<T> iterable) {
-    _context.enforceWritePolicy(_atom);
-
-    _list.insertAll(index, iterable);
-    _notifyListUpdate(index, iterable.toList(growable: false), null);
+    _context.conditionallyRunInAction(() {
+      _list.insertAll(index, iterable);
+      _notifyListUpdate(index, iterable.toList(growable: false), null);
+    });
   }
 
   @override
   bool remove(Object element) {
-    _context.enforceWritePolicy(_atom);
+    var didRemove = false;
 
-    final index = _list.indexOf(element);
-    final didRemove = _list.remove(element);
+    _context.conditionallyRunInAction(() {
+      final index = _list.indexOf(element);
+      didRemove = _list.remove(element);
 
-    if (didRemove) {
-      _notifyListUpdate(index, null, element == null ? null : [element]);
-    }
+      if (didRemove) {
+        _notifyListUpdate(index, null, element == null ? null : [element]);
+      }
+    });
 
     return didRemove;
   }
 
   @override
   T removeAt(int index) {
-    _context.enforceWritePolicy(_atom);
+    T value;
 
-    final value = _list.removeAt(index);
-    _notifyListUpdate(index, null, value == null ? null : [value]);
+    _context.conditionallyRunInAction(() {
+      value = _list.removeAt(index);
+      _notifyListUpdate(index, null, value == null ? null : [value]);
+    });
+
     return value;
   }
 
   @override
   T removeLast() {
-    _context.enforceWritePolicy(_atom);
+    T value;
 
-    final value = _list.removeLast();
+    _context.conditionallyRunInAction(() {
+      value = _list.removeLast();
 
-    // Index is _list.length as it points to the index before the last element is removed
-    _notifyListUpdate(_list.length, null, value == null ? null : [value]);
+      // Index is _list.length as it points to the index before the last element is removed
+      _notifyListUpdate(_list.length, null, value == null ? null : [value]);
+    });
 
     return value;
   }
 
   @override
   void removeRange(int start, int end) {
-    _context.enforceWritePolicy(_atom);
-
-    final removedItems = _list.sublist(start, end);
-    _list.removeRange(start, end);
-    _notifyListUpdate(start, null, removedItems);
+    _context.conditionallyRunInAction(() {
+      final removedItems = _list.sublist(start, end);
+      _list.removeRange(start, end);
+      _notifyListUpdate(start, null, removedItems);
+    });
   }
 
   @override
   void removeWhere(bool Function(T element) test) {
-    _context.enforceWritePolicy(_atom);
-
-    final removedItems = _list.where(test).toList(growable: false);
-    _list.removeWhere(test);
-    _notifyListUpdate(0, null, removedItems);
+    _context.conditionallyRunInAction(() {
+      final removedItems = _list.where(test).toList(growable: false);
+      _list.removeWhere(test);
+      _notifyListUpdate(0, null, removedItems);
+    });
   }
 
   @override
   void replaceRange(int start, int end, Iterable<T> newContents) {
-    _context.enforceWritePolicy(_atom);
-    final oldContents = _list.sublist(start, end);
-    _list.replaceRange(start, end, newContents);
-    _notifyListUpdate(start, newContents, oldContents);
+    _context.conditionallyRunInAction(() {
+      final oldContents = _list.sublist(start, end);
+      _list.replaceRange(start, end, newContents);
+      _notifyListUpdate(start, newContents, oldContents);
+    });
   }
 
   @override
   void retainWhere(bool Function(T element) test) {
-    _context.enforceWritePolicy(_atom);
+    _context.conditionallyRunInAction(() {
+      final removedItems = _list.where((_) => !test(_)).toList(growable: false);
 
-    final removedItems = _list.where((_) => !test(_)).toList(growable: false);
-
-    _list.retainWhere(test);
-    _notifyListUpdate(0, null, removedItems);
+      _list.retainWhere(test);
+      _notifyListUpdate(0, null, removedItems);
+    });
   }
 
   @override
   void setAll(int index, Iterable<T> iterable) {
-    _context.enforceWritePolicy(_atom);
-
-    _list.setAll(index, iterable);
-    _notifyListUpdate(index, null, null);
+    _context.conditionallyRunInAction(() {
+      _list.setAll(index, iterable);
+      _notifyListUpdate(index, null, null);
+    });
   }
 
   @override
   void setRange(int start, int end, Iterable<T> iterable, [int skipCount = 0]) {
-    _context.enforceWritePolicy(_atom);
-
-    _list.setRange(start, end, iterable, skipCount);
-    _notifyListUpdate(start, null, null);
+    _context.conditionallyRunInAction(() {
+      _list.setRange(start, end, iterable, skipCount);
+      _notifyListUpdate(start, null, null);
+    });
   }
 
   @override
   void shuffle([Random random]) {
-    _context.enforceWritePolicy(_atom);
-
-    _list.shuffle(random);
-    _notifyListUpdate(0, null, null);
+    _context.conditionallyRunInAction(() {
+      _list.shuffle(random);
+      _notifyListUpdate(0, null, null);
+    });
   }
 
   @override
   void sort([int Function(T a, T b) compare]) {
-    _context.enforceWritePolicy(_atom);
-
-    _list.sort(compare);
-    _notifyListUpdate(0, null, null);
+    _context.conditionallyRunInAction(() {
+      _list.sort(compare);
+      _notifyListUpdate(0, null, null);
+    });
   }
 
   @override

--- a/mobx/lib/src/api/observable_collections/observable_map.dart
+++ b/mobx/lib/src/api/observable_collections/observable_map.dart
@@ -73,7 +73,7 @@ class ObservableMap<K, V>
         _map[key] = value;
       }
       _atom.reportChanged();
-    });
+    }, _atom);
   }
 
   @override
@@ -90,7 +90,7 @@ class ObservableMap<K, V>
         _map.clear();
       }
       _atom.reportChanged();
-    });
+    }, _atom);
   }
 
   @override
@@ -118,7 +118,7 @@ class ObservableMap<K, V>
 
       value = _map.remove(key);
       _atom.reportChanged();
-    });
+    }, _atom);
 
     return value;
   }

--- a/mobx/lib/src/api/observable_collections/observable_map.dart
+++ b/mobx/lib/src/api/observable_collections/observable_map.dart
@@ -59,38 +59,38 @@ class ObservableMap<K, V>
 
   @override
   void operator []=(K key, V value) {
-    _context.enforceWritePolicy(_atom);
-
-    if (_hasListeners) {
-      if (_map.containsKey(key)) {
-        final oldValue = _map[key];
-        _map[key] = value;
-        _reportUpdate(key, value, oldValue);
+    _context.conditionallyRunInAction(() {
+      if (_hasListeners) {
+        if (_map.containsKey(key)) {
+          final oldValue = _map[key];
+          _map[key] = value;
+          _reportUpdate(key, value, oldValue);
+        } else {
+          _map[key] = value;
+          _reportAdd(key, value);
+        }
       } else {
         _map[key] = value;
-        _reportAdd(key, value);
       }
-    } else {
-      _map[key] = value;
-    }
-    _atom.reportChanged();
+      _atom.reportChanged();
+    });
   }
 
   @override
   void clear() {
-    _context.enforceWritePolicy(_atom);
-
-    if (isEmpty) {
-      return;
-    }
-    if (_hasListeners) {
-      final removed = Map<K, V>.from(_map);
-      _map.clear();
-      removed.forEach(_reportRemove);
-    } else {
-      _map.clear();
-    }
-    _atom.reportChanged();
+    _context.conditionallyRunInAction(() {
+      if (isEmpty) {
+        return;
+      }
+      if (_hasListeners) {
+        final removed = Map<K, V>.from(_map);
+        _map.clear();
+        removed.forEach(_reportRemove);
+      } else {
+        _map.clear();
+      }
+      _atom.reportChanged();
+    });
   }
 
   @override
@@ -102,20 +102,24 @@ class ObservableMap<K, V>
 
   @override
   V remove(Object key) {
-    _context.enforceWritePolicy(_atom);
+    V value;
 
-    if (_hasListeners) {
-      if (_map.containsKey(key)) {
-        final value = _map.remove(key);
-        _reportRemove(key, value);
-        _atom.reportChanged();
-        return value;
+    _context.conditionallyRunInAction(() {
+      if (_hasListeners) {
+        if (_map.containsKey(key)) {
+          value = _map.remove(key);
+          _reportRemove(key, value);
+          _atom.reportChanged();
+          return;
+        }
+
+        value = null;
       }
-      return null;
-    }
 
-    final value = _map.remove(key);
-    _atom.reportChanged();
+      value = _map.remove(key);
+      _atom.reportChanged();
+    });
+
     return value;
   }
 

--- a/mobx/lib/src/api/observable_collections/observable_set.dart
+++ b/mobx/lib/src/api/observable_collections/observable_set.dart
@@ -63,7 +63,7 @@ class ObservableSet<T>
         _reportAdd(value);
       }
       _atom.reportChanged();
-    });
+    }, _atom);
 
     return result;
   }
@@ -107,7 +107,7 @@ class ObservableSet<T>
       }
 
       _atom.reportChanged();
-    });
+    }, _atom);
 
     return removed;
   }
@@ -123,7 +123,7 @@ class ObservableSet<T>
         _set.clear();
       }
       _atom.reportChanged();
-    });
+    }, _atom);
   }
 
   @override

--- a/mobx/lib/src/api/observable_collections/observable_set.dart
+++ b/mobx/lib/src/api/observable_collections/observable_set.dart
@@ -54,13 +54,17 @@ class ObservableSet<T>
 
   @override
   bool add(T value) {
-    _context.enforceWritePolicy(_atom);
+    var result = false;
 
-    final result = _set.add(value);
-    if (result && _hasListeners) {
-      _reportAdd(value);
-    }
-    _atom.reportChanged();
+    _context.conditionallyRunInAction(() {
+      result = _set.add(value);
+
+      if (result && _hasListeners) {
+        _reportAdd(value);
+      }
+      _atom.reportChanged();
+    });
+
     return result;
   }
 
@@ -93,28 +97,33 @@ class ObservableSet<T>
 
   @override
   bool remove(Object value) {
-    _context.enforceWritePolicy(_atom);
+    var removed = false;
 
-    final removed = _set.remove(value);
-    if (removed && _hasListeners) {
-      _reportRemove(value);
-    }
-    _atom.reportChanged();
+    _context.conditionallyRunInAction(() {
+      removed = _set.remove(value);
+
+      if (removed && _hasListeners) {
+        _reportRemove(value);
+      }
+
+      _atom.reportChanged();
+    });
+
     return removed;
   }
 
   @override
   void clear() {
-    _context.enforceWritePolicy(_atom);
-
-    if (_hasListeners) {
-      final items = _set.toList(growable: false);
-      _set.clear();
-      items.forEach(_reportRemove);
-    } else {
-      _set.clear();
-    }
-    _atom.reportChanged();
+    _context.conditionallyRunInAction(() {
+      if (_hasListeners) {
+        final items = _set.toList(growable: false);
+        _set.clear();
+        items.forEach(_reportRemove);
+      } else {
+        _set.clear();
+      }
+      _atom.reportChanged();
+    });
   }
 
   @override

--- a/mobx/lib/src/core/context.dart
+++ b/mobx/lib/src/core/context.dart
@@ -204,9 +204,10 @@ class ReactiveContext {
 
   /// Only run within an action if outside a batch
   /// [fn] is the function to execute. Optionally provide a debug-[name].
-  void conditionallyRunInAction(void Function() fn,
+  void conditionallyRunInAction(void Function() fn, Atom atom,
       {String name, ActionController actionController}) {
     if (isWithinBatch) {
+      enforceWritePolicy(atom);
       fn();
     } else {
       final controller = actionController ??
@@ -215,6 +216,7 @@ class ReactiveContext {
       final runInfo = controller.startAction();
 
       try {
+        enforceWritePolicy(atom);
         fn();
       } finally {
         controller.endAction(runInfo);

--- a/mobx/pubspec.yaml
+++ b/mobx/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mobx
-version: 0.3.2+2
+version: 0.3.3
 description: "MobX is a library for reactively managing the state of your applications. Use the power of observables, actions, and reactions to supercharge your Dart and Flutter apps."
 authors:
   - Pavan Podila <pavan@pixelingene.com>

--- a/mobx/test/context_test.dart
+++ b/mobx/test/context_test.dart
@@ -87,10 +87,11 @@ void main() {
         final controller = MockActionController();
         final context = createContext();
         var hasRun = false;
+        final o = Observable(0);
 
         context.conditionallyRunInAction(() {
           hasRun = true;
-        }, actionController: controller);
+        }, o, actionController: controller);
 
         verify(controller.startAction());
         verify(controller.endAction(any));
@@ -102,10 +103,11 @@ void main() {
           () {
         final context = createContext();
         var hasRun = false;
+        final o = Observable(0);
 
         context.conditionallyRunInAction(() {
           hasRun = true;
-        });
+        }, o);
 
         expect(hasRun, isTrue);
       });
@@ -115,12 +117,14 @@ void main() {
           () {
         final controller = MockActionController();
         final context = createContext();
+        final o = Observable(0);
+
         var hasRun = false;
 
         runInAction(() {
           context.conditionallyRunInAction(() {
             hasRun = true;
-          }, actionController: controller);
+          }, o, actionController: controller);
         }, context: context);
 
         verifyNever(controller.startAction());

--- a/mobx/test/context_test.dart
+++ b/mobx/test/context_test.dart
@@ -98,6 +98,19 @@ void main() {
       });
 
       test(
+          'when no ActionController is provided, it should create an ad-hoc ActionController',
+          () {
+        final context = createContext();
+        var hasRun = false;
+
+        context.conditionallyRunInAction(() {
+          hasRun = true;
+        });
+
+        expect(hasRun, isTrue);
+      });
+
+      test(
           'when running INSIDE an Action, it should NOT USE the ActionController',
           () {
         final controller = MockActionController();

--- a/mobx_codegen/CHANGELOG.md
+++ b/mobx_codegen/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## 0.3.1 - 0.3.2+3
+## 0.3.1 - 0.3.3
 
 - Adding a conditional action-wrapper for field setters.
 - Increasing test coverage
+- Adapting to the API change in `mobx 0.3.3`
 
 ## 0.3.0 - 0.3.0+1
 

--- a/mobx_codegen/lib/src/template/observable.dart
+++ b/mobx_codegen/lib/src/template/observable.dart
@@ -19,10 +19,9 @@ class ObservableTemplate {
 
   @override
   set $name($type value) {
-    // Since we are conditionally wrapping within an Action, there is no need to enforceWritePolicy
     $atomName.context.conditionallyRunInAction(() {
       super.$name = value;
       $atomName.reportChanged();
-    }, name: '\${$atomName.name}_set');
+    }, $atomName, name: '\${$atomName.name}_set');
   }""";
 }

--- a/mobx_codegen/pubspec.yaml
+++ b/mobx_codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobx_codegen
 description: Code generator for MobX that adds support for annotating your code with @observable, @computed, @action and also creating Store classes.
-version: 0.3.2+3
+version: 0.3.3
 authors:
   - Joni Katajamäki <joni.katajamaki@gmail.com>
   - Pavan Podila <pavan@pixelingene.com>
@@ -14,7 +14,7 @@ environment:
 dependencies:
   path: ^1.6.2
   source_gen: ^0.9.4
-  mobx: ^0.3.2
+  mobx: ^0.3.3
   build: ^1.1.4
   analyzer: ^0.36.3
 

--- a/mobx_codegen/test/generator_usage_test.g.dart
+++ b/mobx_codegen/test/generator_usage_test.g.dart
@@ -32,11 +32,10 @@ mixin _$TestStore on _TestStore, Store {
 
   @override
   set field1(String value) {
-    // Since we are conditionally wrapping within an Action, there is no need to enforceWritePolicy
     _$field1Atom.context.conditionallyRunInAction(() {
       super.field1 = value;
       _$field1Atom.reportChanged();
-    }, name: '${_$field1Atom.name}_set');
+    }, _$field1Atom, name: '${_$field1Atom.name}_set');
   }
 
   final _$field2Atom = Atom(name: '_TestStore.field2');
@@ -50,11 +49,10 @@ mixin _$TestStore on _TestStore, Store {
 
   @override
   set field2(String value) {
-    // Since we are conditionally wrapping within an Action, there is no need to enforceWritePolicy
     _$field2Atom.context.conditionallyRunInAction(() {
       super.field2 = value;
       _$field2Atom.reportChanged();
-    }, name: '${_$field2Atom.name}_set');
+    }, _$field2Atom, name: '${_$field2Atom.name}_set');
   }
 
   final _$stuffAtom = Atom(name: '_TestStore.stuff');
@@ -68,11 +66,10 @@ mixin _$TestStore on _TestStore, Store {
 
   @override
   set stuff(String value) {
-    // Since we are conditionally wrapping within an Action, there is no need to enforceWritePolicy
     _$stuffAtom.context.conditionallyRunInAction(() {
       super.stuff = value;
       _$stuffAtom.reportChanged();
-    }, name: '${_$stuffAtom.name}_set');
+    }, _$stuffAtom, name: '${_$stuffAtom.name}_set');
   }
 
   final _$batchItem1Atom = Atom(name: '_TestStore.batchItem1');
@@ -86,11 +83,10 @@ mixin _$TestStore on _TestStore, Store {
 
   @override
   set batchItem1(String value) {
-    // Since we are conditionally wrapping within an Action, there is no need to enforceWritePolicy
     _$batchItem1Atom.context.conditionallyRunInAction(() {
       super.batchItem1 = value;
       _$batchItem1Atom.reportChanged();
-    }, name: '${_$batchItem1Atom.name}_set');
+    }, _$batchItem1Atom, name: '${_$batchItem1Atom.name}_set');
   }
 
   final _$batchItem2Atom = Atom(name: '_TestStore.batchItem2');
@@ -104,11 +100,10 @@ mixin _$TestStore on _TestStore, Store {
 
   @override
   set batchItem2(String value) {
-    // Since we are conditionally wrapping within an Action, there is no need to enforceWritePolicy
     _$batchItem2Atom.context.conditionallyRunInAction(() {
       super.batchItem2 = value;
       _$batchItem2Atom.reportChanged();
-    }, name: '${_$batchItem2Atom.name}_set');
+    }, _$batchItem2Atom, name: '${_$batchItem2Atom.name}_set');
   }
 
   final _$batchItem3Atom = Atom(name: '_TestStore.batchItem3');
@@ -122,11 +117,10 @@ mixin _$TestStore on _TestStore, Store {
 
   @override
   set batchItem3(String value) {
-    // Since we are conditionally wrapping within an Action, there is no need to enforceWritePolicy
     _$batchItem3Atom.context.conditionallyRunInAction(() {
       super.batchItem3 = value;
       _$batchItem3Atom.reportChanged();
-    }, name: '${_$batchItem3Atom.name}_set');
+    }, _$batchItem3Atom, name: '${_$batchItem3Atom.name}_set');
   }
 
   final _$batchItem4Atom = Atom(name: '_TestStore.batchItem4');
@@ -140,11 +134,10 @@ mixin _$TestStore on _TestStore, Store {
 
   @override
   set batchItem4(String value) {
-    // Since we are conditionally wrapping within an Action, there is no need to enforceWritePolicy
     _$batchItem4Atom.context.conditionallyRunInAction(() {
       super.batchItem4 = value;
       _$batchItem4Atom.reportChanged();
-    }, name: '${_$batchItem4Atom.name}_set');
+    }, _$batchItem4Atom, name: '${_$batchItem4Atom.name}_set');
   }
 
   final _$errorFieldAtom = Atom(name: '_TestStore.errorField');
@@ -158,11 +151,10 @@ mixin _$TestStore on _TestStore, Store {
 
   @override
   set errorField(String value) {
-    // Since we are conditionally wrapping within an Action, there is no need to enforceWritePolicy
     _$errorFieldAtom.context.conditionallyRunInAction(() {
       super.errorField = value;
       _$errorFieldAtom.reportChanged();
-    }, name: '${_$errorFieldAtom.name}_set');
+    }, _$errorFieldAtom, name: '${_$errorFieldAtom.name}_set');
   }
 
   @override

--- a/mobx_codegen/test/mobx_codegen_test.dart
+++ b/mobx_codegen/test/mobx_codegen_test.dart
@@ -83,11 +83,10 @@ mixin _\$User on UserBase, Store {
 
   @override
   set firstName(String value) {
-    // Since we are conditionally wrapping within an Action, there is no need to enforceWritePolicy
     _\$firstNameAtom.context.conditionallyRunInAction(() {
       super.firstName = value;
       _\$firstNameAtom.reportChanged();
-    }, name: '\${_\$firstNameAtom.name}_set');
+    }, _\$firstNameAtom, name: '\${_\$firstNameAtom.name}_set');
   }
 
   final _\$lastNameAtom = Atom(name: 'UserBase.lastName');
@@ -101,11 +100,10 @@ mixin _\$User on UserBase, Store {
 
   @override
   set lastName(String value) {
-    // Since we are conditionally wrapping within an Action, there is no need to enforceWritePolicy
     _\$lastNameAtom.context.conditionallyRunInAction(() {
       super.lastName = value;
       _\$lastNameAtom.reportChanged();
-    }, name: '\${_\$lastNameAtom.name}_set');
+    }, _\$lastNameAtom, name: '\${_\$lastNameAtom.name}_set');
   }
 
   @override
@@ -232,11 +230,10 @@ mixin _\$Item<T> on _Item<T>, Store {
 
   @override
   set value(T value) {
-    // Since we are conditionally wrapping within an Action, there is no need to enforceWritePolicy
     _\$valueAtom.context.conditionallyRunInAction(() {
       super.value = value;
       _\$valueAtom.reportChanged();
-    }, name: '\${_\$valueAtom.name}_set');
+    }, _\$valueAtom, name: '\${_\$valueAtom.name}_set');
   }
 }
 """;

--- a/mobx_codegen/test/nested_store.g.dart
+++ b/mobx_codegen/test/nested_store.g.dart
@@ -20,10 +20,9 @@ mixin _$NestedStore on _NestedStore, Store {
 
   @override
   set name(String value) {
-    // Since we are conditionally wrapping within an Action, there is no need to enforceWritePolicy
     _$nameAtom.context.conditionallyRunInAction(() {
       super.name = value;
       _$nameAtom.reportChanged();
-    }, name: '${_$nameAtom.name}_set');
+    }, _$nameAtom, name: '${_$nameAtom.name}_set');
   }
 }

--- a/mobx_codegen/test/templates_test.dart
+++ b/mobx_codegen/test/templates_test.dart
@@ -112,11 +112,10 @@ void main() {
 
   @override
   set fieldName(FieldType value) {
-    // Since we are conditionally wrapping within an Action, there is no need to enforceWritePolicy
     _atomFieldName.context.conditionallyRunInAction(() {
       super.fieldName = value;
       _atomFieldName.reportChanged();
-    }, name: '\${_atomFieldName.name}_set');
+    }, _atomFieldName, name: '\${_atomFieldName.name}_set');
   }"""));
     });
   });

--- a/mobx_examples/lib/counter/counter.g.dart
+++ b/mobx_examples/lib/counter/counter.g.dart
@@ -24,7 +24,7 @@ mixin _$Counter on _Counter, Store {
     _$valueAtom.context.conditionallyRunInAction(() {
       super.value = value;
       _$valueAtom.reportChanged();
-    }, name: '${_$valueAtom.name}_set');
+    }, _$valueAtom, name: '${_$valueAtom.name}_set');
   }
 
   final _$_CounterActionController = ActionController(name: '_Counter');

--- a/mobx_examples/lib/form/form_store.dart
+++ b/mobx_examples/lib/form/form_store.dart
@@ -37,21 +37,6 @@ abstract class _FormStore with Store {
 
   List<ReactionDisposer> _disposers;
 
-  @action
-  void setUsername(String value) {
-    name = value;
-  }
-
-  @action
-  void setEmail(String value) {
-    email = value;
-  }
-
-  @action
-  void setPassword(String value) {
-    password = value;
-  }
-
   void setupValidations() {
     _disposers = [
       reaction((_) => name, validateUsername),

--- a/mobx_examples/lib/form/form_store.g.dart
+++ b/mobx_examples/lib/form/form_store.g.dart
@@ -122,36 +122,6 @@ mixin _$FormStore on _FormStore, Store {
   final _$_FormStoreActionController = ActionController(name: '_FormStore');
 
   @override
-  void setUsername(String value) {
-    final _$actionInfo = _$_FormStoreActionController.startAction();
-    try {
-      return super.setUsername(value);
-    } finally {
-      _$_FormStoreActionController.endAction(_$actionInfo);
-    }
-  }
-
-  @override
-  void setEmail(String value) {
-    final _$actionInfo = _$_FormStoreActionController.startAction();
-    try {
-      return super.setEmail(value);
-    } finally {
-      _$_FormStoreActionController.endAction(_$actionInfo);
-    }
-  }
-
-  @override
-  void setPassword(String value) {
-    final _$actionInfo = _$_FormStoreActionController.startAction();
-    try {
-      return super.setPassword(value);
-    } finally {
-      _$_FormStoreActionController.endAction(_$actionInfo);
-    }
-  }
-
-  @override
   void validatePassword(String value) {
     final _$actionInfo = _$_FormStoreActionController.startAction();
     try {

--- a/mobx_examples/lib/form/form_store.g.dart
+++ b/mobx_examples/lib/form/form_store.g.dart
@@ -36,7 +36,7 @@ mixin _$FormStore on _FormStore, Store {
     _$colorAtom.context.conditionallyRunInAction(() {
       super.color = value;
       _$colorAtom.reportChanged();
-    }, name: '${_$colorAtom.name}_set');
+    }, _$colorAtom, name: '${_$colorAtom.name}_set');
   }
 
   final _$nameAtom = Atom(name: '_FormStore.name');
@@ -54,7 +54,7 @@ mixin _$FormStore on _FormStore, Store {
     _$nameAtom.context.conditionallyRunInAction(() {
       super.name = value;
       _$nameAtom.reportChanged();
-    }, name: '${_$nameAtom.name}_set');
+    }, _$nameAtom, name: '${_$nameAtom.name}_set');
   }
 
   final _$emailAtom = Atom(name: '_FormStore.email');
@@ -72,7 +72,7 @@ mixin _$FormStore on _FormStore, Store {
     _$emailAtom.context.conditionallyRunInAction(() {
       super.email = value;
       _$emailAtom.reportChanged();
-    }, name: '${_$emailAtom.name}_set');
+    }, _$emailAtom, name: '${_$emailAtom.name}_set');
   }
 
   final _$passwordAtom = Atom(name: '_FormStore.password');
@@ -90,7 +90,7 @@ mixin _$FormStore on _FormStore, Store {
     _$passwordAtom.context.conditionallyRunInAction(() {
       super.password = value;
       _$passwordAtom.reportChanged();
-    }, name: '${_$passwordAtom.name}_set');
+    }, _$passwordAtom, name: '${_$passwordAtom.name}_set');
   }
 
   final _$_usernameCheckAtom = Atom(name: '_FormStore._usernameCheck');
@@ -108,7 +108,7 @@ mixin _$FormStore on _FormStore, Store {
     _$_usernameCheckAtom.context.conditionallyRunInAction(() {
       super._usernameCheck = value;
       _$_usernameCheckAtom.reportChanged();
-    }, name: '${_$_usernameCheckAtom.name}_set');
+    }, _$_usernameCheckAtom, name: '${_$_usernameCheckAtom.name}_set');
   }
 
   final _$validateUsernameAsyncAction = AsyncAction('validateUsername');
@@ -166,7 +166,7 @@ mixin _$FormErrorState on _FormErrorState, Store {
     _$usernameAtom.context.conditionallyRunInAction(() {
       super.username = value;
       _$usernameAtom.reportChanged();
-    }, name: '${_$usernameAtom.name}_set');
+    }, _$usernameAtom, name: '${_$usernameAtom.name}_set');
   }
 
   final _$emailAtom = Atom(name: '_FormErrorState.email');
@@ -184,7 +184,7 @@ mixin _$FormErrorState on _FormErrorState, Store {
     _$emailAtom.context.conditionallyRunInAction(() {
       super.email = value;
       _$emailAtom.reportChanged();
-    }, name: '${_$emailAtom.name}_set');
+    }, _$emailAtom, name: '${_$emailAtom.name}_set');
   }
 
   final _$passwordAtom = Atom(name: '_FormErrorState.password');
@@ -202,6 +202,6 @@ mixin _$FormErrorState on _FormErrorState, Store {
     _$passwordAtom.context.conditionallyRunInAction(() {
       super.password = value;
       _$passwordAtom.reportChanged();
-    }, name: '${_$passwordAtom.name}_set');
+    }, _$passwordAtom, name: '${_$passwordAtom.name}_set');
   }
 }

--- a/mobx_examples/lib/form/form_widgets.dart
+++ b/mobx_examples/lib/form/form_widgets.dart
@@ -36,7 +36,7 @@ class _FormExampleState extends State<FormExample> {
             children: <Widget>[
               Observer(
                 builder: (_) => TextField(
-                      onChanged: store.setUsername,
+                      onChanged: (value) => store.name = value,
                       decoration: InputDecoration(
                           labelText: 'Username',
                           hintText: 'Pick a username',
@@ -50,7 +50,7 @@ class _FormExampleState extends State<FormExample> {
                       opacity: store.isUserCheckPending ? 1 : 0)),
               Observer(
                 builder: (_) => TextField(
-                      onChanged: store.setEmail,
+                      onChanged: (value) => store.email = value,
                       decoration: InputDecoration(
                           labelText: 'Email',
                           hintText: 'Enter your email address',
@@ -59,7 +59,7 @@ class _FormExampleState extends State<FormExample> {
               ),
               Observer(
                 builder: (_) => TextField(
-                      onChanged: store.setPassword,
+                      onChanged: (value) => store.password = value,
                       decoration: InputDecoration(
                           labelText: 'Password',
                           hintText: 'Set a password',

--- a/mobx_examples/lib/github/github_store.g.dart
+++ b/mobx_examples/lib/github/github_store.g.dart
@@ -30,7 +30,7 @@ mixin _$GithubStore on _GithubStore, Store {
     _$fetchReposFutureAtom.context.conditionallyRunInAction(() {
       super.fetchReposFuture = value;
       _$fetchReposFutureAtom.reportChanged();
-    }, name: '${_$fetchReposFutureAtom.name}_set');
+    }, _$fetchReposFutureAtom, name: '${_$fetchReposFutureAtom.name}_set');
   }
 
   final _$userAtom = Atom(name: '_GithubStore.user');
@@ -48,7 +48,7 @@ mixin _$GithubStore on _GithubStore, Store {
     _$userAtom.context.conditionallyRunInAction(() {
       super.user = value;
       _$userAtom.reportChanged();
-    }, name: '${_$userAtom.name}_set');
+    }, _$userAtom, name: '${_$userAtom.name}_set');
   }
 
   final _$fetchReposAsyncAction = AsyncAction('fetchRepos');

--- a/mobx_examples/lib/hackernews/news_store.g.dart
+++ b/mobx_examples/lib/hackernews/news_store.g.dart
@@ -25,7 +25,7 @@ mixin _$HackerNewsStore on _HackerNewsStore, Store {
     _$latestItemsFutureAtom.context.conditionallyRunInAction(() {
       super.latestItemsFuture = value;
       _$latestItemsFutureAtom.reportChanged();
-    }, name: '${_$latestItemsFutureAtom.name}_set');
+    }, _$latestItemsFutureAtom, name: '${_$latestItemsFutureAtom.name}_set');
   }
 
   final _$topItemsFutureAtom = Atom(name: '_HackerNewsStore.topItemsFuture');
@@ -43,7 +43,7 @@ mixin _$HackerNewsStore on _HackerNewsStore, Store {
     _$topItemsFutureAtom.context.conditionallyRunInAction(() {
       super.topItemsFuture = value;
       _$topItemsFutureAtom.reportChanged();
-    }, name: '${_$topItemsFutureAtom.name}_set');
+    }, _$topItemsFutureAtom, name: '${_$topItemsFutureAtom.name}_set');
   }
 
   final _$_HackerNewsStoreActionController =

--- a/mobx_examples/lib/multi_counter/multi_counter_store.g.dart
+++ b/mobx_examples/lib/multi_counter/multi_counter_store.g.dart
@@ -24,7 +24,7 @@ mixin _$SingleCounter on _SingleCounter, Store {
     _$valueAtom.context.conditionallyRunInAction(() {
       super.value = value;
       _$valueAtom.reportChanged();
-    }, name: '${_$valueAtom.name}_set');
+    }, _$valueAtom, name: '${_$valueAtom.name}_set');
   }
 
   final _$_SingleCounterActionController =

--- a/mobx_examples/lib/todos/todo.g.dart
+++ b/mobx_examples/lib/todos/todo.g.dart
@@ -24,7 +24,7 @@ mixin _$Todo on _Todo, Store {
     _$descriptionAtom.context.conditionallyRunInAction(() {
       super.description = value;
       _$descriptionAtom.reportChanged();
-    }, name: '${_$descriptionAtom.name}_set');
+    }, _$descriptionAtom, name: '${_$descriptionAtom.name}_set');
   }
 
   final _$doneAtom = Atom(name: '_Todo.done');
@@ -42,6 +42,6 @@ mixin _$Todo on _Todo, Store {
     _$doneAtom.context.conditionallyRunInAction(() {
       super.done = value;
       _$doneAtom.reportChanged();
-    }, name: '${_$doneAtom.name}_set');
+    }, _$doneAtom, name: '${_$doneAtom.name}_set');
   }
 }

--- a/mobx_examples/lib/todos/todo_list.g.dart
+++ b/mobx_examples/lib/todos/todo_list.g.dart
@@ -73,7 +73,7 @@ mixin _$TodoList on _TodoList, Store {
     _$todosAtom.context.conditionallyRunInAction(() {
       super.todos = value;
       _$todosAtom.reportChanged();
-    }, name: '${_$todosAtom.name}_set');
+    }, _$todosAtom, name: '${_$todosAtom.name}_set');
   }
 
   final _$filterAtom = Atom(name: '_TodoList.filter');
@@ -91,7 +91,7 @@ mixin _$TodoList on _TodoList, Store {
     _$filterAtom.context.conditionallyRunInAction(() {
       super.filter = value;
       _$filterAtom.reportChanged();
-    }, name: '${_$filterAtom.name}_set');
+    }, _$filterAtom, name: '${_$filterAtom.name}_set');
   }
 
   final _$currentDescriptionAtom = Atom(name: '_TodoList.currentDescription');
@@ -110,7 +110,7 @@ mixin _$TodoList on _TodoList, Store {
     _$currentDescriptionAtom.context.conditionallyRunInAction(() {
       super.currentDescription = value;
       _$currentDescriptionAtom.reportChanged();
-    }, name: '${_$currentDescriptionAtom.name}_set');
+    }, _$currentDescriptionAtom, name: '${_$currentDescriptionAtom.name}_set');
   }
 
   final _$_TodoListActionController = ActionController(name: '_TodoList');


### PR DESCRIPTION
Addresses some comments raised in #206 around using the conditional action wrapping even for collection methods. This makes it easier to use collection modifiers safely from the get go