### PR TITLE
Fix: ReactiveWritePolicy.observed does not work.

### DIFF
--- a/mobx/lib/src/core/context.dart
+++ b/mobx/lib/src/core/context.dart
@@ -206,8 +206,10 @@ class ReactiveContext {
   /// [fn] is the function to execute. Optionally provide a debug-[name].
   void conditionallyRunInAction(void Function() fn, Atom atom,
       {String name, ActionController actionController}) {
+
+    enforceWritePolicy(atom);
+
     if (isWithinBatch) {
-      enforceWritePolicy(atom);
       fn();
     } else {
       final controller = actionController ??
@@ -216,7 +218,6 @@ class ReactiveContext {
       final runInfo = controller.startAction();
 
       try {
-        enforceWritePolicy(atom);
         fn();
       } finally {
         controller.endAction(runInfo);


### PR DESCRIPTION
mobx should fire exception if one mutate observable outside an action, however, this will never happen because enforceWritePolicy will be wrap in

```dart
final runInfo = controller.startAction();
enforceWritePolicy(atom)
controller.endAction(runInfo);
```