### PR TITLE
Add code generation support for the @store annotation

### DIFF
--- a/mobx_codegen/lib/src/errors.dart
+++ b/mobx_codegen/lib/src/errors.dart
@@ -6,6 +6,7 @@ abstract class CodegenError {
 class StoreClassCodegenErrors implements CodegenError {
   StoreClassCodegenErrors(this.name) {
     _errorCategories = [
+      invalidStoreDeclaration,
       invalidComputedAnnotations,
       invalidObservableAnnotations,
       invalidActionAnnotations,
@@ -19,6 +20,8 @@ class StoreClassCodegenErrors implements CodegenError {
 
   final String name;
 
+  final InvalidStoreDeclarations invalidStoreDeclaration =
+      InvalidStoreDeclarations();
   final PropertyErrors finalObservables = FinalObservableFields();
   final PropertyErrors staticObservables = StaticObservableFields();
   final PropertyErrors staticMethods = InvalidStaticMethods();
@@ -52,6 +55,26 @@ class StoreClassCodegenErrors implements CodegenError {
 const fieldPluralizer = Pluralize('the field', 'fields');
 const methodPluralizer = Pluralize('the method', 'methods');
 const memberPluralizer = Pluralize('the member', 'members');
+
+class InvalidStoreDeclarations implements CodegenError {
+  final NameList _classNames = NameList();
+
+  // ignore: avoid_positional_boolean_parameters
+  bool addIf(bool condition, String className) {
+    if (condition) {
+      _classNames.add(className);
+    }
+    return condition;
+  }
+
+  @override
+  bool get hasErrors => _classNames.isNotEmpty;
+
+  @override
+  String get message => 'Store classes cannot be defined with both the @store '
+      'annotation and Store mixin. Please choose one method or another. '
+      '$_classNames';
+}
 
 abstract class PropertyErrors implements CodegenError {
   final NameList _properties = NameList();

--- a/mobx_codegen/lib/src/mobx_codegen_base.dart
+++ b/mobx_codegen/lib/src/mobx_codegen_base.dart
@@ -6,7 +6,7 @@ import 'package:build/build.dart';
 import 'package:mobx/mobx.dart' show Store;
 // ignore: implementation_imports
 import 'package:mobx/src/api/annotations.dart'
-    show ComputedMethod, MakeAction, MakeObservable;
+    show ComputedMethod, MakeAction, MakeObservable, MakeStore;
 import 'package:mobx_codegen/src/errors.dart';
 import 'package:mobx_codegen/src/template/action.dart';
 import 'package:mobx_codegen/src/template/async_action.dart';
@@ -20,17 +20,21 @@ import 'package:mobx_codegen/src/template/util.dart';
 import 'package:source_gen/source_gen.dart';
 
 class StoreGenerator extends Generator {
-  final _storeChecker = const TypeChecker.fromRuntime(Store);
-
   @override
   FutureOr<String> generate(LibraryReader library, BuildStep buildStep) =>
-      library.classes
-          .where(isValidStoreClass)
-          .expand((c) => expandToMixinCode(library, c))
-          .toSet()
-          .join('\n\n');
+      _generateCodeForLibrary(library).toSet().join('\n\n');
 
-  Iterable<String> expandToMixinCode(
+  Iterable<String> _generateCodeForLibrary(LibraryReader library) sync* {
+    for (final classElement in library.classes) {
+      if (isValidMixinStoreClass(classElement)) {
+        yield* _generateCodeForMixinStore(library, classElement);
+      } else if (isValidAnnotatedStoreClass(classElement)) {
+        yield* _generateCodeForAnnotatedStore(library, classElement);
+      }
+    }
+  }
+
+  Iterable<String> _generateCodeForMixinStore(
     LibraryReader library,
     ClassElement baseClass,
   ) sync* {
@@ -50,31 +54,59 @@ class StoreGenerator extends Generator {
     }, orElse: () => null);
 
     if (mixedClass != null) {
-      yield generateStoreMixinCode(library, baseClass, mixedClass);
+      yield _generateCodeFromTemplate(
+          mixedClass.name, baseClass, MixinStoreTemplate());
     }
   }
 
-  bool isValidStoreClass(ClassElement c) =>
-      c.isAbstract && c.mixins.any(_storeChecker.isExactlyType);
+  Iterable<String> _generateCodeForAnnotatedStore(
+    LibraryReader reader,
+    ClassElement baseClass,
+  ) sync* {
+    assert(baseClass.isPrivate);
+    // Strip off leading underscore
+    final publicTypeName = baseClass.name.substring(1);
+    yield _generateCodeFromTemplate(
+        publicTypeName, baseClass, SubclassStoreTemplate());
+  }
 
-  String generateStoreMixinCode(
-      LibraryReader library, ClassElement baseClass, ClassElement mixedClass) {
-    final visitor = StoreMixinVisitor(baseClass, mixedClass.name);
-    baseClass.visitChildren(visitor);
+  String _generateCodeFromTemplate(
+    String publicTypeName,
+    ClassElement userStoreClass,
+    StoreTemplate template,
+  ) {
+    final visitor = StoreMixinVisitor(publicTypeName, userStoreClass, template);
+    userStoreClass
+      ..accept(visitor)
+      ..visitChildren(visitor);
     return visitor.source;
   }
 }
 
+const _storeMixinChecker = TypeChecker.fromRuntime(Store);
+const _storeAnnotationChecker = TypeChecker.fromRuntime(MakeStore);
+
+bool isValidMixinStoreClass(ClassElement classElement) =>
+    classElement.isAbstract &&
+    classElement.mixins.any(_storeMixinChecker.isExactlyType);
+
+bool isValidAnnotatedStoreClass(ClassElement classElement) =>
+    classElement.isPrivate &&
+    _storeAnnotationChecker.hasAnnotationOfExact(classElement);
+
 class StoreMixinVisitor extends SimpleElementVisitor {
-  StoreMixinVisitor(ClassElement parentClass, String name)
-      : _errors = StoreClassCodegenErrors(name) {
-    _storeTemplate = StoreTemplate()
+  StoreMixinVisitor(
+    String publicTypeName,
+    ClassElement userClass,
+    StoreTemplate template,
+  ) : _errors = StoreClassCodegenErrors(publicTypeName) {
+    _storeTemplate = template
       ..typeParams
           .templates
-          .addAll(parentClass.typeParameters.map(typeParamTemplate))
-      ..typeArgs.templates.addAll(parentClass.typeParameters.map((t) => t.name))
-      ..parentName = parentClass.name
-      ..mixinName = '_\$$name';
+          .addAll(userClass.typeParameters.map(typeParamTemplate))
+      ..typeArgs.templates.addAll(userClass.typeParameters.map((t) => t.name))
+      ..parentTypeName = userClass.name
+      ..publicTypeName = publicTypeName;
   }
 
   final _observableChecker = const TypeChecker.fromRuntime(MakeObservable);
@@ -95,6 +127,14 @@ class StoreMixinVisitor extends SimpleElementVisitor {
       return '';
     }
     return _storeTemplate.toString();
+  }
+
+  @override
+  void visitClassElement(ClassElement element) {
+    if (isValidAnnotatedStoreClass(element) &&
+        isValidMixinStoreClass(element)) {
+      _errors.invalidStoreDeclaration.addIf(true, element.name);
+    }
   }
 
   @override

--- a/mobx_codegen/lib/src/mobx_codegen_base.dart
+++ b/mobx_codegen/lib/src/mobx_codegen_base.dart
@@ -11,6 +11,7 @@ import 'package:mobx_codegen/src/errors.dart';
 import 'package:mobx_codegen/src/template/action.dart';
 import 'package:mobx_codegen/src/template/async_action.dart';
 import 'package:mobx_codegen/src/template/computed.dart';
+import 'package:mobx_codegen/src/template/constructor_override.dart';
 import 'package:mobx_codegen/src/template/method_override.dart';
 import 'package:mobx_codegen/src/template/observable.dart';
 import 'package:mobx_codegen/src/template/observable_future.dart';
@@ -21,8 +22,11 @@ import 'package:source_gen/source_gen.dart';
 
 class StoreGenerator extends Generator {
   @override
-  FutureOr<String> generate(LibraryReader library, BuildStep buildStep) =>
-      _generateCodeForLibrary(library).toSet().join('\n\n');
+  FutureOr<String> generate(LibraryReader library, BuildStep buildStep) {
+    final code = _generateCodeForLibrary(library).toSet().join('\n\n');
+    print(code);
+    return code;
+  }
 
   Iterable<String> _generateCodeForLibrary(LibraryReader library) sync* {
     for (final classElement in library.classes) {
@@ -135,6 +139,17 @@ class StoreMixinVisitor extends SimpleElementVisitor {
         isValidMixinStoreClass(element)) {
       _errors.invalidStoreDeclaration.addIf(true, element.name);
     }
+  }
+
+  @override
+  void visitConstructorElement(ConstructorElement element) {
+    // Note that these constructor templates are only used for annotation stye
+    // store definition. They're ignored otherwise.
+    final template = ConstructorOverrideTemplate()
+      ..store = _storeTemplate
+      ..constructor = MethodOverrideTemplate.fromElement(element);
+
+    _storeTemplate.constructors.add(template);
   }
 
   @override

--- a/mobx_codegen/lib/src/mobx_codegen_base.dart
+++ b/mobx_codegen/lib/src/mobx_codegen_base.dart
@@ -22,11 +22,8 @@ import 'package:source_gen/source_gen.dart';
 
 class StoreGenerator extends Generator {
   @override
-  FutureOr<String> generate(LibraryReader library, BuildStep buildStep) {
-    final code = _generateCodeForLibrary(library).toSet().join('\n\n');
-    print(code);
-    return code;
-  }
+  FutureOr<String> generate(LibraryReader library, BuildStep buildStep) =>
+      _generateCodeForLibrary(library).toSet().join('\n\n');
 
   Iterable<String> _generateCodeForLibrary(LibraryReader library) sync* {
     for (final classElement in library.classes) {

--- a/mobx_codegen/lib/src/template/constructor_override.dart
+++ b/mobx_codegen/lib/src/template/constructor_override.dart
@@ -1,0 +1,17 @@
+import 'package:mobx_codegen/src/template/store.dart';
+
+import 'method_override.dart';
+
+class ConstructorOverrideTemplate {
+  StoreTemplate store;
+  MethodOverrideTemplate constructor;
+
+  String get constructorName => constructor.name == ''
+      ? store.publicTypeName
+      : '${store.publicTypeName}.${constructor.name}';
+
+  @override
+  String toString() => '''
+    $constructorName(${constructor.params}) : super(${constructor.args});
+  ''';
+}

--- a/mobx_codegen/lib/src/template/method_override.dart
+++ b/mobx_codegen/lib/src/template/method_override.dart
@@ -4,10 +4,11 @@ import 'package:mobx_codegen/src/template/comma_list.dart';
 import 'package:mobx_codegen/src/template/params.dart';
 import 'package:mobx_codegen/src/template/util.dart';
 
+/// Stores templating information about constructors and methods.
 class MethodOverrideTemplate {
   MethodOverrideTemplate();
 
-  MethodOverrideTemplate.fromElement(MethodElement method) {
+  MethodOverrideTemplate.fromElement(ExecutableElement method) {
     // ignore: prefer_function_declarations_over_variables
     final param = (ParameterElement elem) => ParamTemplate()
       ..name = elem.name

--- a/mobx_codegen/lib/src/template/observable.dart
+++ b/mobx_codegen/lib/src/template/observable.dart
@@ -8,7 +8,7 @@ class ObservableTemplate {
 
   @override
   String toString() => """
-  final $atomName = Atom(name: '${storeTemplate.parentName}.$name');
+  final $atomName = Atom(name: '${storeTemplate.parentTypeName}.$name');
 
   @override
   $type get $name {

--- a/mobx_codegen/lib/src/template/store.dart
+++ b/mobx_codegen/lib/src/template/store.dart
@@ -8,13 +8,39 @@ import 'package:mobx_codegen/src/template/observable_stream.dart';
 import 'package:mobx_codegen/src/template/params.dart';
 import 'package:mobx_codegen/src/template/rows.dart';
 
-class StoreTemplate {
+class SubclassStoreTemplate extends StoreTemplate {
+  String get typeName => publicTypeName;
+
+  @override
+  String toString() => '''
+  ${StoreTemplate.analyzerIgnores}
+
+  class $typeName$typeParams extends $parentTypeName$typeArgs {
+    $storeBody
+  }''';
+}
+
+class MixinStoreTemplate extends StoreTemplate {
+  String get typeName => '_\$$publicTypeName';
+
+  @override
+  String toString() => '''
+  ${StoreTemplate.analyzerIgnores}
+
+  mixin $typeName$typeParams on $parentTypeName$typeArgs, Store {
+    $storeBody
+  }''';
+}
+
+abstract class StoreTemplate {
+  static const analyzerIgnores = '// ignore_for_file: non_constant_identifier_names, unnecessary_lambdas, prefer_expression_function_bodies, lines_longer_than_80_chars, avoid_as, avoid_annotating_with_dynamic';
+
   final SurroundedCommaList<TypeParamTemplate> typeParams =
       SurroundedCommaList('<', '>', []);
   final SurroundedCommaList<String> typeArgs =
       SurroundedCommaList('<', '>', []);
-  String mixinName;
-  String parentName;
+  String publicTypeName;
+  String parentTypeName;
 
   final Rows<ObservableTemplate> observables = Rows();
   final Rows<ComputedTemplate> computeds = Rows();
@@ -25,30 +51,27 @@ class StoreTemplate {
 
   String _actionControllerName;
   String get actionControllerName =>
-      _actionControllerName ??= '_\$${parentName}ActionController';
+      _actionControllerName ??= '_\$${parentTypeName}ActionController';
 
-  String get _actionControllerField => actions.isEmpty
+  String get actionControllerField => actions.isEmpty
       ? ''
-      : "final $actionControllerName = ActionController(name: '$parentName');";
+      : "final $actionControllerName = ActionController(name: '$parentTypeName');";
+
+  String get storeBody => '''
+  $computeds
+
+  $observables
+
+  $observableFutures
+
+  $observableStreams
+
+  $asyncActions
+
+  $actionControllerField
+
+  $actions''';
 
   @override
-  // ignore: prefer_single_quotes
-  String toString() => """
-  // ignore_for_file: non_constant_identifier_names, unnecessary_lambdas, prefer_expression_function_bodies, lines_longer_than_80_chars, avoid_as, avoid_annotating_with_dynamic
-
-  mixin $mixinName$typeParams on $parentName$typeArgs, Store {
-    $computeds
-
-    $observables
-
-    $observableFutures
-
-    $observableStreams
-
-    $asyncActions
-
-    $_actionControllerField
-
-    $actions
-  }""";
+  String toString();
 }

--- a/mobx_codegen/lib/src/template/store.dart
+++ b/mobx_codegen/lib/src/template/store.dart
@@ -2,6 +2,7 @@ import 'package:mobx_codegen/src/template/action.dart';
 import 'package:mobx_codegen/src/template/async_action.dart';
 import 'package:mobx_codegen/src/template/comma_list.dart';
 import 'package:mobx_codegen/src/template/computed.dart';
+import 'package:mobx_codegen/src/template/constructor_override.dart';
 import 'package:mobx_codegen/src/template/observable.dart';
 import 'package:mobx_codegen/src/template/observable_future.dart';
 import 'package:mobx_codegen/src/template/observable_stream.dart';
@@ -10,6 +11,15 @@ import 'package:mobx_codegen/src/template/rows.dart';
 
 class SubclassStoreTemplate extends StoreTemplate {
   String get typeName => publicTypeName;
+
+  @override
+  String get storeBody {
+    return '''
+      $constructors
+
+      ${super.storeBody}
+    ''';
+  }
 
   @override
   String toString() => '''
@@ -42,6 +52,7 @@ abstract class StoreTemplate {
   String publicTypeName;
   String parentTypeName;
 
+  final Rows<ConstructorOverrideTemplate> constructors = Rows();
   final Rows<ObservableTemplate> observables = Rows();
   final Rows<ComputedTemplate> computeds = Rows();
   final Rows<ActionTemplate> actions = Rows();

--- a/mobx_codegen/pubspec.yaml
+++ b/mobx_codegen/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 dependencies:
   path: ^1.6.2
   source_gen: ^0.9.4
-  mobx: ^0.3.3
+  mobx: 0.3.6-alpha
   build: ^1.1.4
   analyzer: ^0.36.3
 
@@ -25,5 +25,3 @@ dev_dependencies:
   test_coverage: ^0.3.0
   test: ^1.6.3
   mockito: ^4.0.0
-
-

--- a/mobx_codegen/test/data/invalid_store_declaration.dart
+++ b/mobx_codegen/test/data/invalid_store_declaration.dart
@@ -1,0 +1,15 @@
+library generator_sample;
+
+import 'package:mobx/mobx.dart';
+
+part 'generator_sample.g.dart';
+
+class User = _User with _$User;
+
+@store
+abstract class _User with Store {
+  _User();
+
+  @observable
+  int value;
+}

--- a/mobx_codegen/test/data/invalid_store_declaration_output.txt
+++ b/mobx_codegen/test/data/invalid_store_declaration_output.txt
@@ -1,0 +1,2 @@
+Could not make class "User" observable. Changes needed:
+  1. Store classes cannot be defined with the @store annotation and a Store mixin. Please choose one method or another. "_User"

--- a/mobx_codegen/test/data/invalid_store_declaration_output.txt
+++ b/mobx_codegen/test/data/invalid_store_declaration_output.txt
@@ -1,2 +1,2 @@
 Could not make class "User" observable. Changes needed:
-  1. Store classes cannot be defined with the @store annotation and a Store mixin. Please choose one method or another. "_User"
+  1. Store classes cannot be defined with both the @store annotation and Store mixin. Please choose one method or another. "_User"

--- a/mobx_codegen/test/data/valid_annotated_store_input.dart
+++ b/mobx_codegen/test/data/valid_annotated_store_input.dart
@@ -1,0 +1,53 @@
+library generator_sample;
+
+import 'package:mobx/mobx.dart';
+
+part 'generator_sample.g.dart';
+
+@store
+class _User {
+  _User(this.id);
+
+  final int id;
+
+  @observable
+  String firstName = 'Jane';
+
+  @observable
+  String lastName = 'Doe';
+
+  @computed
+  String get fullName => '$firstName $lastName';
+
+  @action
+  void updateNames({String firstName, String lastName}) {
+    if (firstName != null) this.firstName = firstName;
+    if (lastName != null) this.lastName = firstName;
+  }
+
+  @observable
+  Future<String> foobar() async {
+    return 'foobar';
+  }
+
+  @observable
+  Stream<T> loadStuff<T>(String arg1, {T value}) async* {
+    yield value;
+  }
+
+  @observable
+  Stream<String> asyncGenerator() async* {
+    yield 'item1';
+  }
+
+  @action
+  Future<void> setAsyncFirstName() async {
+    firstName = 'Async FirstName';
+  }
+
+  @action
+  @observable
+  Future<void> setAsyncFirstName2() async {
+    firstName = 'Async FirstName 2';
+  }
+}

--- a/mobx_codegen/test/data/valid_annotated_store_input.dart
+++ b/mobx_codegen/test/data/valid_annotated_store_input.dart
@@ -7,6 +7,7 @@ part 'generator_sample.g.dart';
 @store
 class _User {
   _User(this.id);
+  _User.withNames({this.firstName = 'Scott', this.lastName}) : id = 0;
 
   final int id;
 

--- a/mobx_codegen/test/data/valid_annotated_store_output.dart
+++ b/mobx_codegen/test/data/valid_annotated_store_output.dart
@@ -1,4 +1,9 @@
 class User extends _User {
+  User(int id) : super(id);
+
+  User.withNames({String firstName = 'Scott', String lastName})
+      : super(firstName: firstName, lastName: lastName);
+
   Computed<String> _$fullNameComputed;
 
   @override

--- a/mobx_codegen/test/data/valid_annotated_store_output.dart
+++ b/mobx_codegen/test/data/valid_annotated_store_output.dart
@@ -1,0 +1,86 @@
+class User extends _User {
+  Computed<String> _$fullNameComputed;
+
+  @override
+  String get fullName =>
+      (_$fullNameComputed ??= Computed<String>(() => super.fullName)).value;
+
+  final _$firstNameAtom = Atom(name: '_User.firstName');
+
+  @override
+  String get firstName {
+    _$firstNameAtom.context.enforceReadPolicy(_$firstNameAtom);
+    _$firstNameAtom.reportObserved();
+    return super.firstName;
+  }
+
+  @override
+  set firstName(String value) {
+    _$firstNameAtom.context.conditionallyRunInAction(() {
+      super.firstName = value;
+      _$firstNameAtom.reportChanged();
+    }, _$firstNameAtom, name: '${_$firstNameAtom.name}_set');
+  }
+
+  final _$lastNameAtom = Atom(name: '_User.lastName');
+
+  @override
+  String get lastName {
+    _$lastNameAtom.context.enforceReadPolicy(_$lastNameAtom);
+    _$lastNameAtom.reportObserved();
+    return super.lastName;
+  }
+
+  @override
+  set lastName(String value) {
+    _$lastNameAtom.context.conditionallyRunInAction(() {
+      super.lastName = value;
+      _$lastNameAtom.reportChanged();
+    }, _$lastNameAtom, name: '${_$lastNameAtom.name}_set');
+  }
+
+  @override
+  ObservableFuture<String> foobar() {
+    final _$future = super.foobar();
+    return ObservableFuture<String>(_$future);
+  }
+
+  @override
+  ObservableStream<T> loadStuff<T>(String arg1, {T value}) {
+    final _$stream = super.loadStuff<T>(arg1, value: value);
+    return ObservableStream<T>(_$stream);
+  }
+
+  @override
+  ObservableStream<String> asyncGenerator() {
+    final _$stream = super.asyncGenerator();
+    return ObservableStream<String>(_$stream);
+  }
+
+  final _$setAsyncFirstNameAsyncAction = AsyncAction('setAsyncFirstName');
+
+  @override
+  Future<void> setAsyncFirstName() {
+    return _$setAsyncFirstNameAsyncAction.run(() => super.setAsyncFirstName());
+  }
+
+  final _$setAsyncFirstName2AsyncAction = AsyncAction('setAsyncFirstName2');
+
+  @override
+  ObservableFuture<void> setAsyncFirstName2() {
+    return ObservableFuture<void>(
+        _$setAsyncFirstName2AsyncAction.run(() => super.setAsyncFirstName2()));
+  }
+
+  final _$_UserActionController = ActionController(name: '_User');
+
+  @override
+  void updateNames({String firstName, String lastName}) {
+    final _$actionInfo = _$_UserActionController.startAction();
+    try {
+      return super.updateNames(firstName: firstName, lastName: lastName);
+    } finally {
+      _$_UserActionController.endAction(_$actionInfo);
+    }
+  }
+}

--- a/mobx_codegen/test/data/valid_generic_annotated_store_input.dart
+++ b/mobx_codegen/test/data/valid_generic_annotated_store_input.dart
@@ -1,0 +1,11 @@
+library generator_sample;
+
+import 'package:mobx/mobx.dart';
+
+part 'generator_sample.g.dart';
+
+@store
+class _Item<T> {
+  @observable
+  T value;
+}

--- a/mobx_codegen/test/data/valid_generic_annotated_store_input.dart
+++ b/mobx_codegen/test/data/valid_generic_annotated_store_input.dart
@@ -6,6 +6,8 @@ part 'generator_sample.g.dart';
 
 @store
 class _Item<T> {
+  _Item(T aThing, [this.value, T anotherThing]);
+
   @observable
   T value;
 }

--- a/mobx_codegen/test/data/valid_generic_annotated_store_output.dart
+++ b/mobx_codegen/test/data/valid_generic_annotated_store_output.dart
@@ -1,4 +1,7 @@
 class Item<T> extends _Item<T> {
+  Item(T aThing, [T value, T anotherThing])
+      : super(aThing, value, anotherThing);
+
   final _$valueAtom = Atom(name: '_Item.value');
 
   @override

--- a/mobx_codegen/test/data/valid_generic_annotated_store_output.dart
+++ b/mobx_codegen/test/data/valid_generic_annotated_store_output.dart
@@ -1,0 +1,18 @@
+class Item<T> extends _Item<T> {
+  final _$valueAtom = Atom(name: '_Item.value');
+
+  @override
+  T get value {
+    _$valueAtom.context.enforceReadPolicy(_$valueAtom);
+    _$valueAtom.reportObserved();
+    return super.value;
+  }
+
+  @override
+  set value(T value) {
+    _$valueAtom.context.conditionallyRunInAction(() {
+      super.value = value;
+      _$valueAtom.reportChanged();
+    }, _$valueAtom, name: '${_$valueAtom.name}_set');
+  }
+}

--- a/mobx_codegen/test/invalid_annotations_test.dart
+++ b/mobx_codegen/test/invalid_annotations_test.dart
@@ -1,31 +1,39 @@
+import 'package:test/test.dart';
+
 import 'test_utils.dart';
 
 void main() {
-  createTests([
-    const TestInfo(
-        description:
-            'Errors when there is a single invalid @computed annotation',
-        source: './data/invalid_computed_single.dart',
-        output: './data/invalid_computed_single_output.txt'),
-    const TestInfo(
-        description:
-            'Errors when there are multiple invalid @computed annotations',
-        source: './data/invalid_computed_multiple.dart',
-        output: './data/invalid_computed_multiple_output.txt'),
-    const TestInfo(
-        description:
-            'Errors when there is a single invalid @observable annotation',
-        source: './data/invalid_observable_single.dart',
-        output: './data/invalid_observable_single_output.txt'),
-    const TestInfo(
-        description:
-            'Errors when there are multiple invalid @observable annotations',
-        source: './data/invalid_observable_multiple.dart',
-        output: './data/invalid_observable_multiple_output.txt'),
-    const TestInfo(
-        description:
-            'Errors when there are multiple invalid @action annotations',
-        source: './data/invalid_action_multiple.dart',
-        output: './data/invalid_action_multiple_output.txt'),
-  ]);
+  group('invalid annotations', () {
+    createTests([
+      const TestInfo(
+          description: 'Errors when there is an invalid store declaration',
+          source: './data/invalid_store_declaration.dart',
+          output: './data/invalid_store_declaration_output.txt'),
+      const TestInfo(
+          description:
+              'Errors when there is a single invalid @computed annotation',
+          source: './data/invalid_computed_single.dart',
+          output: './data/invalid_computed_single_output.txt'),
+      const TestInfo(
+          description:
+              'Errors when there are multiple invalid @computed annotations',
+          source: './data/invalid_computed_multiple.dart',
+          output: './data/invalid_computed_multiple_output.txt'),
+      const TestInfo(
+          description:
+              'Errors when there is a single invalid @observable annotation',
+          source: './data/invalid_observable_single.dart',
+          output: './data/invalid_observable_single_output.txt'),
+      const TestInfo(
+          description:
+              'Errors when there are multiple invalid @observable annotations',
+          source: './data/invalid_observable_multiple.dart',
+          output: './data/invalid_observable_multiple_output.txt'),
+      const TestInfo(
+          description:
+              'Errors when there are multiple invalid @action annotations',
+          source: './data/invalid_action_multiple.dart',
+          output: './data/invalid_action_multiple_output.txt'),
+    ]);
+  });
 }

--- a/mobx_codegen/test/mobx_codegen_test.dart
+++ b/mobx_codegen/test/mobx_codegen_test.dart
@@ -18,6 +18,17 @@ void main() {
       expect(await generate(source), isEmpty);
     });
 
+    test('ignores public classes annotated with @store', () async {
+      const source = """
+        @store
+        class MyClass {
+          void foobar() => 'Hello';
+        }
+      """;
+
+      expect(await generate(source), isEmpty);
+    });
+
     test('ignores when there is no class other than the abstract Store',
         () async {
       final source = await readFile('./data/only_abstract_store.dart');
@@ -37,7 +48,15 @@ void main() {
       const TestInfo(
           description: 'generates for a generic class mixing Store',
           source: './data/valid_generic_store_input.dart',
-          output: './data/valid_generic_store_output.dart')
+          output: './data/valid_generic_store_output.dart'),
+      const TestInfo(
+          description: 'generates for a class annotated with @store',
+          source: './data/valid_annotated_store_input.dart',
+          output: './data/valid_annotated_store_output.dart'),
+      const TestInfo(
+          description: 'generates for a generic class annotated with @store',
+          source: './data/valid_generic_annotated_store_input.dart',
+          output: './data/valid_generic_annotated_store_output.dart'),
     ]);
   });
 }

--- a/mobx_codegen/test/templates_test.dart
+++ b/mobx_codegen/test/templates_test.dart
@@ -100,7 +100,7 @@ void main() {
   group('ObservableTemplate', () {
     test('renders template based on template data', () {
       final template = ObservableTemplate()
-        ..storeTemplate = (StoreTemplate()..parentName = 'ParentName')
+        ..storeTemplate = (MixinStoreTemplate()..parentTypeName = 'ParentName')
         ..atomName = '_atomFieldName'
         ..type = 'FieldType'
         ..name = 'fieldName';
@@ -197,7 +197,7 @@ void main() {
   group('ActionTemplate', () {
     test('renders properly', () {
       final template = ActionTemplate()
-        ..storeTemplate = (StoreTemplate()..parentName = 'ParentClass')
+        ..storeTemplate = (MixinStoreTemplate()..parentTypeName = 'ParentClass')
         ..method = (MethodOverrideTemplate()
           ..name = 'myAction'
           ..returnType = 'ReturnType'


### PR DESCRIPTION
There are still two remaining tasks:
* [ ] JsonSerializable test (might be moved to separate PR)
* [x] Generated subclass should include constructors from user-defined store class