### PR TITLE
Fix a case where an unknown parameter type is missed

### DIFF
--- a/mobx_codegen/lib/src/type_names.dart
+++ b/mobx_codegen/lib/src/type_names.dart
@@ -32,7 +32,9 @@ String findParameterTypeName(ParameterElement parameter) {
     return _findInitializingParameterTypeName(parameter);
   }
 
-  final node = _findElementNode<NormalFormalParameter>(parameter);
+  final node =
+      _findElementNode<DefaultFormalParameter>(parameter)?.parameter ??
+      _findElementNode<NormalFormalParameter>(parameter);
   if (node is SimpleFormalParameter) {
     return node.type.toString();
   } else {

--- a/mobx_codegen/test/data/valid_annotated_store_referencing_store_input.dart
+++ b/mobx_codegen/test/data/valid_annotated_store_referencing_store_input.dart
@@ -40,7 +40,7 @@ class _CarPart {}
 @store
 class _Engine extends CarPart {
   @action
-  swapInParts({Engine from}) {}
+  void swapInParts({Engine from}) {}
 }
 
 @store

--- a/mobx_codegen/test/data/valid_annotated_store_referencing_store_output.dart
+++ b/mobx_codegen/test/data/valid_annotated_store_referencing_store_output.dart
@@ -105,7 +105,7 @@ class Engine extends _Engine {
   final _$_EngineActionController = ActionController(name: '_Engine');
 
   @override
-  dynamic swapInParts({dynamic from}) {
+  void swapInParts({Engine from}) {
     final _$actionInfo = _$_EngineActionController.startAction();
     try {
       return super.swapInParts(from: from);

--- a/mobx_codegen/test/data/valid_store_with_ui_types_input.dart
+++ b/mobx_codegen/test/data/valid_store_with_ui_types_input.dart
@@ -26,6 +26,7 @@ class _BoxModel {
     this.padding = Size.zero,
     this.margin = Size.zero,
     this.color,
+    Paragraph paragraph,
   });
 
   @observable

--- a/mobx_codegen/test/data/valid_store_with_ui_types_output.dart
+++ b/mobx_codegen/test/data/valid_store_with_ui_types_output.dart
@@ -39,12 +39,14 @@ class BoxModel extends _BoxModel {
       {@required Rect boundingRect,
       Size padding = Size.zero,
       Size margin = Size.zero,
-      Color color})
+      Color color,
+      Paragraph paragraph})
       : super(
             boundingRect: boundingRect,
             padding: padding,
             margin: margin,
-            color: color);
+            color: color,
+            paragraph: paragraph);
 
   final _$boundingRectAtom = Atom(name: '_BoxModel.boundingRect');
 


### PR DESCRIPTION
Turns out that a `NormalFormalParameter` is not always the node that we find when searching for a `ParameterElement`'s counterpart in the AST. If a `DefaultFormalParameter` is discovered, we will now traverse to the `SimpleFormalParameter` containing the type name.
