### PR TITLE
Remove const instance for better coverage

### DIFF
--- a/flutter_mobx/test/flutter_mobx_test.dart
+++ b/flutter_mobx/test/flutter_mobx_test.dart
@@ -296,7 +296,9 @@ void main() {
     expect(find.byType(Container), findsOneWidget);
   });
   testWidgets('StatefulObserverWidget can be subclassed', (tester) async {
-    await tester.pumpWidget(const ConstStatefulObserver());
+    // Ignore the lack of a `const` so that coverage hits the line
+    // ignore: prefer_const_constructors
+    await tester.pumpWidget(ConstStatefulObserver());
 
     expect(find.byType(Container), findsOneWidget);
   });


### PR DESCRIPTION
Const constructors are run during the build, not at runtime, which means using them in tests prevents code coverage from hitting their lines.