### PR TITLE
Fix naming of tracking function argument in reaction

### DIFF
--- a/docs/src/api/reaction.mdx
+++ b/docs/src/api/reaction.mdx
@@ -47,10 +47,10 @@ dispose();
 
 ## reaction
 
-### `ReactionDisposer reaction<T>(T Function(Reaction) predicate, void Function(T) effect)`
+### `ReactionDisposer reaction<T>(T Function(Reaction) fn, void Function(T) effect)`
 
-Monitors the observables used inside the `predicate()` function and runs the `effect()` when
-the predicate returns a different value. Only the observables inside `predicate()` are tracked.
+Monitors the observables used inside the `fn()` tracking function and runs the `effect()` when
+the tracking function returns a different value. Only the observables inside `fn()` are tracked.
 
 ```dart
 import 'package:mobx/mobx.dart';

--- a/docs/src/core-concepts.mdx
+++ b/docs/src/core-concepts.mdx
@@ -191,10 +191,10 @@ dispose();
 // Hello MobX
 ```
 
-**`ReactionDisposer reaction<T>(T Function(Reaction) predicate, void Function(T) effect)`**
+**`ReactionDisposer reaction<T>(T Function(Reaction) fn, void Function(T) effect)`**
 
-Monitors the observables used inside the `predicate()` function and runs the `effect()` when
-the predicate returns a different value. Only the observables inside `predicate()` are tracked.
+Monitors the observables used inside the `fn()` function and runs the `effect()` when
+the tracking function returns a different value. Only the observables inside `fn()` are tracked.
 
 ```dart
 import 'package:mobx/mobx.dart';

--- a/mobx/README.md
+++ b/mobx/README.md
@@ -221,10 +221,10 @@ dispose();
 // Hello MobX
 ```
 
-**`ReactionDisposer reaction<T>(T Function(Reaction) predicate, void Function(T) effect)`**
+**`ReactionDisposer reaction<T>(T Function(Reaction) fn, void Function(T) effect)`**
 
-Monitors the observables used inside the `predicate()` function and runs the `effect()` when
-the predicate returns a different value. Only the observables inside `predicate()` are tracked.
+Monitors the observables used inside the `fn()` function and runs the `effect()` when
+the `fn()` function returns a different value. Only the observables inside `fn()` are tracked.
 
 ```dart
 import 'package:mobx/mobx.dart';

--- a/mobx/lib/src/api/reaction.dart
+++ b/mobx/lib/src/api/reaction.dart
@@ -31,28 +31,27 @@ ReactionDisposer autorun(Function(Reaction) fn,
     createAutorun(context ?? mainContext, fn,
         name: name, delay: delay, onError: onError);
 
-/// Executes the [predicate] function and tracks the observables used in it. Returns
+/// Executes the [fn] function and tracks the observables used in it. Returns
 /// a function to dispose the reaction.
 ///
-/// The [predicate] is supposed to return a value of type T. When it changes, the
+/// The [fn] is supposed to return a value of type T. When it changes, the
 /// [effect] function is executed.
 ///
-/// *Note*: Only the [predicate] function is tracked and not the [effect].
+/// *Note*: Only the [fn] function is tracked and not the [effect].
 ///
 /// You can also pass in an optional [name], a debouncing [delay] in milliseconds. Use
 /// [fireImmediately] if you want to invoke the effect immediately without waiting for
-/// the [predicate] to change its value. It is possible to define a custom [equals] function
-/// to override the default comparison for the value returned by [predicate], to have fined
+/// the [fn] to change its value. It is possible to define a custom [equals] function
+/// to override the default comparison for the value returned by [fn], to have fined
 /// grained control over when the reactions should run.
-ReactionDisposer reaction<T>(
-        T Function(Reaction) predicate, void Function(T) effect,
+ReactionDisposer reaction<T>(T Function(Reaction) fn, void Function(T) effect,
         {String name,
         int delay,
         bool fireImmediately,
         EqualityComparator<T> equals,
         ReactiveContext context,
         void Function(Object, Reaction) onError}) =>
-    createReaction(context ?? mainContext, predicate, effect,
+    createReaction(context ?? mainContext, fn, effect,
         name: name,
         delay: delay,
         equals: equals,

--- a/mobx/lib/src/core/reaction_helper.dart
+++ b/mobx/lib/src/core/reaction_helper.dart
@@ -65,8 +65,8 @@ ReactionDisposer createAutorun(
 }
 
 /// An internal helper function to create a [reaction]
-ReactionDisposer createReaction<T>(ReactiveContext context,
-    T Function(Reaction) predicate, void Function(T) effect,
+ReactionDisposer createReaction<T>(
+    ReactiveContext context, T Function(Reaction) fn, void Function(T) effect,
     {String name,
     int delay,
     bool fireImmediately,
@@ -93,7 +93,7 @@ ReactionDisposer createReaction<T>(ReactiveContext context,
     var changed = false;
 
     rxn.track(() {
-      final nextValue = predicate(rxn);
+      final nextValue = fn(rxn);
 
       // Use the equality-comparator if provided
       final isEqual =

--- a/mobx/test/autorun_test.dart
+++ b/mobx/test/autorun_test.dart
@@ -99,7 +99,7 @@ void main() {
       dispose();
     });
 
-    test('with pre-mature disposal in predicate', () {
+    test('with pre-mature disposal in tracking function', () {
       final x = Observable(10);
 
       final d = autorun((reaction) {

--- a/mobx/test/reaction_test.dart
+++ b/mobx/test/reaction_test.dart
@@ -89,7 +89,7 @@ void main() {
       fakeAsync((async) {
         x.value = 11;
 
-        // Even though predicate has changed, effect should not be executed
+        // Even though tracking function has changed, effect should not be executed
         expect(executed, isFalse);
         async.elapse(const Duration(milliseconds: 500));
         expect(
@@ -127,7 +127,7 @@ void main() {
         // Effect should be executed, as we are forcing an immediate change even though there is a delay
         expect(executed, isTrue);
 
-        x.value = 11; // predicate goes from false -> true
+        x.value = 11; // tracking function goes from false -> true
 
         executed = false;
         async.elapse(const Duration(milliseconds: 500));
@@ -139,7 +139,7 @@ void main() {
         expect(executed, isTrue);
 
         executed = false;
-        // predicate goes from true -> false, but effect should not run for next 1s
+        // tracking function goes from true -> false, but effect should not run for next 1s
         x.value = 9;
 
         expect(executed, isFalse);
@@ -151,7 +151,7 @@ void main() {
       });
     });
 
-    test('with pre-mature disposal in predicate', () {
+    test('with pre-mature disposal in tracking function', () {
       final x = Observable(10);
       var executed = false;
 
@@ -175,7 +175,7 @@ void main() {
       d();
     });
 
-    test('fires onError on exception inside predicate', () {
+    test('fires onError on exception inside tracking function', () {
       var thrown = false;
       final dispose = reaction(
           (_) {


### PR DESCRIPTION
Noticed that the argument in `reaction` was named as `predicate` when it doesn't return a boolean value. Changed this to `fn` though we may want to change this something else. Alternatives I can think of are `trackingFunction`/`trackingFn` or `dataFunction`/`dataFn`

Sidenote: suggest agreeing on a standard in the API docs. I noticed there are cases where functions are referred to as `<function>` and other places use `<function>()`. I would suggest the former and it's also the approach used in the Flutter docs


