### PR TITLE
Fixes two links to mobx-dart on netlify

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Language: [English](README.md) | [Português](translation/pt-BR/README.md)
 [![Build Status](https://github.com/mobxjs/mobx.dart/workflows/Build/badge.svg)](https://github.com/mobxjs/mobx.dart/actions)
 [![Publish](https://github.com/mobxjs/mobx.dart/workflows/Publish/badge.svg)](https://github.com/mobxjs/mobx.dart/actions)
 [![Coverage Status](https://img.shields.io/codecov/c/github/mobxjs/mobx.dart/master.svg)](https://codecov.io/gh/mobxjs/mobx.dart)
-[![Netlify Status](https://api.netlify.com/api/v1/badges/05330d31-0411-4aac-a278-76615bcaff9e/deploy-status)](https://app.netlify.com/sites/mobx-dart/deploys)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/05330d31-0411-4aac-a278-76615bcaff9e/deploy-status)](https://app.netlify.com/sites/mobx/deploys)
 
 [![Join the chat at https://discord.gg/dNHY52k](https://img.shields.io/badge/Chat-on%20Discord-lightgrey?style=flat&logo=discord)](https://discord.gg/dNHY52k)
 
@@ -58,7 +58,7 @@ We are very thankful to our sponsors to make us part of their _Open Source Softw
 
 ### Get Started
 
-Follow along with the [Getting Started guide on the MobX.dart Website](https://mobx-dart.netlify.com/getting-started).
+Follow along with the [Getting Started guide on the MobX.dart Website](https://mobx.netlify.com/getting-started).
 
 ### Go deep
 


### PR DESCRIPTION
The netlify deploy is on mobx.netlify.com; there were two links to mobx-dart still in the readme.