### PR TITLE
Support parameters without type annotations

### DIFF
--- a/mobx_codegen/lib/src/type_names.dart
+++ b/mobx_codegen/lib/src/type_names.dart
@@ -35,7 +35,7 @@ String findParameterTypeName(ParameterElement parameter) {
   final node =
       _findElementNode<DefaultFormalParameter>(parameter)?.parameter ??
       _findElementNode<NormalFormalParameter>(parameter);
-  if (node is SimpleFormalParameter) {
+  if (node is SimpleFormalParameter && node.type != null) {
     return node.type.toString();
   } else {
     return 'dynamic';

--- a/mobx_codegen/test/data/valid_input.dart
+++ b/mobx_codegen/test/data/valid_input.dart
@@ -52,4 +52,7 @@ abstract class UserBase with Store {
   Future<void> setAsyncFirstName2() async {
     firstName = 'Async FirstName 2';
   }
+
+  @action
+  void setBlob(blob) {} // ignore: type_annotate_public_apis
 }

--- a/mobx_codegen/test/data/valid_output.dart
+++ b/mobx_codegen/test/data/valid_output.dart
@@ -83,4 +83,14 @@ mixin _$User on UserBase, Store {
       _$UserBaseActionController.endAction(_$actionInfo);
     }
   }
+
+  @override
+  void setBlob(dynamic blob) {
+    final _$actionInfo = _$UserBaseActionController.startAction();
+    try {
+      return super.setBlob(blob);
+    } finally {
+      _$UserBaseActionController.endAction(_$actionInfo);
+    }
+  }
 }


### PR DESCRIPTION
A parameter without a type annotation was having its type generated as "null". This corrects the situation by handling the null case in the parameter type name finder.

Fixes #298 