### PR TITLE
Add map function on Future extension

### DIFF
--- a/mobx/lib/src/api/extensions/observable_future_extension.dart
+++ b/mobx/lib/src/api/extensions/observable_future_extension.dart
@@ -4,4 +4,7 @@ part of '../extensions.dart';
 extension ObservableFutureExtension<T> on Future<T> {
   ObservableFuture<T> asObservable({ReactiveContext context, String name}) =>
       ObservableFuture<T>(this, context: context, name: name);
+  /// Transform the future value into other type after complete future
+  /// Useful to transform list to ObservableList in requests
+  Future<E> map<E>(Future<E> Function(Future<T>) transform) => transform(this);
 }


### PR DESCRIPTION
Transform the future value into another type after complete future. Useful to transform List to ObservableList in requests