### PR TITLE
Fix @observable generic types when using import aliases

### DIFF
--- a/mobx_codegen/pubspec.yaml
+++ b/mobx_codegen/pubspec.yaml
@@ -16,8 +16,6 @@ dependencies:
   source_gen: ^0.9.4
 
 dev_dependencies:
-#  flutter:
-#    sdk: flutter
   build_runner: ^1.7.2
   build_test: ^0.10.9
   logging: ^0.11.3
@@ -25,6 +23,3 @@ dev_dependencies:
   test: ^1.9.4
   test_coverage:
     git: https://github.com/shyndman/test-coverage
-
-#flutter:
-#  uses-material-design: true

--- a/mobx_codegen/test/data/valid_generic_store_input.dart
+++ b/mobx_codegen/test/data/valid_generic_store_input.dart
@@ -9,4 +9,7 @@ class Item<A extends num> = _Item<A> with _$Item<A>;
 abstract class _Item<T extends num> with Store {
   @observable
   T value;
+
+  @observable
+  List<T> values;
 }

--- a/mobx_codegen/test/data/valid_generic_store_output.dart
+++ b/mobx_codegen/test/data/valid_generic_store_output.dart
@@ -15,4 +15,21 @@ mixin _$Item<T extends num> on _Item<T>, Store {
       _$valueAtom.reportChanged();
     }, _$valueAtom, name: '${_$valueAtom.name}_set');
   }
+
+  final _$valuesAtom = Atom(name: '_Item.values');
+
+  @override
+  List<T> get values {
+    _$valuesAtom.context.enforceReadPolicy(_$valuesAtom);
+    _$valuesAtom.reportObserved();
+    return super.values;
+  }
+
+  @override
+  set values(List<T> value) {
+    _$valuesAtom.context.conditionallyRunInAction(() {
+      super.values = value;
+      _$valuesAtom.reportChanged();
+    }, _$valuesAtom, name: '${_$valuesAtom.name}_set');
+  }
 }

--- a/mobx_codegen/test/data/valid_import_prefixed_input.dart
+++ b/mobx_codegen/test/data/valid_import_prefixed_input.dart
@@ -7,22 +7,41 @@ import 'package:mobx/mobx.dart';
 
 part 'generator_sample.g.dart';
 
-class User = UserBase with _$User;
+class User<T extends io.Process> = UserBase<T> with _$User<T>;
 
-abstract class UserBase with Store {
+abstract class UserBase<T extends io.Process> with Store {
   UserBase();
+
+  @observable
+  List<String> names;
+
+  @observable
+  List<io.File> files;
+
+  @observable
+  List<T> processes;
 
   @observable
   io.File biography;
 
+  // This should output the type's constraint, prefixed
   @observable
-  User friend;
+  User friendWithImplicitTypeArgument;
 
   @observable
-  void Function(io.File, {io.File another}) callback;
+  User<T> friendWithExplicitTypeArgument;
+
+  @observable
+  void Function(io.File, {T another}) callback;
 
   @observable
   io.File Function(String, [int, io.File]) callback2;
+
+  @observable
+  ValueCallback<io.Process> localTypedefCallback;
+
+  @observable
+  io.BadCertificateCallback prefixedTypedefCallback;
 
   @computed
   io.File get biographyNotes => io.File('${biography.path}.notes');
@@ -41,3 +60,5 @@ abstract class UserBase with Store {
     yield directory;
   }
 }
+
+typedef ValueCallback<T> = void Function(T);

--- a/mobx_codegen/test/data/valid_import_prefixed_output.dart
+++ b/mobx_codegen/test/data/valid_import_prefixed_output.dart
@@ -1,10 +1,61 @@
-mixin _$User on UserBase, Store {
+mixin _$User<T extends io.Process> on UserBase<T>, Store {
   Computed<io.File> _$biographyNotesComputed;
 
   @override
   io.File get biographyNotes => (_$biographyNotesComputed ??=
           Computed<io.File>(() => super.biographyNotes))
       .value;
+
+  final _$namesAtom = Atom(name: 'UserBase.names');
+
+  @override
+  List<String> get names {
+    _$namesAtom.context.enforceReadPolicy(_$namesAtom);
+    _$namesAtom.reportObserved();
+    return super.names;
+  }
+
+  @override
+  set names(List<String> value) {
+    _$namesAtom.context.conditionallyRunInAction(() {
+      super.names = value;
+      _$namesAtom.reportChanged();
+    }, _$namesAtom, name: '${_$namesAtom.name}_set');
+  }
+
+  final _$filesAtom = Atom(name: 'UserBase.files');
+
+  @override
+  List<io.File> get files {
+    _$filesAtom.context.enforceReadPolicy(_$filesAtom);
+    _$filesAtom.reportObserved();
+    return super.files;
+  }
+
+  @override
+  set files(List<io.File> value) {
+    _$filesAtom.context.conditionallyRunInAction(() {
+      super.files = value;
+      _$filesAtom.reportChanged();
+    }, _$filesAtom, name: '${_$filesAtom.name}_set');
+  }
+
+  final _$processesAtom = Atom(name: 'UserBase.processes');
+
+  @override
+  List<T> get processes {
+    _$processesAtom.context.enforceReadPolicy(_$processesAtom);
+    _$processesAtom.reportObserved();
+    return super.processes;
+  }
+
+  @override
+  set processes(List<T> value) {
+    _$processesAtom.context.conditionallyRunInAction(() {
+      super.processes = value;
+      _$processesAtom.reportChanged();
+    }, _$processesAtom, name: '${_$processesAtom.name}_set');
+  }
 
   final _$biographyAtom = Atom(name: 'UserBase.biography');
 
@@ -23,34 +74,57 @@ mixin _$User on UserBase, Store {
     }, _$biographyAtom, name: '${_$biographyAtom.name}_set');
   }
 
-  final _$friendAtom = Atom(name: 'UserBase.friend');
+  final _$friendWithImplicitTypeArgumentAtom =
+      Atom(name: 'UserBase.friendWithImplicitTypeArgument');
 
   @override
-  User get friend {
-    _$friendAtom.context.enforceReadPolicy(_$friendAtom);
-    _$friendAtom.reportObserved();
-    return super.friend;
+  User<io.Process> get friendWithImplicitTypeArgument {
+    _$friendWithImplicitTypeArgumentAtom.context
+        .enforceReadPolicy(_$friendWithImplicitTypeArgumentAtom);
+    _$friendWithImplicitTypeArgumentAtom.reportObserved();
+    return super.friendWithImplicitTypeArgument;
   }
 
   @override
-  set friend(User value) {
-    _$friendAtom.context.conditionallyRunInAction(() {
-      super.friend = value;
-      _$friendAtom.reportChanged();
-    }, _$friendAtom, name: '${_$friendAtom.name}_set');
+  set friendWithImplicitTypeArgument(User<io.Process> value) {
+    _$friendWithImplicitTypeArgumentAtom.context.conditionallyRunInAction(() {
+      super.friendWithImplicitTypeArgument = value;
+      _$friendWithImplicitTypeArgumentAtom.reportChanged();
+    }, _$friendWithImplicitTypeArgumentAtom,
+        name: '${_$friendWithImplicitTypeArgumentAtom.name}_set');
+  }
+
+  final _$friendWithExplicitTypeArgumentAtom =
+      Atom(name: 'UserBase.friendWithExplicitTypeArgument');
+
+  @override
+  User<T> get friendWithExplicitTypeArgument {
+    _$friendWithExplicitTypeArgumentAtom.context
+        .enforceReadPolicy(_$friendWithExplicitTypeArgumentAtom);
+    _$friendWithExplicitTypeArgumentAtom.reportObserved();
+    return super.friendWithExplicitTypeArgument;
+  }
+
+  @override
+  set friendWithExplicitTypeArgument(User<T> value) {
+    _$friendWithExplicitTypeArgumentAtom.context.conditionallyRunInAction(() {
+      super.friendWithExplicitTypeArgument = value;
+      _$friendWithExplicitTypeArgumentAtom.reportChanged();
+    }, _$friendWithExplicitTypeArgumentAtom,
+        name: '${_$friendWithExplicitTypeArgumentAtom.name}_set');
   }
 
   final _$callbackAtom = Atom(name: 'UserBase.callback');
 
   @override
-  void Function(io.File, {io.File another}) get callback {
+  void Function(io.File, {T another}) get callback {
     _$callbackAtom.context.enforceReadPolicy(_$callbackAtom);
     _$callbackAtom.reportObserved();
     return super.callback;
   }
 
   @override
-  set callback(void Function(io.File, {io.File another}) value) {
+  set callback(void Function(io.File, {T another}) value) {
     _$callbackAtom.context.conditionallyRunInAction(() {
       super.callback = value;
       _$callbackAtom.reportChanged();
@@ -72,6 +146,46 @@ mixin _$User on UserBase, Store {
       super.callback2 = value;
       _$callback2Atom.reportChanged();
     }, _$callback2Atom, name: '${_$callback2Atom.name}_set');
+  }
+
+  final _$localTypedefCallbackAtom =
+      Atom(name: 'UserBase.localTypedefCallback');
+
+  @override
+  ValueCallback<io.Process> get localTypedefCallback {
+    _$localTypedefCallbackAtom.context
+        .enforceReadPolicy(_$localTypedefCallbackAtom);
+    _$localTypedefCallbackAtom.reportObserved();
+    return super.localTypedefCallback;
+  }
+
+  @override
+  set localTypedefCallback(ValueCallback<io.Process> value) {
+    _$localTypedefCallbackAtom.context.conditionallyRunInAction(() {
+      super.localTypedefCallback = value;
+      _$localTypedefCallbackAtom.reportChanged();
+    }, _$localTypedefCallbackAtom,
+        name: '${_$localTypedefCallbackAtom.name}_set');
+  }
+
+  final _$prefixedTypedefCallbackAtom =
+      Atom(name: 'UserBase.prefixedTypedefCallback');
+
+  @override
+  io.BadCertificateCallback get prefixedTypedefCallback {
+    _$prefixedTypedefCallbackAtom.context
+        .enforceReadPolicy(_$prefixedTypedefCallbackAtom);
+    _$prefixedTypedefCallbackAtom.reportObserved();
+    return super.prefixedTypedefCallback;
+  }
+
+  @override
+  set prefixedTypedefCallback(io.BadCertificateCallback value) {
+    _$prefixedTypedefCallbackAtom.context.conditionallyRunInAction(() {
+      super.prefixedTypedefCallback = value;
+      _$prefixedTypedefCallbackAtom.reportChanged();
+    }, _$prefixedTypedefCallbackAtom,
+        name: '${_$prefixedTypedefCallbackAtom.name}_set');
   }
 
   @override


### PR DESCRIPTION
There were a number of bugs with the previous implementation of the `LibraryScopedNameFinder`. This resolves them, as well as ensures that a single code path is followed whether or not the analyzed source code contains named imports, reducing the potential for future bugs.

The following bugs have been corrected when using named imports:
* Missing type arguments on classes
* Missing type arguments on function typedefs
* Missing prefixes from imported typedefs
* Missing prefixes from implicit type argument bounds

Fixes #367