### PR TITLE
Upgrade the analyzer to support a range of versions

### DIFF
--- a/mobx_codegen/CHANGELOG.md
+++ b/mobx_codegen/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.3.9+1 - 0.3.10
+
+- Alters the analyzer dependency to support a range — from the previously supported version
+  (0.36.3), up to latest (0.39.0).
+- Adds support for library prefixes in all situations (`import 'package:foo' as foo`),
+  so type names are prefixed in generated part files.
+
 ## 0.3.8 - 0.3.9+1
 
 - Fixes a minor issue where types in generated code would appear as dynamic when they shouldn't.

--- a/mobx_codegen/lib/src/mobx_codegen_base.dart
+++ b/mobx_codegen/lib/src/mobx_codegen_base.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type_system.dart';
 import 'package:build/build.dart';
 import 'package:mobx_codegen/src/template/store.dart';
 import 'package:mobx_codegen/src/store_class_visitor.dart';
@@ -9,16 +10,24 @@ import 'package:source_gen/source_gen.dart';
 
 class StoreGenerator extends Generator {
   @override
-  FutureOr<String> generate(LibraryReader library, BuildStep buildStep) {
+  FutureOr<String> generate(LibraryReader library, BuildStep buildStep) async {
+    if (library.allElements.isEmpty) {
+      return '';
+    }
+
+    final typeSystem = await library.allElements.first.session.typeSystem;
     final file = StoreFileTemplate()
-      ..storeSources = _generateCodeForLibrary(library).toSet();
+      ..storeSources = _generateCodeForLibrary(library, typeSystem).toSet();
     return file.toString();
   }
 
-  Iterable<String> _generateCodeForLibrary(LibraryReader library) sync* {
+  Iterable<String> _generateCodeForLibrary(
+    LibraryReader library,
+    TypeSystem typeSystem,
+  ) sync* {
     for (final classElement in library.classes) {
       if (isMixinStoreClass(classElement)) {
-        yield* _generateCodeForMixinStore(library, classElement);
+        yield* _generateCodeForMixinStore(library, classElement, typeSystem);
       } else if (isAnnotatedStoreClass(classElement)) {
         yield* _generateCodeForAnnotatedStore(library, classElement);
       }
@@ -28,6 +37,7 @@ class StoreGenerator extends Generator {
   Iterable<String> _generateCodeForMixinStore(
     LibraryReader library,
     ClassElement baseClass,
+    TypeSystem typeSystem,
   ) sync* {
     final otherClasses = library.classes.where((c) => c != baseClass);
     final mixedClass = otherClasses.firstWhere((c) {
@@ -39,9 +49,8 @@ class StoreGenerator extends Generator {
 
       // Apply the subclass' type arguments to the base type (if there are none
       // this has no impact), and perform a supertype check.
-      return baseClass.type
-          .instantiate(c.supertype.typeArguments)
-          .isSupertypeOf(c.type);
+      return typeSystem.isSubtypeOf(
+          c.type, baseClass.type.instantiate(c.supertype.typeArguments));
     }, orElse: () => null);
 
     if (mixedClass != null) {

--- a/mobx_codegen/lib/src/store_class_visitor.dart
+++ b/mobx_codegen/lib/src/store_class_visitor.dart
@@ -69,6 +69,10 @@ class StoreClassVisitor extends SimpleElementVisitor {
 
   @override
   void visitConstructorElement(ConstructorElement element) {
+    if (element.isSynthetic) {
+      return;
+    }
+
     // Note that these constructor templates are only used for annotation stye
     // store definition. They're ignored otherwise.
     final template = ConstructorOverrideTemplate()

--- a/mobx_codegen/lib/src/type_names.dart
+++ b/mobx_codegen/lib/src/type_names.dart
@@ -1,15 +1,9 @@
 // ignore: deprecated_member_use
 import 'package:analyzer/analyzer.dart';
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/dart/element/type.dart';
 
-String findVariableTypeName(VariableElement variable) {
-  if (!_isTypeDynamic(variable.type)) {
-    return variable.type.displayName;
-  }
-
-  return _findElementNode<VariableDeclarationList>(variable).type.toSource();
-}
+String findVariableTypeName(VariableElement variable) =>
+    _findElementNode<VariableDeclarationList>(variable).type.toSource();
 
 String findGetterTypeName(PropertyAccessorElement getter) {
   assert(getter.isGetter);
@@ -22,18 +16,13 @@ String findSetterTypeName(PropertyAccessorElement setter) {
 }
 
 String findParameterTypeName(ParameterElement parameter) {
-  if (!_isTypeDynamic(parameter.type)) {
-    return parameter.type.displayName;
-  }
-
   // If we're dealing with a parameter of the format `this.field`, let's look
   // up the corresponding field or property element, and grab its type.
   if (parameter.isInitializingFormal) {
     return _findInitializingParameterTypeName(parameter);
   }
 
-  final node =
-      _findElementNode<DefaultFormalParameter>(parameter)?.parameter ??
+  final node = _findElementNode<DefaultFormalParameter>(parameter)?.parameter ??
       _findElementNode<NormalFormalParameter>(parameter);
   if (node is SimpleFormalParameter && node.type != null) {
     return node.type.toString();
@@ -58,22 +47,10 @@ String _findInitializingParameterTypeName(ParameterElement parameter) {
   return 'dynamic';
 }
 
-String findReturnTypeName(ExecutableElement executable) {
-  if (!_isTypeDynamic(executable.returnType)) {
-    return executable.returnType.displayName;
-  }
-
-  return _findReturnType(executable)?.toSource() ?? 'dynamic';
-}
+String findReturnTypeName(ExecutableElement executable) =>
+    _findReturnType(executable)?.toSource() ?? 'dynamic';
 
 List<String> findReturnTypeArgumentTypeNames(ExecutableElement executable) {
-  if (!_isTypeDynamic(executable.returnType)) {
-    final type = executable.returnType;
-    return type is ParameterizedType
-        ? type.typeArguments.map((argType) => argType.displayName).toList()
-        : [];
-  }
-
   final returnType = _findReturnType(executable);
   if (returnType is NamedType && returnType.typeArguments != null) {
     return returnType.typeArguments.arguments
@@ -84,22 +61,12 @@ List<String> findReturnTypeArgumentTypeNames(ExecutableElement executable) {
   return [];
 }
 
-String findTypeParameterBoundsTypeName(TypeParameterElement typeParameter) {
-  if (!_isTypeDynamic(typeParameter.bound)) {
-    return typeParameter.bound.displayName;
-  }
-
-  return _findElementNode<TypeParameter>(typeParameter).bound.toSource();
-}
+String findTypeParameterBoundsTypeName(TypeParameterElement typeParameter) =>
+    _findElementNode<TypeParameter>(typeParameter).bound.toSource();
 
 TypeAnnotation _findReturnType(ExecutableElement executable) =>
     _findElementNode<FunctionDeclaration>(executable)?.returnType ??
     _findElementNode<MethodDeclaration>(executable)?.returnType;
-
-/// Returns `true` if [type], or one of [type]'s type arguments, is dynamic.
-bool _isTypeDynamic(DartType type) =>
-    type.isDynamic ||
-    (type is ParameterizedType && type.typeArguments.any(_isTypeDynamic));
 
 /// Returns [element]'s closest matching AST node ancestor of type [T], or
 /// `null` if not found.

--- a/mobx_codegen/pubspec.yaml
+++ b/mobx_codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobx_codegen
 description: Code generator for MobX that adds support for annotating your code with @observable, @computed, @action and also creating Store classes. Stores can be created with a mixin or @store.
-version: 0.3.9+1
+version: 0.3.10
 authors:
   - Joni Katajamäki <joni.katajamaki@gmail.com>
   - Pavan Podila <pavan@pixelingene.com>

--- a/mobx_codegen/pubspec.yaml
+++ b/mobx_codegen/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
   sdk: '>=2.2.0 <3.0.0'
 
 dependencies:
-  analyzer: ^0.36.3
+  analyzer: '>=0.36.3 <0.39.0'
   build: ^1.1.4
   meta: ^1.1.0
   mobx: ^0.3.6

--- a/mobx_codegen/test/data/valid_annotated_store_referencing_store_input.dart
+++ b/mobx_codegen/test/data/valid_annotated_store_referencing_store_input.dart
@@ -1,8 +1,8 @@
 library generator_sample;
 
-import 'dart:ui' as ui;
-
 import 'package:mobx/mobx.dart';
+
+import 'dart:ui';
 
 part 'generator_sample.g.dart';
 
@@ -11,7 +11,7 @@ class _Car {
   _Car(this.engine);
 
   @observable
-  ui.Color paintColor;
+  Color paintColor;
 
   @observable
   Engine _engine;

--- a/mobx_codegen/test/data/valid_annotated_store_referencing_store_output.dart
+++ b/mobx_codegen/test/data/valid_annotated_store_referencing_store_output.dart
@@ -95,13 +95,9 @@ class Car extends _Car {
   }
 }
 
-class CarPart extends _CarPart {
-  CarPart() : super();
-}
+class CarPart extends _CarPart {}
 
 class Engine extends _Engine {
-  Engine() : super();
-
   final _$_EngineActionController = ActionController(name: '_Engine');
 
   @override
@@ -115,13 +111,9 @@ class Engine extends _Engine {
   }
 }
 
-class Tire extends _Tire {
-  Tire() : super();
-}
+class Tire extends _Tire {}
 
 class Windshield extends _Windshield {
-  Windshield() : super();
-
   @override
   ObservableStream<List<Bug>> squashedBugs() {
     final _$stream = super.squashedBugs();
@@ -130,8 +122,6 @@ class Windshield extends _Windshield {
 }
 
 class Bug extends _Bug {
-  Bug() : super();
-
   final _$_BugActionController = ActionController(name: '_Bug');
 
   @override

--- a/mobx_codegen/test/data/valid_annotated_store_referencing_store_output.dart
+++ b/mobx_codegen/test/data/valid_annotated_store_referencing_store_output.dart
@@ -11,14 +11,14 @@ class Car extends _Car {
   final _$paintColorAtom = Atom(name: '_Car.paintColor');
 
   @override
-  ui.Color get paintColor {
+  Color get paintColor {
     _$paintColorAtom.context.enforceReadPolicy(_$paintColorAtom);
     _$paintColorAtom.reportObserved();
     return super.paintColor;
   }
 
   @override
-  set paintColor(ui.Color value) {
+  set paintColor(Color value) {
     _$paintColorAtom.context.conditionallyRunInAction(() {
       super.paintColor = value;
       _$paintColorAtom.reportChanged();

--- a/mobx_codegen/test/data/valid_import_prefixed_input.dart
+++ b/mobx_codegen/test/data/valid_import_prefixed_input.dart
@@ -1,0 +1,60 @@
+library generator_sample;
+
+import 'dart:core' as c;
+
+import 'package:meta/meta.dart';
+import 'package:mobx/mobx.dart';
+
+part 'generator_sample.g.dart';
+
+class User = UserBase with _$User;
+
+abstract class UserBase with Store {
+  UserBase(this.id);
+
+  final c.int id;
+
+  @observable
+  c.String firstName = 'Jane';
+
+  @observable
+  c.String lastName = 'Doe';
+
+  @computed
+  c.String get fullName => '$firstName $lastName';
+
+  @action
+  void updateNames({@required c.String firstName, c.String lastName}) {
+    if (firstName != null) this.firstName = firstName;
+    if (lastName != null) this.lastName = firstName;
+  }
+
+  @observable
+  c.Future<c.String> foobar() async {
+    return 'foobar';
+  }
+
+  @observable
+  c.Stream<T> loadStuff<T>(c.String arg1, {T value}) async* {
+    yield value;
+  }
+
+  @observable
+  c.Stream<c.String> asyncGenerator() async* {
+    yield 'item1';
+  }
+
+  @action
+  c.Future<void> setAsyncFirstName() async {
+    firstName = 'Async FirstName';
+  }
+
+  @action
+  @observable
+  c.Future<void> setAsyncFirstName2() async {
+    firstName = 'Async FirstName 2';
+  }
+
+  @action
+  void setBlob(blob) {} // ignore: type_annotate_public_apis
+}

--- a/mobx_codegen/test/data/valid_import_prefixed_output.dart
+++ b/mobx_codegen/test/data/valid_import_prefixed_output.dart
@@ -1,0 +1,96 @@
+mixin _$User on UserBase, Store {
+  Computed<c.String> _$fullNameComputed;
+
+  @override
+  c.String get fullName =>
+      (_$fullNameComputed ??= Computed<c.String>(() => super.fullName)).value;
+
+  final _$firstNameAtom = Atom(name: 'UserBase.firstName');
+
+  @override
+  c.String get firstName {
+    _$firstNameAtom.context.enforceReadPolicy(_$firstNameAtom);
+    _$firstNameAtom.reportObserved();
+    return super.firstName;
+  }
+
+  @override
+  set firstName(c.String value) {
+    _$firstNameAtom.context.conditionallyRunInAction(() {
+      super.firstName = value;
+      _$firstNameAtom.reportChanged();
+    }, _$firstNameAtom, name: '${_$firstNameAtom.name}_set');
+  }
+
+  final _$lastNameAtom = Atom(name: 'UserBase.lastName');
+
+  @override
+  c.String get lastName {
+    _$lastNameAtom.context.enforceReadPolicy(_$lastNameAtom);
+    _$lastNameAtom.reportObserved();
+    return super.lastName;
+  }
+
+  @override
+  set lastName(c.String value) {
+    _$lastNameAtom.context.conditionallyRunInAction(() {
+      super.lastName = value;
+      _$lastNameAtom.reportChanged();
+    }, _$lastNameAtom, name: '${_$lastNameAtom.name}_set');
+  }
+
+  @override
+  ObservableFuture<c.String> foobar() {
+    final _$future = super.foobar();
+    return ObservableFuture<c.String>(_$future);
+  }
+
+  @override
+  ObservableStream<T> loadStuff<T>(c.String arg1, {T value}) {
+    final _$stream = super.loadStuff<T>(arg1, value: value);
+    return ObservableStream<T>(_$stream);
+  }
+
+  @override
+  ObservableStream<c.String> asyncGenerator() {
+    final _$stream = super.asyncGenerator();
+    return ObservableStream<c.String>(_$stream);
+  }
+
+  final _$setAsyncFirstNameAsyncAction = AsyncAction('setAsyncFirstName');
+
+  @override
+  Future<void> setAsyncFirstName() {
+    return _$setAsyncFirstNameAsyncAction.run(() => super.setAsyncFirstName());
+  }
+
+  final _$setAsyncFirstName2AsyncAction = AsyncAction('setAsyncFirstName2');
+
+  @override
+  ObservableFuture<void> setAsyncFirstName2() {
+    return ObservableFuture<void>(
+        _$setAsyncFirstName2AsyncAction.run(() => super.setAsyncFirstName2()));
+  }
+
+  final _$UserBaseActionController = ActionController(name: 'UserBase');
+
+  @override
+  void updateNames({@required c.String firstName, c.String lastName}) {
+    final _$actionInfo = _$UserBaseActionController.startAction();
+    try {
+      return super.updateNames(firstName: firstName, lastName: lastName);
+    } finally {
+      _$UserBaseActionController.endAction(_$actionInfo);
+    }
+  }
+
+  @override
+  void setBlob(dynamic blob) {
+    final _$actionInfo = _$UserBaseActionController.startAction();
+    try {
+      return super.setBlob(blob);
+    } finally {
+      _$UserBaseActionController.endAction(_$actionInfo);
+    }
+  }
+}

--- a/mobx_codegen/test/mobx_codegen_test.dart
+++ b/mobx_codegen/test/mobx_codegen_test.dart
@@ -60,6 +60,10 @@ void main() {
           description: 'generates dart:ui types correctly',
           source: './data/valid_store_with_ui_types_input.dart',
           output: './data/valid_store_with_ui_types_output.dart'),
+      const TestInfo(
+          description: 'generates types with import prefixes correctly',
+          source: './data/valid_import_prefixed_input.dart',
+          output: './data/valid_import_prefixed_output.dart'),
     ]);
   });
 }

--- a/mobx_examples/pubspec.yaml
+++ b/mobx_examples/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
 dependencies:
   mobx: ^0.3.7
   flutter_mobx: ^0.3.0
-  mobx_codegen: ^0.3.7
+  mobx_codegen: ^0.3.10
   github:
   validators:
   hnpwa_client:


### PR DESCRIPTION
Allow a version range for the analyzer package so that downstream packages can take advantage of the newer build_resolver package. Of note, the newer build_resolver resolves dart:ui types.

This also changes the supertype check for mixin-style stores to use the TypeSystem class. The previously used method is deprecated in the latest analyzer.

Updating the analyzer had the side-effect of not outputting prefixed types (like ui.Color) because they are no longer unknown, but the I've updated the type name finders so they always ask the AST as a workaround.

Fixes #130 