### PR TITLE
Upgrade build_resolvers to 1.3.2

### DIFF
--- a/mobx_codegen/CHANGELOG.md
+++ b/mobx_codegen/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.4.2
 
 - Upgraded the `build_resolvers` dependency to 1.3.2, which fixes issues with certain
-  versions of Dart being unable to resolve dart:ui types.
+  versions of Dart being unable to resolve `dart:ui` types.
 
 ## 0.4.1+2
 

--- a/mobx_codegen/CHANGELOG.md
+++ b/mobx_codegen/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.2
+
+- Upgraded the `build_resolvers` dependency to 1.3.2, which fixes issues with certain
+  versions of Dart being unable to resolve dart:ui types.
+
 ## 0.4.1+2
 
 - Going back to original `test_coverage` package

--- a/mobx_codegen/lib/mobx_codegen.dart
+++ b/mobx_codegen/lib/mobx_codegen.dart
@@ -2,4 +2,4 @@ library mobx_codegen;
 
 export 'src/mobx_codegen_base.dart';
 
-const version = '0.4.1+2';
+const version = '0.4.2';

--- a/mobx_codegen/pubspec.yaml
+++ b/mobx_codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobx_codegen
 description: Code generator for MobX that adds support for annotating your code with @observable, @computed, @action and also creating Store classes.
-version: 0.4.1+2
+version: 0.4.2
 
 homepage: https://github.com/mobxjs/mobx.dart
 
@@ -10,6 +10,7 @@ environment:
 dependencies:
   analyzer: ">=0.38.5 <0.40.0"
   build: ^1.1.4
+  build_resolvers: ^1.3.2
   meta: ^1.1.0
   mobx: ^0.4.0
   path: ^1.6.2


### PR DESCRIPTION
This resolves the `dart:ui` type resolution problems we've been seeing with some versions of Flutter.

Fixes #381