### PR TITLE
Add generated test coverage badge to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ Generated.xcconfig
 
 coverage/
 .test_coverage.dart
+coverage_badge.svg
 
 # Miscellaneous
 *.class


### PR DESCRIPTION
This file is generated as a result of a `pub run test_coverage`, and is unneeded.
