### PR TITLE
Simpler coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Run tests
         working-directory: ${{ matrix.package }}
-        run: pub run test_coverage
+        run: ./tool/coverage.sh
 
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Run tests
         working-directory: ${{ matrix.package }}
-        run: ./tool/coverage.sh
+        run: ../tool/coverage.sh
 
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ pubspec.lock
 node_modules
 .idea
 *.log
+*.out
 local.properties
 .vscode/settings.json
 local.properties

--- a/mobx/pubspec.yaml
+++ b/mobx/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   meta: ^1.1.6
 
 dev_dependencies:
+  coverage: ^0.13.9
   fake_async: ^1.0.1
   mockito: ^4.1.1
   test: ^1.9.4
-  test_coverage: ^0.4.1

--- a/mobx/test/all_tests.dart
+++ b/mobx/test/all_tests.dart
@@ -1,0 +1,62 @@
+import 'action_controller_test.dart' as action_controller_test;
+import 'action_test.dart' as action_test;
+import 'annotations_test.dart' as annotations_test;
+import 'async_action_test.dart' as async_action_test;
+import 'autorun_test.dart' as autorun_test;
+import 'bug_related_test.dart' as bug_related_test;
+import 'computed_test.dart' as computed_test;
+import 'context_test.dart' as context_test;
+import 'exceptions_test.dart' as exceptions_test;
+import 'extensions/observable_future_extension_test.dart'
+    as extensions_observable_future_extension_test;
+import 'extensions/observable_list_extension_test.dart'
+    as extensions_observable_list_extension_test;
+import 'extensions/observable_map_extension_test.dart'
+    as extensions_observable_map_extension_test;
+import 'extensions/observable_set_extension_test.dart'
+    as extensions_observable_set_extension_test;
+import 'extensions/observable_stream_extension_test.dart'
+    as extensions_observable_stream_extension_test;
+import 'intercept_test.dart' as intercept_test;
+import 'listenable_test.dart' as listenable_test;
+import 'observable_future_test.dart' as observable_future_test;
+import 'observable_list_test.dart' as observable_list_test;
+import 'observable_map_test.dart' as observable_map_test;
+import 'observable_set_test.dart' as observable_set_test;
+import 'observable_stream_test.dart' as observable_stream_test;
+import 'observable_test.dart' as observable_test;
+import 'observable_value_test.dart' as observable_value_test;
+import 'observe_test.dart' as observe_test;
+import 'reaction_test.dart' as reaction_test;
+import 'reactive_policies_test.dart' as reactive_policies_test;
+import 'when_test.dart' as when_test;
+
+void main() {
+  action_test.main();
+  bug_related_test.main();
+  listenable_test.main();
+  computed_test.main();
+  observable_future_test.main();
+  observable_map_test.main();
+  intercept_test.main();
+  exceptions_test.main();
+  context_test.main();
+  extensions_observable_map_extension_test.main();
+  extensions_observable_stream_extension_test.main();
+  extensions_observable_set_extension_test.main();
+  extensions_observable_list_extension_test.main();
+  extensions_observable_future_extension_test.main();
+  observe_test.main();
+  reaction_test.main();
+  observable_set_test.main();
+  observable_test.main();
+  when_test.main();
+  reactive_policies_test.main();
+  annotations_test.main();
+  observable_value_test.main();
+  autorun_test.main();
+  async_action_test.main();
+  observable_list_test.main();
+  action_controller_test.main();
+  observable_stream_test.main();
+}

--- a/mobx_codegen/pubspec.yaml
+++ b/mobx_codegen/pubspec.yaml
@@ -17,9 +17,9 @@ dependencies:
   source_gen: ^0.9.4
 
 dev_dependencies:
+  coverage: ^0.13.9
   build_runner: ^1.7.2
   build_test: ^0.10.9
   logging: ^0.11.3
   mockito: ^4.0.0
   test: ^1.9.4
-  test_coverage: ^0.4.1

--- a/mobx_codegen/test/all_tests.dart
+++ b/mobx_codegen/test/all_tests.dart
@@ -1,0 +1,15 @@
+import 'errors_test.dart' as errors_test;
+import 'generator_usage_test.dart' as generator_usage_test;
+import 'invalid_annotations_test.dart' as invalid_annotations_test;
+import 'mobx_codegen_test.dart' as mobx_codegen_test;
+import 'templates_test.dart' as templates_test;
+import 'util_test.dart' as util_test;
+
+void main() {
+  generator_usage_test.main();
+  errors_test.main();
+  invalid_annotations_test.main();
+  templates_test.main();
+  mobx_codegen_test.main();
+  util_test.main();
+}

--- a/tool/coverage.sh
+++ b/tool/coverage.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Fast fail the script on failures.
+set -e
+
+OBS_PORT=9292
+echo "Collecting coverage on port $OBS_PORT..."
+
+# Start tests in one VM.
+echo "Starting tests..."
+dart \
+  --disable-service-auth-codes \
+  --pause-isolates-on-exit \
+  --enable_asserts \
+  --enable-vm-service=$OBS_PORT \
+  test/all_tests.dart &
+
+# Run the coverage collector to generate the JSON coverage report.
+echo "Collecting coverage..."
+nohup pub run coverage:collect_coverage \
+  --port=$OBS_PORT \
+  --out=coverage/coverage.json \
+  --wait-paused \
+  --resume-isolates
+
+echo "Generating LCOV report..."
+pub run coverage:format_coverage \
+  --lcov \
+  --in=coverage/coverage.json \
+  --out=coverage/lcov.info \
+  --packages=.packages \
+  --report-on=lib


### PR DESCRIPTION
This removes the dependency on `test_coverage` and relies on the base package `coverage` to all the work of collecting coverage. This appears to be more reliable on CI.