### PR TITLE
WIP: Configure mobx_codegen to use the Flutter image in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
       - run: tool/circle_run.sh
 
   build_mobx_codegen:
-    executor: dart_sdk_image
+    executor: flutter_sdk_image
     environment:
       - FLUTTER: false
       - PACKAGE: mobx_codegen

--- a/tool/circle_run.sh
+++ b/tool/circle_run.sh
@@ -4,6 +4,9 @@ set -o errexit
 set -o nounset
 set -o xtrace
 
+# Setup PATH for this subshell
+echo "import 'dart:io'; void main() { print(Platform.version); }" >> version.dart && dart version.dart
+
 cd $PACKAGE
 
 # Print the dart version, in case we need it for bug reports


### PR DESCRIPTION
In order to introduce tests that include `dart:ui` types, it's necessary that we run using the `dart` binary provided by Flutter.

MR: codegen_flutter_ci