### PR TITLE
_isValidating can't be null

### DIFF
--- a/flutter_mobx_forms/lib/src/field_state.dart
+++ b/flutter_mobx_forms/lib/src/field_state.dart
@@ -36,7 +36,7 @@ abstract class _FieldState<T> with Store {
   T value;
 
   @observable
-  bool _isValidating;
+  bool _isValidating = false;
 
   final ErrorContext errorContext = ErrorContext();
 


### PR DESCRIPTION
Because assert(!_isValidating) is asserting negate of null which is illegal.