### PR TITLE
Output a single ignore_for_file per store file

### DIFF
--- a/mobx_codegen/lib/src/mobx_codegen_base.dart
+++ b/mobx_codegen/lib/src/mobx_codegen_base.dart
@@ -17,13 +17,17 @@ import 'package:mobx_codegen/src/template/observable.dart';
 import 'package:mobx_codegen/src/template/observable_future.dart';
 import 'package:mobx_codegen/src/template/observable_stream.dart';
 import 'package:mobx_codegen/src/template/store.dart';
+import 'package:mobx_codegen/src/template/store_file.dart';
 import 'package:mobx_codegen/src/template/util.dart';
 import 'package:source_gen/source_gen.dart';
 
 class StoreGenerator extends Generator {
   @override
-  FutureOr<String> generate(LibraryReader library, BuildStep buildStep) =>
-      _generateCodeForLibrary(library).toSet().join('\n\n');
+  FutureOr<String> generate(LibraryReader library, BuildStep buildStep) {
+    final file = StoreFileTemplate()
+      ..storeSources = _generateCodeForLibrary(library).toSet();
+    return file.toString();
+  }
 
   Iterable<String> _generateCodeForLibrary(LibraryReader library) sync* {
     for (final classElement in library.classes) {

--- a/mobx_codegen/lib/src/template/store.dart
+++ b/mobx_codegen/lib/src/template/store.dart
@@ -13,13 +13,11 @@ class SubclassStoreTemplate extends StoreTemplate {
   String get typeName => publicTypeName;
 
   @override
-  String get storeBody {
-    return '''
-      $constructors
+  String get storeBody => '''
+  $constructors
 
-      ${super.storeBody}
-    ''';
-  }
+  ${super.storeBody}
+  ''';
 
   @override
   String toString() => '''

--- a/mobx_codegen/lib/src/template/store.dart
+++ b/mobx_codegen/lib/src/template/store.dart
@@ -23,8 +23,6 @@ class SubclassStoreTemplate extends StoreTemplate {
 
   @override
   String toString() => '''
-  ${StoreTemplate.analyzerIgnores}
-
   class $typeName$typeParams extends $parentTypeName$typeArgs {
     $storeBody
   }''';
@@ -35,16 +33,12 @@ class MixinStoreTemplate extends StoreTemplate {
 
   @override
   String toString() => '''
-  ${StoreTemplate.analyzerIgnores}
-
   mixin $typeName$typeParams on $parentTypeName$typeArgs, Store {
     $storeBody
   }''';
 }
 
 abstract class StoreTemplate {
-  static const analyzerIgnores = '// ignore_for_file: non_constant_identifier_names, unnecessary_lambdas, prefer_expression_function_bodies, lines_longer_than_80_chars, avoid_as, avoid_annotating_with_dynamic';
-
   final SurroundedCommaList<TypeParamTemplate> typeParams =
       SurroundedCommaList('<', '>', []);
   final SurroundedCommaList<String> typeArgs =

--- a/mobx_codegen/lib/src/template/store_file.dart
+++ b/mobx_codegen/lib/src/template/store_file.dart
@@ -1,0 +1,14 @@
+const _analyzerIgnores =
+    '// ignore_for_file: non_constant_identifier_names, unnecessary_lambdas, prefer_expression_function_bodies, lines_longer_than_80_chars, avoid_as, avoid_annotating_with_dynamic';
+
+/// Template for a file containing one or more generated stores.
+class StoreFileTemplate {
+  Iterable<String> storeSources;
+
+  @override
+  String toString() => '''
+    $_analyzerIgnores
+
+    ${storeSources.join('\n\n')}
+  ''';
+}


### PR DESCRIPTION
In this PR we introduce a new template representing a file containing one or more stores. This template includes a single top-level `ignore_for_file` directive.

Fixes #270