### PR TITLE
Add settings example with ProxyProvider

### DIFF
--- a/docs/src/guides/organizing-stores.mdx
+++ b/docs/src/guides/organizing-stores.mdx
@@ -214,7 +214,7 @@ class MyApp extends StatelessWidget {
 }
 ```
 
-Here, the `ProxyProvider` API allows us to declare that `SettingsStore` depends on an instance of the `PreferencesService` class. When the `SettingsStore` instance is retrieved, it will ensure that its dependencies have been constructed.
+Here, the `ProxyProvider` API allows us to declare that `SettingsStore` depends on an instance of the `PreferencesService` class and will ensure the objects are constructed in the appropriate order based on the chain of dependencies.
 Note that in this particular example, we have used the `Consumer` widget that is an alternative to using `Provider.of<T>` for retrieving a value. Whilst this adds an additional level of indentation, some may prefer this approach as it's
 declarative and assists in building a mental model where a value provided so that can be consumed further down in the widget tree. Furthermore, it facilitates in writing code where dependencies can be more explicit. The following is a widget
 that depends on the `SettingsStore`

--- a/docs/src/guides/organizing-stores.mdx
+++ b/docs/src/guides/organizing-stores.mdx
@@ -177,6 +177,8 @@ class CounterListPage extends StatelessWidget {
 }
 ```
 
+## Using ProxyProvider with a service
+
 For handling when a store depends on a service, the `ProxyProvider` API can be used
 
 ```dart

--- a/docs/src/guides/organizing-stores.mdx
+++ b/docs/src/guides/organizing-stores.mdx
@@ -129,7 +129,7 @@ In short, we have taken cues from the [SOLID](https://en.wikipedia.org/wiki/SOLI
 
 The provider-pattern has become a standard way of making the top level stores available across the entire app. It avoids creating a singleton-`Store`, making it easier to use the `Store` as a plain class instance.
 
-Using the [provider][1] package on pub, you can setup a repository of stores at the App level. Then using the `Provider.of<T>()` api, you can read this value inside your `Widget.build()` methods.
+Using the [provider][1] package on pub, you can setup a repository of stores at the App level. Then using the `Provider.of<T>()` API, you can read this value inside your `Widget.build()` methods.
 
 In the example below, we are setting up a store at the app-level:
 
@@ -156,7 +156,7 @@ class MyApp extends StatelessWidget {
 }
 ```
 
-Then inside a nested widget, deep inside, you can retrieve the store with the `Provider.of<T>(BuildContext context)` api. You will do this in the `build` method of the `Widget`, where the `context` is available.
+Then inside a nested widget, deep inside, you can retrieve the store with the `Provider.of<T>(BuildContext context)` API. You will do this in the `build` method of the `Widget`, where the `context` is available.
 
 ```dart
 class CounterListPage extends StatelessWidget {
@@ -177,13 +177,98 @@ class CounterListPage extends StatelessWidget {
 }
 ```
 
+For handling when a store depends on a service, the `ProxyProvider` API can be used
+
+```dart
+class MyApp extends StatelessWidget {
+  const MyApp(this._sharedPreferences);
+
+  final SharedPreferences _sharedPreferences;
+
+  @override
+  Widget build(BuildContext context) => MultiProvider(
+          providers: [
+            Provider<PreferencesService>(
+              builder: (_) => PreferencesService(_sharedPreferences),
+            ),
+            ProxyProvider<PreferencesService, SettingsStore>(
+                builder: (_, preferencesService, __) =>
+                    SettingsStore(preferencesService)),
+          ],
+          child: Consumer<SettingsStore>(
+            builder: (_, store, __) => Observer(
+              builder: (_) => MaterialApp(
+                initialRoute: '/',
+                theme: ThemeData(
+                  primarySwatch: Colors.blue,
+                  brightness:
+                      store.useDarkMode ? Brightness.dark : Brightness.light,
+                ),
+                routes: {
+                  '/': (_) => ExampleList(),
+                }..addEntries(
+                    examples.map((ex) => MapEntry(ex.path, ex.widgetBuilder))),
+              ),
+            ),
+          ));
+}
+```
+
+Here, the `ProxyProvider` API allows us to declare that `SettingsStore` depends on an instance of the `PreferencesService` class. When the `SettingsStore` instance is retrieved, it will ensure that its dependencies have been constructed.
+Note that in this particular example, we have used the `Consumer` widget that is an alternative to using `Provider.of<T>` for retrieving a value. Whilst this adds an additional level of indentation, some may prefer this approach as it's
+declarative and assists in building a mental model where a value provided so that can be consumed further down in the widget tree. Furthermore, it facilitates in writing code where dependencies can be more explicit. The following is a widget
+that depends on the `SettingsStore`
+
+```dart
+class SettingsExample extends StatelessWidget {
+  const SettingsExample(this.store);
+
+  final SettingsStore store;
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+      appBar: AppBar(
+        title: const Text('Settings'),
+      ),
+      body: Observer(
+        builder: (context) => SwitchListTile(
+          value: store.useDarkMode,
+          title: const Text('Use dark mode'),
+          onChanged: (value) {
+            store.setDarkMode(value: value);
+          },
+        ),
+      ));
+}
+```
+
+Using a non-default constructor here allows us to explicit declare that the `SettingsExample` class depends on the `SettingsStore` for it to function. Some developers may already be familiar with structuring code this way
+when working with applications/frameworks that support constructor injection. An instance of the `SettingsStore` is passed through the `Consumer` widget as per the example code below
+
+```dart
+...
+Example(
+    title: 'Settings',
+    description: 'Settings for toggling dark mode',
+    path: '/settings',
+    widgetBuilder: (_) => Consumer<SettingsStore>(
+      builder: (_, store, __) => SettingsExample(store),
+    ),
+  )
+...
+```
+
+A side effect of this is that writing widget tests become easier as well as we'd know what dependencies a widget has. We could then pass, say, mocks (e.g. using the [mockito][2] package] of said dependencies can be passed if required.
+
 ### A variety of providers
 
 There are multiple types of `Providers` available in the [![pub package](https://img.shields.io/pub/v/provider.svg?label=provider&color=blue)](https://pub.dartlang.org/packages/mobx)
 package. The ones most relevant and useful to MobX are:
 
-- `Provider` for constructing and disposing values on the fly. This is good when the value has a fixed lifetime.
+- `Provider` for constructing and disposing objects on the fly. This is good when the object has a fixed lifetime.
 - `Provider.value`, a `Provider` constructor for single values, known before hand
+- `ProxyProvider` for constructing objects that depend on other objects e.g. a store depending on a service
 - `MultiProvider` for passing multiple values
 
 [1]: https://pub.dartlang.org/packages/provider
+[2]: https://pub.dev/packages/mockito

--- a/mobx_examples/lib/examples.dart
+++ b/mobx_examples/lib/examples.dart
@@ -1,12 +1,16 @@
 import 'package:flutter/material.dart';
-import 'package:mobx_examples/clock/clock_widgets.dart';
-import 'package:mobx_examples/counter/counter_widgets.dart';
-import 'package:mobx_examples/form/form_widgets.dart';
-import 'package:mobx_examples/github/github_widgets.dart';
-import 'package:mobx_examples/hackernews/news_widgets.dart';
-import 'package:mobx_examples/multi_counter/multi_counter_widgets.dart';
-import 'package:mobx_examples/random_stream/random_widgets.dart';
-import 'package:mobx_examples/todos/todo_widgets.dart';
+import 'package:provider/provider.dart';
+
+import 'clock/clock_widgets.dart';
+import 'counter/counter_widgets.dart';
+import 'form/form_widgets.dart';
+import 'github/github_widgets.dart';
+import 'hackernews/news_widgets.dart';
+import 'multi_counter/multi_counter_widgets.dart';
+import 'random_stream/random_widgets.dart';
+import 'settings/settings_store.dart';
+import 'settings/settings_widgets.dart';
+import 'todos/todo_widgets.dart';
 
 class Example {
   Example(
@@ -71,4 +75,12 @@ final List<Example> examples = [
     path: '/hn',
     widgetBuilder: (_) => const HackerNewsExample(),
   ),
+  Example(
+    title: 'Settings',
+    description: 'Settings for toggling dark mode',
+    path: '/settings',
+    widgetBuilder: (_) => Consumer<SettingsStore>(
+      builder: (_, store, __) => SettingsExample(store),
+    ),
+  )
 ];

--- a/mobx_examples/lib/examples.dart
+++ b/mobx_examples/lib/examples.dart
@@ -1,16 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import 'clock/clock_widgets.dart';
-import 'counter/counter_widgets.dart';
-import 'form/form_widgets.dart';
-import 'github/github_widgets.dart';
-import 'hackernews/news_widgets.dart';
-import 'multi_counter/multi_counter_widgets.dart';
-import 'random_stream/random_widgets.dart';
-import 'settings/settings_store.dart';
-import 'settings/settings_widgets.dart';
-import 'todos/todo_widgets.dart';
+import 'package:mobx_examples/clock/clock_widgets.dart';
+import 'package:mobx_examples/counter/counter_widgets.dart';
+import 'package:mobx_examples/form/form_widgets.dart';
+import 'package:mobx_examples/github/github_widgets.dart';
+import 'package:mobx_examples/hackernews/news_widgets.dart';
+import 'package:mobx_examples/multi_counter/multi_counter_widgets.dart';
+import 'package:mobx_examples/random_stream/random_widgets.dart';
+import 'package:mobx_examples/settings/settings_store.dart';
+import 'package:mobx_examples/settings/settings_widgets.dart';
+import 'package:mobx_examples/todos/todo_widgets.dart';
 
 class Example {
   Example(

--- a/mobx_examples/lib/form/form_widgets.dart
+++ b/mobx_examples/lib/form/form_widgets.dart
@@ -36,12 +36,12 @@ class _FormExampleState extends State<FormExample> {
             children: <Widget>[
               Observer(
                 builder: (_) => TextField(
-                      onChanged: (value) => store.name = value,
-                      decoration: InputDecoration(
-                          labelText: 'Username',
-                          hintText: 'Pick a username',
-                          errorText: store.error.username),
-                    ),
+                  onChanged: (value) => store.name = value,
+                  decoration: InputDecoration(
+                      labelText: 'Username',
+                      hintText: 'Pick a username',
+                      errorText: store.error.username),
+                ),
               ),
               Observer(
                   builder: (_) => AnimatedOpacity(
@@ -50,21 +50,21 @@ class _FormExampleState extends State<FormExample> {
                       opacity: store.isUserCheckPending ? 1 : 0)),
               Observer(
                 builder: (_) => TextField(
-                      onChanged: (value) => store.email = value,
-                      decoration: InputDecoration(
-                          labelText: 'Email',
-                          hintText: 'Enter your email address',
-                          errorText: store.error.email),
-                    ),
+                  onChanged: (value) => store.email = value,
+                  decoration: InputDecoration(
+                      labelText: 'Email',
+                      hintText: 'Enter your email address',
+                      errorText: store.error.email),
+                ),
               ),
               Observer(
                 builder: (_) => TextField(
-                      onChanged: (value) => store.password = value,
-                      decoration: InputDecoration(
-                          labelText: 'Password',
-                          hintText: 'Set a password',
-                          errorText: store.error.password),
-                    ),
+                  onChanged: (value) => store.password = value,
+                  decoration: InputDecoration(
+                      labelText: 'Password',
+                      hintText: 'Set a password',
+                      errorText: store.error.password),
+                ),
               ),
               RaisedButton(
                 child: const Text('Sign up'),

--- a/mobx_examples/lib/github/github_widgets.dart
+++ b/mobx_examples/lib/github/github_widgets.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:mobx/mobx.dart';
-import 'package:mobx_examples/github/github_store.dart';
+
+import 'github_store.dart';
 
 class GithubExample extends StatefulWidget {
   const GithubExample();

--- a/mobx_examples/lib/github/github_widgets.dart
+++ b/mobx_examples/lib/github/github_widgets.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:mobx/mobx.dart';
 
-import 'github_store.dart';
+import 'package:mobx_examples/github/github_store.dart';
 
 class GithubExample extends StatefulWidget {
   const GithubExample();

--- a/mobx_examples/lib/hackernews/news_widgets.dart
+++ b/mobx_examples/lib/hackernews/news_widgets.dart
@@ -3,7 +3,7 @@ import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:hnpwa_client/hnpwa_client.dart';
 import 'package:mobx/mobx.dart';
 
-import 'news_store.dart';
+import 'package:mobx_examples/hackernews/news_store.dart';
 
 class HackerNewsExample extends StatefulWidget {
   const HackerNewsExample();

--- a/mobx_examples/lib/hackernews/news_widgets.dart
+++ b/mobx_examples/lib/hackernews/news_widgets.dart
@@ -2,7 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:hnpwa_client/hnpwa_client.dart';
 import 'package:mobx/mobx.dart';
-import 'package:mobx_examples/hackernews/news_store.dart';
+
+import 'news_store.dart';
 
 class HackerNewsExample extends StatefulWidget {
   const HackerNewsExample();

--- a/mobx_examples/lib/main.dart
+++ b/mobx_examples/lib/main.dart
@@ -1,28 +1,51 @@
 import 'package:flutter/material.dart';
-import 'package:mobx_examples/examples.dart';
-import 'package:mobx_examples/multi_counter/multi_counter_store.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'counter/counter.dart';
+import 'examples.dart';
+import 'multi_counter/multi_counter_store.dart';
+import 'settings/preferences_service.dart';
+import 'settings/settings_store.dart';
 
-void main() => runApp(MyApp());
+void main() async {
+  final sharedPreferences = await SharedPreferences.getInstance();
+  runApp(MyApp(sharedPreferences));
+}
 
 class MyApp extends StatelessWidget {
+  const MyApp(this._sharedPreferences);
+
+  final SharedPreferences _sharedPreferences;
+
   @override
   Widget build(BuildContext context) => MultiProvider(
           providers: [
-            Provider<MultiCounterStore>.value(value: MultiCounterStore()),
-            Provider<Counter>.value(value: Counter()),
-          ],
-          child: MaterialApp(
-            initialRoute: '/',
-            theme: ThemeData(
-              primarySwatch: Colors.blue,
+            Provider<MultiCounterStore>(builder: (_) => MultiCounterStore()),
+            Provider<Counter>(builder: (_) => Counter()),
+            Provider<PreferencesService>(
+              builder: (_) => PreferencesService(_sharedPreferences),
             ),
-            routes: {
-              '/': (_) => ExampleList(),
-            }..addEntries(
-                examples.map((ex) => MapEntry(ex.path, ex.widgetBuilder))),
+            ProxyProvider<PreferencesService, SettingsStore>(
+                builder: (_, preferencesService, __) =>
+                    SettingsStore(preferencesService)),
+          ],
+          child: Consumer<SettingsStore>(
+            builder: (_, store, __) => Observer(
+              builder: (_) => MaterialApp(
+                initialRoute: '/',
+                theme: ThemeData(
+                  primarySwatch: Colors.blue,
+                  brightness:
+                      store.useDarkMode ? Brightness.dark : Brightness.light,
+                ),
+                routes: {
+                  '/': (_) => ExampleList(),
+                }..addEntries(
+                    examples.map((ex) => MapEntry(ex.path, ex.widgetBuilder))),
+              ),
+            ),
           ));
 }
 

--- a/mobx_examples/lib/main.dart
+++ b/mobx_examples/lib/main.dart
@@ -3,11 +3,11 @@ import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-import 'counter/counter.dart';
-import 'examples.dart';
-import 'multi_counter/multi_counter_store.dart';
-import 'settings/preferences_service.dart';
-import 'settings/settings_store.dart';
+import 'package:mobx_examples/counter/counter.dart';
+import 'package:mobx_examples/examples.dart';
+import 'package:mobx_examples/multi_counter/multi_counter_store.dart';
+import 'package:mobx_examples/settings/preferences_service.dart';
+import 'package:mobx_examples/settings/settings_store.dart';
 
 void main() async {
   final sharedPreferences = await SharedPreferences.getInstance();

--- a/mobx_examples/lib/multi_counter/multi_counter_widgets.dart
+++ b/mobx_examples/lib/multi_counter/multi_counter_widgets.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
-import 'package:mobx_examples/multi_counter/multi_counter_store.dart';
 import 'package:provider/provider.dart';
+
+import 'multi_counter_store.dart';
 
 class MultiCounterExample extends StatefulWidget {
   const MultiCounterExample();

--- a/mobx_examples/lib/multi_counter/multi_counter_widgets.dart
+++ b/mobx_examples/lib/multi_counter/multi_counter_widgets.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:provider/provider.dart';
 
-import 'multi_counter_store.dart';
+import 'package:mobx_examples/multi_counter/multi_counter_store.dart';
 
 class MultiCounterExample extends StatefulWidget {
   const MultiCounterExample();

--- a/mobx_examples/lib/random_stream/random_widgets.dart
+++ b/mobx_examples/lib/random_stream/random_widgets.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 
-import 'random_store.dart';
+import 'package:mobx_examples/random_stream/random_store.dart';
 
 class RandomNumberExample extends StatefulWidget {
   const RandomNumberExample();

--- a/mobx_examples/lib/random_stream/random_widgets.dart
+++ b/mobx_examples/lib/random_stream/random_widgets.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
-import 'package:mobx_examples/random_stream/random_store.dart';
+
+import 'random_store.dart';
 
 class RandomNumberExample extends StatefulWidget {
   const RandomNumberExample();

--- a/mobx_examples/lib/settings/preferences_service.dart
+++ b/mobx_examples/lib/settings/preferences_service.dart
@@ -1,0 +1,14 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class PreferencesService {
+  const PreferencesService(this._sharedPreferences);
+
+  static const String _useDarkModeKey = 'useDarkMode';
+  final SharedPreferences _sharedPreferences;
+
+  set useDarkMode(bool useDarkMode) {
+    _sharedPreferences.setBool(_useDarkModeKey, useDarkMode);
+  }
+
+  bool get useDarkMode => _sharedPreferences.getBool(_useDarkModeKey) ?? false;
+}

--- a/mobx_examples/lib/settings/settings_store.dart
+++ b/mobx_examples/lib/settings/settings_store.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/foundation.dart';
+import 'package:mobx/mobx.dart';
+import 'preferences_service.dart';
+
+part 'settings_store.g.dart';
+
+class SettingsStore = _SettingsStore with _$SettingsStore;
+
+abstract class _SettingsStore with Store {
+  _SettingsStore(this._preferencesService);
+
+  PreferencesService _preferencesService;
+
+  @observable
+  bool useDarkMode = false;
+
+  @action
+  void setDarkMode({@required bool value}) {
+    _preferencesService.useDarkMode = value;
+    useDarkMode = value;
+  }
+}

--- a/mobx_examples/lib/settings/settings_store.dart
+++ b/mobx_examples/lib/settings/settings_store.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:mobx/mobx.dart';
-import 'preferences_service.dart';
+import 'package:mobx_examples/settings/preferences_service.dart';
 
 part 'settings_store.g.dart';
 

--- a/mobx_examples/lib/settings/settings_store.dart
+++ b/mobx_examples/lib/settings/settings_store.dart
@@ -7,12 +7,14 @@ part 'settings_store.g.dart';
 class SettingsStore = _SettingsStore with _$SettingsStore;
 
 abstract class _SettingsStore with Store {
-  _SettingsStore(this._preferencesService);
+  _SettingsStore(this._preferencesService) {
+    useDarkMode = _preferencesService.useDarkMode;
+  }
 
   PreferencesService _preferencesService;
 
   @observable
-  bool useDarkMode = false;
+  bool useDarkMode;
 
   @action
   void setDarkMode({@required bool value}) {

--- a/mobx_examples/lib/settings/settings_store.g.dart
+++ b/mobx_examples/lib/settings/settings_store.g.dart
@@ -1,0 +1,41 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'settings_store.dart';
+
+// **************************************************************************
+// StoreGenerator
+// **************************************************************************
+
+// ignore_for_file: non_constant_identifier_names, unnecessary_lambdas, prefer_expression_function_bodies, lines_longer_than_80_chars, avoid_as, avoid_annotating_with_dynamic
+
+mixin _$SettingsStore on _SettingsStore, Store {
+  final _$useDarkModeAtom = Atom(name: '_SettingsStore.useDarkMode');
+
+  @override
+  bool get useDarkMode {
+    _$useDarkModeAtom.context.enforceReadPolicy(_$useDarkModeAtom);
+    _$useDarkModeAtom.reportObserved();
+    return super.useDarkMode;
+  }
+
+  @override
+  set useDarkMode(bool value) {
+    _$useDarkModeAtom.context.conditionallyRunInAction(() {
+      super.useDarkMode = value;
+      _$useDarkModeAtom.reportChanged();
+    }, _$useDarkModeAtom, name: '${_$useDarkModeAtom.name}_set');
+  }
+
+  final _$_SettingsStoreActionController =
+      ActionController(name: '_SettingsStore');
+
+  @override
+  void setDarkMode({bool value}) {
+    final _$actionInfo = _$_SettingsStoreActionController.startAction();
+    try {
+      return super.setDarkMode(value: value);
+    } finally {
+      _$_SettingsStoreActionController.endAction(_$actionInfo);
+    }
+  }
+}

--- a/mobx_examples/lib/settings/settings_widgets.dart
+++ b/mobx_examples/lib/settings/settings_widgets.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
+import 'package:mobx_examples/settings/settings_store.dart';
+
+class SettingsExample extends StatelessWidget {
+  const SettingsExample(this.store);
+
+  final SettingsStore store;
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+      appBar: AppBar(
+        title: const Text('Settings'),
+      ),
+      body: Observer(
+        builder: (context) => SwitchListTile(
+          value: store.useDarkMode,
+          title: const Text('Use dark mode'),
+          onChanged: (value) {
+            store.setDarkMode(value: value);
+          },
+        ),
+      ));
+}

--- a/mobx_examples/lib/todos/todo_list.dart
+++ b/mobx_examples/lib/todos/todo_list.dart
@@ -1,6 +1,7 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'package:mobx/mobx.dart';
-import 'package:mobx_examples/todos/todo.dart';
+
+import 'todo.dart';
 
 part 'todo_list.g.dart';
 

--- a/mobx_examples/lib/todos/todo_widgets.dart
+++ b/mobx_examples/lib/todos/todo_widgets.dart
@@ -80,27 +80,27 @@ class ActionBar extends StatelessWidget {
     return Column(children: <Widget>[
       Observer(
         builder: (_) => Column(
-              children: <Widget>[
-                RadioListTile(
-                    dense: true,
-                    title: const Text('All'),
-                    value: VisibilityFilter.all,
-                    groupValue: list.filter,
-                    onChanged: (filter) => list.filter = filter),
-                RadioListTile(
-                    dense: true,
-                    title: const Text('Pending'),
-                    value: VisibilityFilter.pending,
-                    groupValue: list.filter,
-                    onChanged: (filter) => list.filter = filter),
-                RadioListTile(
-                    dense: true,
-                    title: const Text('Completed'),
-                    value: VisibilityFilter.completed,
-                    groupValue: list.filter,
-                    onChanged: (filter) => list.filter = filter),
-              ],
-            ),
+          children: <Widget>[
+            RadioListTile(
+                dense: true,
+                title: const Text('All'),
+                value: VisibilityFilter.all,
+                groupValue: list.filter,
+                onChanged: (filter) => list.filter = filter),
+            RadioListTile(
+                dense: true,
+                title: const Text('Pending'),
+                value: VisibilityFilter.pending,
+                groupValue: list.filter,
+                onChanged: (filter) => list.filter = filter),
+            RadioListTile(
+                dense: true,
+                title: const Text('Completed'),
+                value: VisibilityFilter.completed,
+                groupValue: list.filter,
+                onChanged: (filter) => list.filter = filter),
+          ],
+        ),
       ),
       Observer(
           builder: (_) => ButtonBar(

--- a/mobx_examples/lib/todos/todo_widgets.dart
+++ b/mobx_examples/lib/todos/todo_widgets.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:provider/provider.dart';
 
-import 'todo_list.dart';
+import 'package:mobx_examples/todos/todo_list.dart';
 
 class TodoExample extends StatelessWidget {
   @override

--- a/mobx_examples/pubspec.yaml
+++ b/mobx_examples/pubspec.yaml
@@ -20,12 +20,14 @@ dependencies:
   validators:
   hnpwa_client:
   url_launcher:
+  shared_preferences:
   provider: ^3.0.0
   json_serializable: ^3.0.0
   flutter:
     sdk: flutter
 
   cupertino_icons: ^0.1.2
+  mockito:
 
 dev_dependencies:
   build_runner:

--- a/mobx_examples/test/widget_test.dart
+++ b/mobx_examples/test/widget_test.dart
@@ -9,11 +9,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:mobx_examples/main.dart';
+import 'package:mockito/mockito.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class MockSharedPreferences extends Mock implements SharedPreferences {}
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(MyApp());
+    await tester.pumpWidget(MyApp(MockSharedPreferences()));
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
- Added an example that for demonstrating using the ProxyProvider and Consumer widgets. Updated relevant docs as well
- Updated code in example to use relative imports (as per https://dart.dev/guides/language/effective-dart/usage#prefer-relative-paths-when-importing-libraries-within-your-own-packages-lib-directory). Can revert if there's a reason I may have missed on why package imports had been used
- Note that I updated the wording in the organizing stores page around the Provider API, as I believe it's more correct to say that it deals with constructing and disposing objects 