### PR TITLE
Add support for codegen of "unknown" type names

### DIFF
--- a/mobx_codegen/lib/src/mobx_codegen_base.dart
+++ b/mobx_codegen/lib/src/mobx_codegen_base.dart
@@ -19,6 +19,7 @@ import 'package:mobx_codegen/src/template/observable_stream.dart';
 import 'package:mobx_codegen/src/template/store.dart';
 import 'package:mobx_codegen/src/template/store_file.dart';
 import 'package:mobx_codegen/src/template/util.dart';
+import 'package:mobx_codegen/src/type_names.dart';
 import 'package:source_gen/source_gen.dart';
 
 class StoreGenerator extends Generator {
@@ -176,7 +177,7 @@ class StoreMixinVisitor extends SimpleElementVisitor {
     final template = ObservableTemplate()
       ..storeTemplate = _storeTemplate
       ..atomName = '_\$${element.name}Atom'
-      ..type = element.type.displayName
+      ..type = findVariableTypeName(element)
       ..name = element.name;
 
     _storeTemplate.observables.add(template);
@@ -207,7 +208,7 @@ class StoreMixinVisitor extends SimpleElementVisitor {
     final template = ComputedTemplate()
       ..computedName = '_\$${element.name}Computed'
       ..name = element.name
-      ..type = element.returnType.displayName;
+      ..type = findGetterTypeName(element);
     _storeTemplate.computeds.add(template);
 
     return;

--- a/mobx_codegen/lib/src/template/method_override.dart
+++ b/mobx_codegen/lib/src/template/method_override.dart
@@ -1,8 +1,8 @@
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/dart/element/type.dart';
 import 'package:mobx_codegen/src/template/comma_list.dart';
 import 'package:mobx_codegen/src/template/params.dart';
 import 'package:mobx_codegen/src/template/util.dart';
+import 'package:mobx_codegen/src/type_names.dart';
 
 /// Stores templating information about constructors and methods.
 class MethodOverrideTemplate {
@@ -12,7 +12,7 @@ class MethodOverrideTemplate {
     // ignore: prefer_function_declarations_over_variables
     final param = (ParameterElement elem) => ParamTemplate()
       ..name = elem.name
-      ..type = elem.type.displayName
+      ..type = findParameterTypeName(elem)
       ..defaultValue = elem.defaultValueCode;
 
     final positionalParams = method.parameters
@@ -25,19 +25,15 @@ class MethodOverrideTemplate {
     final namedParams =
         method.parameters.where((param) => param.isNamed).toList();
 
-    final returnType = method.returnType;
-    final returnTypeArgs = returnType is ParameterizedType
-        ? returnType.typeArguments.map((p) => p.displayName).toList()
-        : <String>[];
-
     this
       ..name = method.name
-      ..returnType = method.returnType.displayName
+      ..returnType = findReturnTypeName(method)
       ..setTypeParams(method.typeParameters.map(typeParamTemplate))
       ..positionalParams = positionalParams.map(param)
       ..optionalParams = optionalParams.map(param)
       ..namedParams = namedParams.map(param)
-      ..returnTypeArgs = SurroundedCommaList('<', '>', returnTypeArgs);
+      ..returnTypeArgs = SurroundedCommaList(
+          '<', '>', findReturnTypeArgumentTypeNames(method));
   }
 
   String name;

--- a/mobx_codegen/lib/src/template/util.dart
+++ b/mobx_codegen/lib/src/template/util.dart
@@ -1,5 +1,6 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'package:mobx_codegen/src/template/params.dart';
+import 'package:mobx_codegen/src/type_names.dart';
 import 'package:source_gen/source_gen.dart';
 
 // ignore: avoid_annotating_with_dynamic
@@ -33,4 +34,5 @@ class AsyncMethodChecker {
 TypeParamTemplate typeParamTemplate(TypeParameterElement param) =>
     TypeParamTemplate()
       ..name = param.name
-      ..bound = param.bound?.displayName;
+      ..bound =
+          param.bound != null ? findTypeParameterBoundsTypeName(param) : null;

--- a/mobx_codegen/lib/src/type_names.dart
+++ b/mobx_codegen/lib/src/type_names.dart
@@ -1,0 +1,116 @@
+// ignore: deprecated_member_use
+import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
+
+String findVariableTypeName(VariableElement variable) {
+  if (!_isTypeDynamic(variable.type)) {
+    return variable.type.displayName;
+  }
+
+  return _findElementNode<VariableDeclarationList>(variable).type.toSource();
+}
+
+String findGetterTypeName(PropertyAccessorElement getter) {
+  assert(getter.isGetter);
+  return findReturnTypeName(getter);
+}
+
+String findSetterTypeName(PropertyAccessorElement setter) {
+  assert(setter.isSetter);
+  return findParameterTypeName(setter.parameters.first);
+}
+
+String findParameterTypeName(ParameterElement parameter) {
+  if (!_isTypeDynamic(parameter.type)) {
+    return parameter.type.displayName;
+  }
+
+  // If we're dealing with a parameter of the format `this.field`, let's look
+  // up the corresponding field or property element, and grab its type.
+  if (parameter.isInitializingFormal) {
+    return _findInitializingParameterTypeName(parameter);
+  }
+
+  final node = _findElementNode<NormalFormalParameter>(parameter);
+  if (node is SimpleFormalParameter) {
+    return node.type.toString();
+  } else {
+    return 'dynamic';
+  }
+}
+
+String _findInitializingParameterTypeName(ParameterElement parameter) {
+  final ClassElement classElement = parameter.enclosingElement.enclosingElement;
+
+  final correspondingField = classElement.getField(parameter.name);
+  if (correspondingField != null) {
+    return findVariableTypeName(correspondingField);
+  }
+
+  final correspondingSetter = classElement.getSetter(parameter.name);
+  if (correspondingSetter != null) {
+    return findSetterTypeName(correspondingSetter);
+  }
+
+  return 'dynamic';
+}
+
+String findReturnTypeName(ExecutableElement executable) {
+  if (!_isTypeDynamic(executable.returnType)) {
+    return executable.returnType.displayName;
+  }
+
+  return _findReturnType(executable)?.toSource() ?? 'dynamic';
+}
+
+List<String> findReturnTypeArgumentTypeNames(ExecutableElement executable) {
+  if (!_isTypeDynamic(executable.returnType)) {
+    final type = executable.returnType;
+    return type is ParameterizedType
+        ? type.typeArguments.map((argType) => argType.displayName).toList()
+        : [];
+  }
+
+  final returnType = _findReturnType(executable);
+  if (returnType is NamedType && returnType.typeArguments != null) {
+    return returnType.typeArguments.arguments
+        .map((arg) => arg.toSource())
+        .toList();
+  }
+
+  return [];
+}
+
+String findTypeParameterBoundsTypeName(TypeParameterElement typeParameter) {
+  if (!_isTypeDynamic(typeParameter.bound)) {
+    return typeParameter.bound.displayName;
+  }
+
+  return _findElementNode<TypeParameter>(typeParameter).bound.toSource();
+}
+
+TypeAnnotation _findReturnType(ExecutableElement executable) =>
+    _findElementNode<FunctionDeclaration>(executable)?.returnType ??
+    _findElementNode<MethodDeclaration>(executable)?.returnType;
+
+/// Returns `true` if [type], or one of [type]'s type arguments, is dynamic.
+bool _isTypeDynamic(DartType type) =>
+    type.isDynamic ||
+    (type is ParameterizedType && type.typeArguments.any(_isTypeDynamic));
+
+/// Returns [element]'s closest matching AST node ancestor of type [T], or
+/// `null` if not found.
+T _findElementNode<T extends AstNode>(Element element) {
+  final parsedLibrary =
+      element.session.getParsedLibraryByElement(element.library);
+  final elementDeclaration = parsedLibrary.getElementDeclaration(element);
+
+  // For whatever reason, sometimes the element declaration doesn't contain the
+  // AST node we're looking for. In this case, we use a NodeLocator to find the
+  // node in the element's compilation unit.
+  final node = elementDeclaration.node ??
+      NodeLocator(element.nameOffset)
+          .searchWithin(elementDeclaration.parsedUnit.unit);
+  return node.thisOrAncestorOfType<T>();
+}

--- a/mobx_codegen/lib/src/type_names.dart
+++ b/mobx_codegen/lib/src/type_names.dart
@@ -44,12 +44,12 @@ String _findInitializingParameterTypeName(ParameterElement parameter) {
   final ClassElement classElement = parameter.enclosingElement.enclosingElement;
 
   final correspondingField = classElement.getField(parameter.name);
-  if (correspondingField != null) {
+  if (correspondingField != null && !correspondingField.isSynthetic) {
     return findVariableTypeName(correspondingField);
   }
 
   final correspondingSetter = classElement.getSetter(parameter.name);
-  if (correspondingSetter != null) {
+  if (correspondingSetter != null && !correspondingSetter.isSynthetic) {
     return findSetterTypeName(correspondingSetter);
   }
 

--- a/mobx_codegen/test/data/valid_annotated_store_input.dart
+++ b/mobx_codegen/test/data/valid_annotated_store_input.dart
@@ -9,6 +9,9 @@ part 'generator_sample.g.dart';
 class _User {
   _User(this.id);
   _User.withNames({this.firstName = 'Scott', this.lastName}) : id = 0;
+  _User.withGenericList(List<int> ints) : id = 0 {
+    print(ints);
+  }
 
   final int id;
 

--- a/mobx_codegen/test/data/valid_annotated_store_output.dart
+++ b/mobx_codegen/test/data/valid_annotated_store_output.dart
@@ -4,6 +4,8 @@ class User extends _User {
   User.withNames({String firstName = 'Scott', String lastName})
       : super.withNames(firstName: firstName, lastName: lastName);
 
+  User.withGenericList(List<int> ints) : super.withGenericList(ints);
+
   Computed<String> _$fullNameComputed;
 
   @override

--- a/mobx_codegen/test/data/valid_annotated_store_referencing_store_input.dart
+++ b/mobx_codegen/test/data/valid_annotated_store_referencing_store_input.dart
@@ -1,0 +1,50 @@
+library generator_sample;
+
+import 'dart:ui' as ui;
+
+import 'package:mobx/mobx.dart';
+
+part 'generator_sample.g.dart';
+
+@store
+class _Car {
+  _Car(this.engine);
+
+  @observable
+  ui.Color paintColor;
+
+  @observable
+  Engine engine;
+
+  @observable
+  ObservableList<Tire> tires = ObservableList<Tire>();
+
+  @observable
+  Windshield windshield = Windshield();
+
+  @action
+  Future<List<Tire>> changeTiresIfRequired() async => [];
+
+  @action
+  Future<List<T>> changeCarPartsIfRequired<T extends CarPart>() async => [];
+}
+
+@store
+class _CarPart {}
+
+@store
+class _Engine extends CarPart {}
+
+@store
+class _Tire extends CarPart {}
+
+@store
+class _Windshield extends CarPart {
+  @observable
+  Stream<List<Bug>> squashedBugs() async* {
+    yield <Bug>[];
+  }
+}
+
+@store
+class _Bug {}

--- a/mobx_codegen/test/data/valid_annotated_store_referencing_store_input.dart
+++ b/mobx_codegen/test/data/valid_annotated_store_referencing_store_input.dart
@@ -24,8 +24,8 @@ class _Car {
   @observable
   Windshield windshield = Windshield();
 
-  @observable
-  Set<Tire> flatTires => {};
+  @computed
+  Set<Tire> get flatTires() => {};
 
   @action
   Future<List<Tire>> changeTiresIfRequired() async => [];
@@ -56,6 +56,6 @@ class _Windshield extends CarPart {
 
 @store
 class _Bug {
-  @computed
+  @action
   T sizeInMillimeters<T extends num>() => null;
 }

--- a/mobx_codegen/test/data/valid_annotated_store_referencing_store_input.dart
+++ b/mobx_codegen/test/data/valid_annotated_store_referencing_store_input.dart
@@ -14,13 +14,18 @@ class _Car {
   ui.Color paintColor;
 
   @observable
-  Engine engine;
+  Engine _engine;
+  Engine get engine => _engine;
+  set engine(Engine value) => _engine = engine;
 
   @observable
   ObservableList<Tire> tires = ObservableList<Tire>();
 
   @observable
   Windshield windshield = Windshield();
+
+  @observable
+  Set<Tire> flatTires => {};
 
   @action
   Future<List<Tire>> changeTiresIfRequired() async => [];
@@ -33,7 +38,10 @@ class _Car {
 class _CarPart {}
 
 @store
-class _Engine extends CarPart {}
+class _Engine extends CarPart {
+  @action
+  swapInParts({Engine from}) {}
+}
 
 @store
 class _Tire extends CarPart {}
@@ -47,4 +55,7 @@ class _Windshield extends CarPart {
 }
 
 @store
-class _Bug {}
+class _Bug {
+  @computed
+  T sizeInMillimeters<T extends num>() => null;
+}

--- a/mobx_codegen/test/data/valid_annotated_store_referencing_store_output.dart
+++ b/mobx_codegen/test/data/valid_annotated_store_referencing_store_output.dart
@@ -1,0 +1,115 @@
+class Car extends _Car {
+  Car(Engine engine) : super(engine);
+
+  final _$paintColorAtom = Atom(name: '_Car.paintColor');
+
+  @override
+  ui.Color get paintColor {
+    _$paintColorAtom.context.enforceReadPolicy(_$paintColorAtom);
+    _$paintColorAtom.reportObserved();
+    return super.paintColor;
+  }
+
+  @override
+  set paintColor(ui.Color value) {
+    _$paintColorAtom.context.conditionallyRunInAction(() {
+      super.paintColor = value;
+      _$paintColorAtom.reportChanged();
+    }, _$paintColorAtom, name: '${_$paintColorAtom.name}_set');
+  }
+
+  final _$engineAtom = Atom(name: '_Car.engine');
+
+  @override
+  Engine get engine {
+    _$engineAtom.context.enforceReadPolicy(_$engineAtom);
+    _$engineAtom.reportObserved();
+    return super.engine;
+  }
+
+  @override
+  set engine(Engine value) {
+    _$engineAtom.context.conditionallyRunInAction(() {
+      super.engine = value;
+      _$engineAtom.reportChanged();
+    }, _$engineAtom, name: '${_$engineAtom.name}_set');
+  }
+
+  final _$tiresAtom = Atom(name: '_Car.tires');
+
+  @override
+  ObservableList<Tire> get tires {
+    _$tiresAtom.context.enforceReadPolicy(_$tiresAtom);
+    _$tiresAtom.reportObserved();
+    return super.tires;
+  }
+
+  @override
+  set tires(ObservableList<Tire> value) {
+    _$tiresAtom.context.conditionallyRunInAction(() {
+      super.tires = value;
+      _$tiresAtom.reportChanged();
+    }, _$tiresAtom, name: '${_$tiresAtom.name}_set');
+  }
+
+  final _$windshieldAtom = Atom(name: '_Car.windshield');
+
+  @override
+  Windshield get windshield {
+    _$windshieldAtom.context.enforceReadPolicy(_$windshieldAtom);
+    _$windshieldAtom.reportObserved();
+    return super.windshield;
+  }
+
+  @override
+  set windshield(Windshield value) {
+    _$windshieldAtom.context.conditionallyRunInAction(() {
+      super.windshield = value;
+      _$windshieldAtom.reportChanged();
+    }, _$windshieldAtom, name: '${_$windshieldAtom.name}_set');
+  }
+
+  final _$changeTiresIfRequiredAsyncAction =
+      AsyncAction('changeTiresIfRequired');
+
+  @override
+  Future<List<Tire>> changeTiresIfRequired() {
+    return _$changeTiresIfRequiredAsyncAction
+        .run(() => super.changeTiresIfRequired());
+  }
+
+  final _$changeCarPartsIfRequiredAsyncAction =
+      AsyncAction('changeCarPartsIfRequired');
+
+  @override
+  Future<List<T>> changeCarPartsIfRequired<T extends CarPart>() {
+    return _$changeCarPartsIfRequiredAsyncAction
+        .run(() => super.changeCarPartsIfRequired<T>());
+  }
+}
+
+class CarPart extends _CarPart {
+  CarPart() : super();
+}
+
+class Engine extends _Engine {
+  Engine() : super();
+}
+
+class Tire extends _Tire {
+  Tire() : super();
+}
+
+class Windshield extends _Windshield {
+  Windshield() : super();
+
+  @override
+  ObservableStream<List<Bug>> squashedBugs() {
+    final _$stream = super.squashedBugs();
+    return ObservableStream<List<Bug>>(_$stream);
+  }
+}
+
+class Bug extends _Bug {
+  Bug() : super();
+}

--- a/mobx_codegen/test/data/valid_annotated_store_referencing_store_output.dart
+++ b/mobx_codegen/test/data/valid_annotated_store_referencing_store_output.dart
@@ -1,6 +1,13 @@
 class Car extends _Car {
   Car(Engine engine) : super(engine);
 
+  Computed<Set<Tire>> _$flatTiresComputed;
+
+  @override
+  Set<Tire> get flatTires =>
+      (_$flatTiresComputed ??= Computed<Set<Tire>>(() => super.flatTires))
+          .value;
+
   final _$paintColorAtom = Atom(name: '_Car.paintColor');
 
   @override
@@ -18,21 +25,21 @@ class Car extends _Car {
     }, _$paintColorAtom, name: '${_$paintColorAtom.name}_set');
   }
 
-  final _$engineAtom = Atom(name: '_Car.engine');
+  final _$_engineAtom = Atom(name: '_Car._engine');
 
   @override
-  Engine get engine {
-    _$engineAtom.context.enforceReadPolicy(_$engineAtom);
-    _$engineAtom.reportObserved();
-    return super.engine;
+  Engine get _engine {
+    _$_engineAtom.context.enforceReadPolicy(_$_engineAtom);
+    _$_engineAtom.reportObserved();
+    return super._engine;
   }
 
   @override
-  set engine(Engine value) {
-    _$engineAtom.context.conditionallyRunInAction(() {
-      super.engine = value;
-      _$engineAtom.reportChanged();
-    }, _$engineAtom, name: '${_$engineAtom.name}_set');
+  set _engine(Engine value) {
+    _$_engineAtom.context.conditionallyRunInAction(() {
+      super._engine = value;
+      _$_engineAtom.reportChanged();
+    }, _$_engineAtom, name: '${_$_engineAtom.name}_set');
   }
 
   final _$tiresAtom = Atom(name: '_Car.tires');
@@ -94,6 +101,18 @@ class CarPart extends _CarPart {
 
 class Engine extends _Engine {
   Engine() : super();
+
+  final _$_EngineActionController = ActionController(name: '_Engine');
+
+  @override
+  dynamic swapInParts({dynamic from}) {
+    final _$actionInfo = _$_EngineActionController.startAction();
+    try {
+      return super.swapInParts(from: from);
+    } finally {
+      _$_EngineActionController.endAction(_$actionInfo);
+    }
+  }
 }
 
 class Tire extends _Tire {
@@ -112,4 +131,16 @@ class Windshield extends _Windshield {
 
 class Bug extends _Bug {
   Bug() : super();
+
+  final _$_BugActionController = ActionController(name: '_Bug');
+
+  @override
+  T sizeInMillimeters<T extends num>() {
+    final _$actionInfo = _$_BugActionController.startAction();
+    try {
+      return super.sizeInMillimeters<T>();
+    } finally {
+      _$_BugActionController.endAction(_$actionInfo);
+    }
+  }
 }

--- a/mobx_codegen/test/data/valid_store_with_ui_types_input.dart
+++ b/mobx_codegen/test/data/valid_store_with_ui_types_input.dart
@@ -1,0 +1,36 @@
+library generator_sample;
+
+import 'dart:ui';
+
+import 'package:mobx/mobx.dart';
+
+part 'generator_sample.g.dart';
+
+class CircleModel = _CircleModel with _$CircleModel;
+
+abstract class _CircleModel with Store {
+  _CircleModel({this.origin, this.radius});
+
+  @observable
+  Offset origin;
+
+  @observable
+  Radius radius;
+}
+
+@store
+class _BoxModel {
+  _BoxModel({this.boundingRect, this.padding, this.margin, this.color});
+
+  @observable
+  Rect boundingRect;
+
+  @observable
+  Size padding;
+
+  @observable
+  Size margin;
+
+  @observable
+  Color color;
+}

--- a/mobx_codegen/test/data/valid_store_with_ui_types_output.dart
+++ b/mobx_codegen/test/data/valid_store_with_ui_types_output.dart
@@ -1,0 +1,112 @@
+mixin _$CircleModel on _CircleModel, Store {
+  final _$originAtom = Atom(name: '_CircleModel.origin');
+
+  @override
+  Offset get origin {
+    _$originAtom.context.enforceReadPolicy(_$originAtom);
+    _$originAtom.reportObserved();
+    return super.origin;
+  }
+
+  @override
+  set origin(Offset value) {
+    _$originAtom.context.conditionallyRunInAction(() {
+      super.origin = value;
+      _$originAtom.reportChanged();
+    }, _$originAtom, name: '${_$originAtom.name}_set');
+  }
+
+  final _$radiusAtom = Atom(name: '_CircleModel.radius');
+
+  @override
+  Radius get radius {
+    _$radiusAtom.context.enforceReadPolicy(_$radiusAtom);
+    _$radiusAtom.reportObserved();
+    return super.radius;
+  }
+
+  @override
+  set radius(Radius value) {
+    _$radiusAtom.context.conditionallyRunInAction(() {
+      super.radius = value;
+      _$radiusAtom.reportChanged();
+    }, _$radiusAtom, name: '${_$radiusAtom.name}_set');
+  }
+}
+
+class BoxModel extends _BoxModel {
+  BoxModel({Rect boundingRect, Size padding, Size margin, Color color})
+      : super(
+            boundingRect: boundingRect,
+            padding: padding,
+            margin: margin,
+            color: color);
+
+  final _$boundingRectAtom = Atom(name: '_BoxModel.boundingRect');
+
+  @override
+  Rect get boundingRect {
+    _$boundingRectAtom.context.enforceReadPolicy(_$boundingRectAtom);
+    _$boundingRectAtom.reportObserved();
+    return super.boundingRect;
+  }
+
+  @override
+  set boundingRect(Rect value) {
+    _$boundingRectAtom.context.conditionallyRunInAction(() {
+      super.boundingRect = value;
+      _$boundingRectAtom.reportChanged();
+    }, _$boundingRectAtom, name: '${_$boundingRectAtom.name}_set');
+  }
+
+  final _$paddingAtom = Atom(name: '_BoxModel.padding');
+
+  @override
+  Size get padding {
+    _$paddingAtom.context.enforceReadPolicy(_$paddingAtom);
+    _$paddingAtom.reportObserved();
+    return super.padding;
+  }
+
+  @override
+  set padding(Size value) {
+    _$paddingAtom.context.conditionallyRunInAction(() {
+      super.padding = value;
+      _$paddingAtom.reportChanged();
+    }, _$paddingAtom, name: '${_$paddingAtom.name}_set');
+  }
+
+  final _$marginAtom = Atom(name: '_BoxModel.margin');
+
+  @override
+  Size get margin {
+    _$marginAtom.context.enforceReadPolicy(_$marginAtom);
+    _$marginAtom.reportObserved();
+    return super.margin;
+  }
+
+  @override
+  set margin(Size value) {
+    _$marginAtom.context.conditionallyRunInAction(() {
+      super.margin = value;
+      _$marginAtom.reportChanged();
+    }, _$marginAtom, name: '${_$marginAtom.name}_set');
+  }
+
+  final _$colorAtom = Atom(name: '_BoxModel.color');
+
+  @override
+  Color get color {
+    _$colorAtom.context.enforceReadPolicy(_$colorAtom);
+    _$colorAtom.reportObserved();
+    return super.color;
+  }
+
+  @override
+  set color(Color value) {
+    _$colorAtom.context.conditionallyRunInAction(() {
+      super.color = value;
+      _$colorAtom.reportChanged();
+    }, _$colorAtom, name: '${_$colorAtom.name}_set');
+  }
+}

--- a/mobx_codegen/test/mobx_codegen_test.dart
+++ b/mobx_codegen/test/mobx_codegen_test.dart
@@ -57,6 +57,14 @@ void main() {
           description: 'generates for a generic class annotated with @store',
           source: './data/valid_generic_annotated_store_input.dart',
           output: './data/valid_generic_annotated_store_output.dart'),
+      const TestInfo(
+          description: 'generates correct types for a @store referencing another @store',
+          source: './data/valid_annotated_store_referencing_store_input.dart',
+          output: './data/valid_annotated_store_referencing_store_output.dart'),
+      const TestInfo(
+          description: 'generates dart:ui types correctly',
+          source: './data/valid_store_with_ui_types_input.dart',
+          output: './data/valid_store_with_ui_types_output.dart'),
     ]);
   });
 }


### PR DESCRIPTION
If the analyzer is unable to resolve a type, it reports that the type is
"dynamic", and our codegen writes it out way. This situation is
particularly noticeable because the build package's analyzer draws from
a pre-computed analysis summary that does not include dart:ui.

The recent work on annotated stores demonstrates a similar and related
problem, where we'd like to reference generated types in our store
definitions, but because the analyzer doesn't know about types that have
not yet been generated, dynamics litter the generated code.

This PR explores an approach where we output types to generated code
as they were written in the input instead of relying on the analyzer's
interpretation. If we encounter a type that the analyzer reports as
dynamic, we look up the element's AST node, and use the name found
there. Magic.

Fixes #268 
Fixes #267 
Fixes #165 