### PR TITLE
Suppress test error logging in absence of exception

### DIFF
--- a/mobx_codegen/test/test_utils.dart
+++ b/mobx_codegen/test/test_utils.dart
@@ -30,8 +30,12 @@ Future<String> generate(String source) async {
   final errors = <String>[];
   void captureError(LogRecord logRecord) {
     if (logRecord.level == Level.SEVERE) {
-      stderr.writeln(
-          '${logRecord.message}\n${logRecord.error}${logRecord.stackTrace}');
+      // If we've encountered an exception, print to stderr for easier debugging
+      if (logRecord.error != null) {
+        stderr.writeln(
+            '${logRecord.message}\n${logRecord.error}${logRecord.stackTrace}');
+      }
+
       errors.add(logRecord.message);
     }
   }


### PR DESCRIPTION
This was getting a little noisy in the general case, because our application-level validation logs to SEVERE.