### PR TITLE
Add support for analyzer 0.39.x

### DIFF
--- a/mobx_codegen/lib/src/mobx_codegen_base.dart
+++ b/mobx_codegen/lib/src/mobx_codegen_base.dart
@@ -15,6 +15,10 @@ class StoreGenerator extends Generator {
       return '';
     }
 
+    // TODO(shyndman): This ignored deprecation can be removed when we
+    // increase the analyzer dependency's lower bound to 0.39.1, and
+    // migrate to using `LibraryElement.typeSystem`.
+    // ignore: deprecated_member_use
     final typeSystem = await library.allElements.first.session.typeSystem;
     final file = StoreFileTemplate()
       ..storeSources = _generateCodeForLibrary(library, typeSystem).toSet();
@@ -50,6 +54,10 @@ class StoreGenerator extends Generator {
       // Apply the subclass' type arguments to the base type (if there are none
       // this has no impact), and perform a supertype check.
       return typeSystem.isSubtypeOf(
+          // TODO(shyndman): This ignored deprecation can be removed when we
+          // increase the analyzer dependency's lower bound to 0.38.2, and
+          // migrate to using `ClassElement.instantiate`.
+          // ignore: deprecated_member_use
           c.type, baseClass.type.instantiate(c.supertype.typeArguments));
     }, orElse: () => null);
 

--- a/mobx_codegen/pubspec.yaml
+++ b/mobx_codegen/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
   sdk: '>=2.2.0 <3.0.0'
 
 dependencies:
-  analyzer: '>=0.36.3 <0.39.0'
+  analyzer: '>=0.36.3 <0.40.0'
   build: ^1.1.4
   meta: ^1.1.0
   mobx: ^0.3.6


### PR DESCRIPTION
Two APIs we depend on become deprecrated in the 0.39.x series. I've ignored them for now, and filed
https://github.com/mobxjs/mobx.dart/issues/354 to add support as we remove support for older `analyzer` versions.

Fixes #341