### PR TITLE
make main function in examples return a future

### DIFF
--- a/mobx_examples/lib/main.dart
+++ b/mobx_examples/lib/main.dart
@@ -9,8 +9,7 @@ import 'package:mobx_examples/multi_counter/multi_counter_store.dart';
 import 'package:mobx_examples/settings/preferences_service.dart';
 import 'package:mobx_examples/settings/settings_store.dart';
 
-// ignore: avoid_void_async
-void main() async {
+Future<void> main() async {
   final sharedPreferences = await SharedPreferences.getInstance();
   runApp(MyApp(sharedPreferences));
 }


### PR DESCRIPTION
Was looking at an example app that one of the members of the Flutter team and found out that the main function can be made to return a `Future`. This should allow us to having an async void function and remove the need to suppress the warning