### PR TITLE
Correct Observer debug name to point to constructing frame

### DIFF
--- a/flutter_mobx/test/flutter_mobx_test.dart
+++ b/flutter_mobx/test/flutter_mobx_test.dart
@@ -238,7 +238,8 @@ void main() {
     expect(element.reaction.name, equals('$observer'));
   });
 
-  testWidgets("Debug mode inserts stacktrace in the reaction's name",
+  testWidgets(
+      "Debug mode inserts the caller's stack frame in the reaction's name",
       (tester) async {
     final observer = LoggingObserver(
       builder: (_) => Container(),
@@ -251,7 +252,19 @@ void main() {
         tester.element(find.byWidget(observer)) as ObserverElementMixin;
 
     expect(element.reaction.name, startsWith('$observer\n'));
-    expect(element.reaction.name, contains('createReaction'));
+    // Note that is the stack frame representation of this testWidgets()
+    // anonymous function.
+    expect(element.reaction.name, contains(' main.<anonymous closure>'));
+  });
+
+  testWidgets(
+      'Observer stack frame lookup gracefully if caller\'s stack frame '
+      'is not found', (tester) async {
+    expect(
+      // Provide an empty stack trace, which will not match
+      Observer.debugFindConstructingStackFrame(StackTrace.fromString('')),
+      null,
+    );
   });
 
   testWidgets('Observer should log when there are no observables in builder',


### PR DESCRIPTION
NOTE: This merged into the wrong branch last time around.

Having been moved into a getName() call, the function failed to serve
its purpose of pointing to a location in user source for easier
debugging.

Determination of the stack frame has also been improved to search for
the first non-constructor, in order to support subclasses of Observable.
This functionality has been tested in the browser and VM.

Fixes #361

MR: constructing_frame2