### PR TITLE
Add ObservableValue class

### DIFF
--- a/mobx/lib/src/api/async/observable_future.dart
+++ b/mobx/lib/src/api/async/observable_future.dart
@@ -41,7 +41,7 @@ class FutureResult<T> {
   }
 }
 
-class ObservableFuture<T> implements Future<T> {
+class ObservableFuture<T> implements Future<T>, ObservableValue<T> {
   /// Create a new observable future that tracks the state of the provided future.
   ObservableFuture(Future<T> future, {ReactiveContext context})
       : this._(context ?? mainContext, future, FutureStatus.pending, null);
@@ -91,6 +91,7 @@ class ObservableFuture<T> implements Future<T> {
   /// Value if this completed with a value.
   ///
   /// Null otherwise.
+  @override
   T get value => status == FutureStatus.fulfilled ? _result.result : null;
 
   /// Error value if this completed with an error

--- a/mobx/lib/src/api/async/observable_stream.dart
+++ b/mobx/lib/src/api/async/observable_stream.dart
@@ -2,7 +2,7 @@ part of '../async.dart';
 
 enum StreamStatus { waiting, active, done }
 
-class ObservableStream<T> implements Stream<T> {
+class ObservableStream<T> implements Stream<T>, ObservableValue<T> {
   ObservableStream(Stream<T> stream,
       {T initialValue, bool cancelOnError = false, ReactiveContext context})
       : this._(context ?? mainContext, stream, initialValue, cancelOnError);
@@ -31,6 +31,7 @@ class ObservableStream<T> implements Stream<T> {
   dynamic get data => _controller.data;
 
   /// Current value or null if waiting and no initialValue, or null if data is an error.
+  @override
   T get value =>
       _controller.valueType == _ValueType.value ? _controller.data : null;
 

--- a/mobx/lib/src/core.dart
+++ b/mobx/lib/src/core.dart
@@ -11,6 +11,7 @@ part 'core/context.dart';
 part 'core/derivation.dart';
 part 'core/notification_handlers.dart';
 part 'core/observable.dart';
+part 'core/observable_value.dart';
 part 'core/reaction.dart';
 part 'core/reaction_helper.dart';
 part 'interceptable.dart';

--- a/mobx/lib/src/core/computed.dart
+++ b/mobx/lib/src/core/computed.dart
@@ -1,6 +1,6 @@
 part of '../core.dart';
 
-class Computed<T> extends Atom implements Derivation {
+class Computed<T> extends Atom implements Derivation, ObservableValue<T> {
   /// Creates a computed value with an optional [name].
   ///
   /// The passed in function: [fn], is used to give back the computed value.
@@ -57,6 +57,7 @@ class Computed<T> extends Atom implements Derivation {
 
   bool _isComputing = false;
 
+  @override
   T get value {
     if (_isComputing) {
       throw MobXException('Cycle detected in computation $name: $_fn');

--- a/mobx/lib/src/core/observable.dart
+++ b/mobx/lib/src/core/observable.dart
@@ -1,7 +1,10 @@
 part of '../core.dart';
 
 class Observable<T> extends Atom
-    implements Interceptable<T>, Listenable<ChangeNotification<T>> {
+    implements
+        Interceptable<T>,
+        Listenable<ChangeNotification<T>>,
+        ObservableValue<T> {
   /// Create an observable value with an [initialValue] and an optional [name]
   ///
   /// Observable values are tracked inside MobX. When a reaction uses them
@@ -36,6 +39,7 @@ class Observable<T> extends Atom
 
   T _value;
 
+  @override
   T get value {
     _context.enforceReadPolicy(this);
 

--- a/mobx/lib/src/core/observable_value.dart
+++ b/mobx/lib/src/core/observable_value.dart
@@ -1,0 +1,5 @@
+part of '../core.dart';
+
+abstract class ObservableValue<T> {
+  T get value;
+}

--- a/mobx/test/observable_value_test.dart
+++ b/mobx/test/observable_value_test.dart
@@ -1,0 +1,21 @@
+import 'dart:async';
+
+import 'package:mobx/mobx.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ObservableValue', () {
+    test('basics work', () {
+      final ObservableValue<int> x1 = Observable(1);
+      final ObservableValue<int> x2 = Computed(() => x1.value * 2);
+      final ObservableValue<int> x3 = ObservableFuture.value(3);
+      final ObservableValue<int> x4 =
+          ObservableStream(const Stream<int>.empty(), initialValue: 4);
+
+      expect(x1.value, equals(1));
+      expect(x2.value, equals(2));
+      expect(x3.value, equals(3));
+      expect(x4.value, equals(4));
+    });
+  });
+}


### PR DESCRIPTION
This allows to work with observable classes(`Observable`, `Computed`, `ObservableFuture`, `ObservableStream`) through a common interface.

Fixes #301