### PR TITLE
Display stack traces with all caught errors

### DIFF
--- a/flutter_mobx/lib/src/observer.dart
+++ b/flutter_mobx/lib/src/observer.dart
@@ -68,7 +68,7 @@ class ObserverState extends State<Observer> {
       FlutterError.reportError(FlutterErrorDetails(
         library: 'flutter_mobx',
         exception: e,
-        stack: e is FlutterError ? e.stackTrace : null,
+        stack: e is Error ? e.stackTrace : null,
       ));
     });
   }


### PR DESCRIPTION
Errors have attached stack traces as well, so we might as well be showing them.