### PR TITLE
Ignore another analyzer deprecation

### DIFF
--- a/mobx_codegen/lib/src/type_names.dart
+++ b/mobx_codegen/lib/src/type_names.dart
@@ -96,6 +96,10 @@ class LibraryScopedNameFinder {
             type is TypeParameterType ||
             // If the type lives in this library, no prefix necessary
             typeElement.library == library) {
+      // TODO(shyndman): This ignored deprecation can be removed when we
+      // increase the analyzer dependency's lower bound to 0.39.2, and
+      // migrate to using `DartType.getDisplayString`.
+      // ignore: deprecated_member_use
       return type.displayName;
     }
 


### PR DESCRIPTION
The analyzer 0.39.3 update was causing our latest builds to break, because of a new deprecation to `DartType.displayName`.

I updated #354 as a reminder to remove it when we upgrade our dependencies.