### PR TITLE
Fix a typo in Computed Observables section

### DIFF
--- a/docs/src/core-concepts.mdx
+++ b/docs/src/core-concepts.mdx
@@ -97,7 +97,7 @@ Such _derived state_, that depends on _core-state_ or _other derived-state_ is c
 ```dart
 import 'package:mobx/mobx.dart';
 
-part 'counter.g.dart';
+part 'contact.g.dart';
 
 class Contact = ContactBase with _$Contact;
 


### PR DESCRIPTION
I think that in the example of Computed Observables the class Contact as part with name "contact.g.dart" and not "counter.g.dart".
Maybe it's a typo from the previuos example.