### PR TITLE
Fix change reporting in ObservableMap.[]=

### DIFF
--- a/mobx/lib/src/api/observable_collections/observable_map.dart
+++ b/mobx/lib/src/api/observable_collections/observable_map.dart
@@ -60,12 +60,11 @@ class ObservableMap<K, V>
   @override
   void operator []=(K key, V value) {
     _context.conditionallyRunInAction(() {
-      V oldValue;
+      final oldValue = _map[key];
       var type = 'set';
 
       if (_hasListeners) {
         if (_map.containsKey(key)) {
-          oldValue = _map[key];
           type = 'update';
         } else {
           type = 'add';


### PR DESCRIPTION
`oldValue` was only being set in certain conditions, which prevented the equality check from having the desired effect.