### PR TITLE
Reaction comparator

### DIFF
--- a/mobx/lib/src/api/reaction.dart
+++ b/mobx/lib/src/api/reaction.dart
@@ -41,17 +41,21 @@ ReactionDisposer autorun(Function(Reaction) fn,
 ///
 /// You can also pass in an optional [name], a debouncing [delay] in milliseconds. Use
 /// [fireImmediately] if you want to invoke the effect immediately without waiting for
-/// the [predicate] to change its value.
+/// the [predicate] to change its value. It is possible to define a custom [equals] function
+/// to override the default comparison for the value returned by [predicate], to have fined
+/// grained control over when the reactions should run.
 ReactionDisposer reaction<T>(
         T Function(Reaction) predicate, void Function(T) effect,
         {String name,
         int delay,
         bool fireImmediately,
+        EqualityComparator<T> equals,
         ReactiveContext context,
         void Function(Object, Reaction) onError}) =>
     createReaction(context ?? mainContext, predicate, effect,
         name: name,
         delay: delay,
+        equals: equals,
         fireImmediately: fireImmediately,
         onError: onError);
 

--- a/mobx/lib/src/core.dart
+++ b/mobx/lib/src/core.dart
@@ -39,3 +39,4 @@ class MobXCaughtException implements Exception {
 }
 
 typedef Dispose = void Function();
+typedef EqualityComparator<T> = bool Function(T, T);

--- a/mobx/lib/src/core/observable.dart
+++ b/mobx/lib/src/core/observable.dart
@@ -10,22 +10,29 @@ class Observable<T> extends Atom
   ///
   /// An Observable's value is read with the `value` property.
   ///
+  /// It is possible to override equality comparison of new values with [equals].
+  ///
   /// ```
   /// var x = Observable(10);
   /// var message = Observable('hello');
   ///
   /// print('x = ${x.value}'); // read an Observable's value
   /// ```
-  factory Observable(T initialValue, {String name, ReactiveContext context}) =>
-      Observable._(context ?? mainContext, initialValue, name: name);
+  factory Observable(T initialValue,
+          {String name,
+          ReactiveContext context,
+          EqualityComparator<T> equals}) =>
+      Observable._(context ?? mainContext, initialValue,
+          name: name, equals: equals);
 
-  Observable._(ReactiveContext context, this._value, {String name})
+  Observable._(ReactiveContext context, this._value, {String name, this.equals})
       : _interceptors = Interceptors(context),
         _listeners = Listeners(context),
         super._(context, name: name ?? context.nameFor('Observable'));
 
   final Interceptors<T> _interceptors;
   final Listeners<ChangeNotification<T>> _listeners;
+  final EqualityComparator<T> equals;
 
   T _value;
 
@@ -73,7 +80,10 @@ class Observable<T> extends Atom
       prepared = change.newValue;
     }
 
-    return (prepared != _value) ? prepared : WillChangeNotification.unchanged;
+    final areEqual =
+        equals == null ? prepared == value : equals(prepared, _value);
+
+    return (!areEqual) ? prepared : WillChangeNotification.unchanged;
   }
 
   @override

--- a/mobx/lib/src/core/reaction_helper.dart
+++ b/mobx/lib/src/core/reaction_helper.dart
@@ -68,6 +68,7 @@ ReactionDisposer createReaction<T>(ReactiveContext context,
     {String name,
     int delay,
     bool fireImmediately,
+    EqualityComparator equals,
     void Function(Object, Reaction) onError}) {
   ReactionImpl rxn;
 
@@ -91,12 +92,17 @@ ReactionDisposer createReaction<T>(ReactiveContext context,
 
     rxn.track(() {
       final nextValue = predicate(rxn);
-      changed = firstTime || (nextValue != value);
+      if (equals != null) {
+        changed = firstTime || !equals(nextValue, value);
+      } else {
+        changed = firstTime || nextValue != value;
+      }
       value = nextValue;
     });
 
     final canInvokeEffect =
         (firstTime && fireImmediately == true) || (!firstTime && changed);
+
     if (canInvokeEffect) {
       effectAction([value]);
     }

--- a/mobx/test/observe_test.dart
+++ b/mobx/test/observe_test.dart
@@ -36,6 +36,60 @@ void main() {
       dispose();
     });
 
+    group('equality override', () {
+      test('yields a new value', () {
+        final x = Observable(
+          10,
+          equals: (_, __) => false,
+        );
+
+        var executed = false;
+
+        final dispose = x.observe((change) {
+          expect(change.newValue, equals(10));
+          executed = true;
+        }, fireImmediately: true);
+
+        expect(executed, isTrue);
+        executed = false;
+
+        x.value = 10;
+        expect(executed, isTrue);
+        executed = false;
+
+        x.value = 10;
+        expect(executed, isTrue);
+        executed = false;
+
+        dispose();
+      });
+
+      test('does not yield a new value', () {
+        final x = Observable(
+          10,
+          equals: (_, __) => true,
+        );
+
+        var executed = false;
+
+        final dispose = x.observe((change) {
+          expect(change.newValue, equals(10));
+          executed = true;
+        }, fireImmediately: true);
+
+        expect(executed, isTrue);
+        executed = false;
+
+        x.value = 10;
+        expect(executed, isFalse);
+
+        x.value = 11;
+        expect(executed, isFalse);
+
+        dispose();
+      });
+    });
+
     test('can be disposed', () {
       final x = Observable(10);
       var executed = false;

--- a/mobx/test/reaction_test.dart
+++ b/mobx/test/reaction_test.dart
@@ -35,6 +35,40 @@ void main() {
           executed, isFalse); // reaction has been disposed, so no more effects
     });
 
+    group('equals override', () {
+      test('basics work', () {
+        var executed = false;
+
+        bool equals(_, __) => false;
+
+        final x = Observable(10, equals: equals);
+        final d = reaction(
+          (_) => x.value,
+          (_) {
+            executed = true;
+          },
+          name: 'Basic Reaction',
+          equals: equals,
+        );
+
+        expect(executed, isFalse);
+
+        x.value = 11;
+        expect(executed, isTrue);
+        executed = false;
+
+        x.value = 11;
+        expect(executed, isTrue);
+        executed = false;
+
+        d();
+
+        x.value = 11;
+        expect(executed,
+            isFalse); // reaction has been disposed, so no more effects
+      });
+    });
+
     test('crashes if asserts are ommited', () {
       expect(() => ReactionImpl(null, () {}),
           throwsA(const TypeMatcher<AssertionError>()));


### PR DESCRIPTION
I'm already using this feature in my project but I'd like to get some feedback on this, if I'm doing it right I'd also like to contribute more with docs & tests. 😄

Add the possibility to override equality comparator function in reactions. This feature is already present in the JavaScript version, detailed here: https://mobx.js.org/refguide/reaction.html

The problem originally was that I have 2 types which I don't have control of, to override the `compareTo` or `==` operator, but they are constantly changing in my app and I need to react on changes of them even if they are just reassigned with the same value.

What do you think, is this feature a step towards the right direction or should mobx encourage people defining their own wrappers and equality?

EDIT: Update after some investigation I realized that this cannot be added for `autorun` THAT easily 😄  and does not really make sense for `when` nor `asyncWhen`.