### PR TITLE
Upgrade our minimum analyzer dependency to 0.38.5

### DIFF
--- a/mobx_codegen/CHANGELOG.md
+++ b/mobx_codegen/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.0
+
+- Upgraded our `analyzer` dependency's minimum version to **0.38.5** in order to
+  workaround a bug where collection types would resolve to dynamic
+
 ## 0.3.13
 
 - Fixes the extraction of generic return-types which have nested generic type arguments, eg: `Future<List<User>>`

--- a/mobx_codegen/lib/mobx_codegen.dart
+++ b/mobx_codegen/lib/mobx_codegen.dart
@@ -2,4 +2,4 @@ library mobx_codegen;
 
 export 'src/mobx_codegen_base.dart';
 
-const version = '0.3.13';
+const version = '0.4.0';

--- a/mobx_codegen/pubspec.yaml
+++ b/mobx_codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobx_codegen
 description: Code generator for MobX that adds support for annotating your code with @observable, @computed, @action and also creating Store classes. Stores can be created with a mixin or @store.
-version: 0.3.13
+version: 0.4.0
 
 homepage: https://github.com/mobxjs/mobx.dart
 
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.2.0 <3.0.0'
 
 dependencies:
-  analyzer: '>=0.36.3 <0.40.0'
+  analyzer: '>=0.38.5 <0.40.0'
   build: ^1.1.4
   meta: ^1.1.0
   mobx: ^0.4.0


### PR DESCRIPTION
Analyzer versions prior to 0.38.5 were failing to resolve certain dart:core and dart:async types, and as such they were being written to generated code as dynamic.

Fixes #367