### PR TITLE
Print full error details in test scenarios

### DIFF
--- a/mobx_codegen/test/test_utils.dart
+++ b/mobx_codegen/test/test_utils.dart
@@ -30,6 +30,8 @@ Future<String> generate(String source) async {
   final errors = <String>[];
   void captureError(LogRecord logRecord) {
     if (logRecord.level == Level.SEVERE) {
+      stderr.writeln(
+          '${logRecord.message}\n${logRecord.error}${logRecord.stackTrace}');
       errors.add(logRecord.message);
     }
   }


### PR DESCRIPTION
Previously the generator would fail with 'Error running StoreGenerator'
in test situations, adding overhead to figuring out the source of
errors.

Closes #343