### PR TITLE
Add a throwReactionErrors setup task.

### DIFF
--- a/mobx/test/action_controller_test.dart
+++ b/mobx/test/action_controller_test.dart
@@ -9,6 +9,7 @@ class MockDerivation extends Mock implements Derivation {}
 
 void main() {
   turnOffWritePolicy();
+  testSetup();
 
   group('ActionController', () {
     test('can be created with both null context and name', () {

--- a/mobx/test/action_controller_test.dart
+++ b/mobx/test/action_controller_test.dart
@@ -8,7 +8,6 @@ import 'util.dart';
 class MockDerivation extends Mock implements Derivation {}
 
 void main() {
-  turnOffWritePolicy();
   testSetup();
 
   group('ActionController', () {

--- a/mobx/test/action_test.dart
+++ b/mobx/test/action_test.dart
@@ -7,6 +7,7 @@ import 'util.dart';
 
 void main() {
   turnOffWritePolicy();
+  testSetup();
 
   group('Action', () {
     test('basics work', () {

--- a/mobx/test/action_test.dart
+++ b/mobx/test/action_test.dart
@@ -6,7 +6,6 @@ import 'shared_mocks.dart';
 import 'util.dart';
 
 void main() {
-  turnOffWritePolicy();
   testSetup();
 
   group('Action', () {

--- a/mobx/test/annotations_test.dart
+++ b/mobx/test/annotations_test.dart
@@ -1,7 +1,11 @@
 import 'package:mobx/mobx.dart';
 import 'package:test/test.dart';
 
+import 'util.dart';
+
 void main() {
+  testSetup();
+
   test('annotations are defined', () {
     expect(observable, isNotNull);
     expect(computed, isNotNull);

--- a/mobx/test/async_action_test.dart
+++ b/mobx/test/async_action_test.dart
@@ -1,9 +1,13 @@
 import 'package:mobx/mobx.dart';
 import 'package:test/test.dart';
 
+import 'util.dart';
+
 Future sleep(int ms) => Future.delayed(Duration(milliseconds: ms));
 
 void main() {
+  testSetup();
+
   setUp(() {
     mainContext.config =
         ReactiveConfig(writePolicy: ReactiveWritePolicy.always);

--- a/mobx/test/autorun_test.dart
+++ b/mobx/test/autorun_test.dart
@@ -9,6 +9,7 @@ import 'util.dart';
 
 void main() {
   turnOffWritePolicy();
+  testSetup();
 
   group('autorun()', () {
     test('basics work', () {

--- a/mobx/test/autorun_test.dart
+++ b/mobx/test/autorun_test.dart
@@ -8,7 +8,6 @@ import 'shared_mocks.dart';
 import 'util.dart';
 
 void main() {
-  turnOffWritePolicy();
   testSetup();
 
   group('autorun()', () {

--- a/mobx/test/bug_related_test.dart
+++ b/mobx/test/bug_related_test.dart
@@ -5,6 +5,7 @@ import 'util.dart';
 
 void main() {
   turnOffWritePolicy();
+  testSetup();
 
   test('reaction should work with a map operation on list. Github Issue #211',
       () {

--- a/mobx/test/bug_related_test.dart
+++ b/mobx/test/bug_related_test.dart
@@ -4,7 +4,6 @@ import 'package:test/test.dart';
 import 'util.dart';
 
 void main() {
-  turnOffWritePolicy();
   testSetup();
 
   test('reaction should work with a map operation on list. Github Issue #211',

--- a/mobx/test/computed_test.dart
+++ b/mobx/test/computed_test.dart
@@ -8,6 +8,7 @@ import 'util.dart';
 
 void main() {
   turnOffWritePolicy();
+  throwReactionErrors();
 
   group('Computed', () {
     test('basics work', () {

--- a/mobx/test/computed_test.dart
+++ b/mobx/test/computed_test.dart
@@ -7,7 +7,6 @@ import 'shared_mocks.dart';
 import 'util.dart';
 
 void main() {
-  turnOffWritePolicy();
   testSetup();
 
   group('Computed', () {

--- a/mobx/test/computed_test.dart
+++ b/mobx/test/computed_test.dart
@@ -8,7 +8,7 @@ import 'util.dart';
 
 void main() {
   turnOffWritePolicy();
-  throwReactionErrors();
+  testSetup();
 
   group('Computed', () {
     test('basics work', () {

--- a/mobx/test/context_test.dart
+++ b/mobx/test/context_test.dart
@@ -6,7 +6,6 @@ import 'shared_mocks.dart';
 import 'util.dart';
 
 void main() {
-  turnOffWritePolicy();
   testSetup(throwReactionErrors: false);
 
   group('ReactiveContext', () {

--- a/mobx/test/context_test.dart
+++ b/mobx/test/context_test.dart
@@ -7,6 +7,7 @@ import 'util.dart';
 
 void main() {
   turnOffWritePolicy();
+  testSetup(throwReactionErrors: false);
 
   group('ReactiveContext', () {
     test('comes with default config', () {

--- a/mobx/test/exceptions_test.dart
+++ b/mobx/test/exceptions_test.dart
@@ -1,7 +1,11 @@
 import 'package:mobx/mobx.dart';
 import 'package:test/test.dart';
 
+import 'util.dart';
+
 void main() {
+  testSetup();
+
   test('MobXException has the right toString()', () {
     final ex = MobXException('Test Exception');
 

--- a/mobx/test/extensions/observable_future_extension_test.dart
+++ b/mobx/test/extensions/observable_future_extension_test.dart
@@ -7,7 +7,6 @@ import 'package:test/test.dart';
 import '../util.dart';
 
 void main() {
-  turnOffWritePolicy();
   testSetup();
 
   group('ObservableFutureExtension', () {

--- a/mobx/test/extensions/observable_future_extension_test.dart
+++ b/mobx/test/extensions/observable_future_extension_test.dart
@@ -8,6 +8,7 @@ import '../util.dart';
 
 void main() {
   turnOffWritePolicy();
+  testSetup();
 
   group('ObservableFutureExtension', () {
     test('Transform Future in ObservableFuture', () async {

--- a/mobx/test/extensions/observable_list_extension_test.dart
+++ b/mobx/test/extensions/observable_list_extension_test.dart
@@ -5,7 +5,6 @@ import 'package:test/test.dart';
 import '../util.dart';
 
 void main() {
-  turnOffWritePolicy();
   testSetup();
 
   group('ObservableListExtension', () {

--- a/mobx/test/extensions/observable_list_extension_test.dart
+++ b/mobx/test/extensions/observable_list_extension_test.dart
@@ -6,6 +6,7 @@ import '../util.dart';
 
 void main() {
   turnOffWritePolicy();
+  testSetup();
 
   group('ObservableListExtension', () {
     test('Transform List in ObservableList', () async {

--- a/mobx/test/extensions/observable_map_extension_test.dart
+++ b/mobx/test/extensions/observable_map_extension_test.dart
@@ -6,6 +6,7 @@ import '../util.dart';
 
 void main() {
   turnOffWritePolicy();
+  testSetup();
 
   group('ObservableMapExtension', () {
     test('Transform Map in ObservableMap', () async {

--- a/mobx/test/extensions/observable_map_extension_test.dart
+++ b/mobx/test/extensions/observable_map_extension_test.dart
@@ -5,7 +5,6 @@ import 'package:test/test.dart';
 import '../util.dart';
 
 void main() {
-  turnOffWritePolicy();
   testSetup();
 
   group('ObservableMapExtension', () {

--- a/mobx/test/extensions/observable_set_extension_test.dart
+++ b/mobx/test/extensions/observable_set_extension_test.dart
@@ -5,7 +5,6 @@ import 'package:test/test.dart';
 import '../util.dart';
 
 void main() {
-  turnOffWritePolicy();
   testSetup();
 
   group('ObservableSetExtension', () {

--- a/mobx/test/extensions/observable_set_extension_test.dart
+++ b/mobx/test/extensions/observable_set_extension_test.dart
@@ -6,6 +6,7 @@ import '../util.dart';
 
 void main() {
   turnOffWritePolicy();
+  testSetup();
 
   group('ObservableSetExtension', () {
     test('Transform Set in ObservableSet', () async {

--- a/mobx/test/extensions/observable_stream_extension_test.dart
+++ b/mobx/test/extensions/observable_stream_extension_test.dart
@@ -8,6 +8,7 @@ import '../util.dart';
 
 void main() {
   turnOffWritePolicy();
+  testSetup();
 
   group('ObservableStreamExtension', () {
     test('Transform Stream in ObservableStream', () async {

--- a/mobx/test/extensions/observable_stream_extension_test.dart
+++ b/mobx/test/extensions/observable_stream_extension_test.dart
@@ -7,7 +7,6 @@ import 'package:test/test.dart';
 import '../util.dart';
 
 void main() {
-  turnOffWritePolicy();
   testSetup();
 
   group('ObservableStreamExtension', () {

--- a/mobx/test/intercept_test.dart
+++ b/mobx/test/intercept_test.dart
@@ -6,7 +6,6 @@ import 'shared_mocks.dart';
 import 'util.dart';
 
 void main() {
-  turnOffWritePolicy();
   testSetup();
 
   group('intercept', () {

--- a/mobx/test/intercept_test.dart
+++ b/mobx/test/intercept_test.dart
@@ -7,6 +7,7 @@ import 'util.dart';
 
 void main() {
   turnOffWritePolicy();
+  testSetup();
 
   group('intercept', () {
     test('basics work', () {

--- a/mobx/test/listenable_test.dart
+++ b/mobx/test/listenable_test.dart
@@ -7,6 +7,7 @@ import 'util.dart';
 
 void main() {
   turnOffWritePolicy();
+  testSetup();
 
   group('Listenable', () {
     test('dispose function removes added listener', () {

--- a/mobx/test/listenable_test.dart
+++ b/mobx/test/listenable_test.dart
@@ -6,7 +6,6 @@ import 'shared_mocks.dart';
 import 'util.dart';
 
 void main() {
-  turnOffWritePolicy();
   testSetup();
 
   group('Listenable', () {

--- a/mobx/test/observable_future_test.dart
+++ b/mobx/test/observable_future_test.dart
@@ -6,7 +6,6 @@ import 'package:test/test.dart';
 import 'util.dart';
 
 void main() {
-  turnOffWritePolicy();
   testSetup();
 
   group('ObservableFuture', () {

--- a/mobx/test/observable_future_test.dart
+++ b/mobx/test/observable_future_test.dart
@@ -7,6 +7,7 @@ import 'util.dart';
 
 void main() {
   turnOffWritePolicy();
+  testSetup();
 
   group('ObservableFuture', () {
     test('generates a name if not given', () {

--- a/mobx/test/observable_list_test.dart
+++ b/mobx/test/observable_list_test.dart
@@ -8,6 +8,7 @@ import 'util.dart';
 
 void main() {
   turnOffWritePolicy();
+  testSetup();
 
   group('ObservableList', () {
     test('generates a name if not given', () {

--- a/mobx/test/observable_list_test.dart
+++ b/mobx/test/observable_list_test.dart
@@ -7,7 +7,6 @@ import 'shared_mocks.dart';
 import 'util.dart';
 
 void main() {
-  turnOffWritePolicy();
   testSetup();
 
   group('ObservableList', () {
@@ -235,8 +234,6 @@ void main() {
     });
 
     group('fires reportObserved() for read-methods', () {
-      turnOffWritePolicy();
-
       <String, Function(ObservableList<int>)>{
         'isEmpty': (_) => _.isEmpty,
         'isNotEmpty': (_) => _.isNotEmpty,
@@ -273,8 +270,6 @@ void main() {
   });
 
   group('fires reportChanged() for write-methods', () {
-    turnOffWritePolicy();
-
     <String, void Function(ObservableList<int>)>{
       'length=': (_) => _.length = 0,
       'last=': (_) => _.last = 100,
@@ -301,8 +296,6 @@ void main() {
   });
 
   group('fires reportObserved() lazily on iterator returning methods', () {
-    turnOffWritePolicy();
-
     <String, Iterable Function(ObservableList<int>)>{
       'map': (_) => _.map((v) => v + 3),
       'expand': (_) => _.expand((v) => [3, 2]),

--- a/mobx/test/observable_map_test.dart
+++ b/mobx/test/observable_map_test.dart
@@ -8,6 +8,7 @@ import 'util.dart';
 
 void main() {
   turnOffWritePolicy();
+  testSetup();
 
   group('MapKeysIterable', () {
     test('length reports observed', () {

--- a/mobx/test/observable_map_test.dart
+++ b/mobx/test/observable_map_test.dart
@@ -7,7 +7,6 @@ import 'shared_mocks.dart';
 import 'util.dart';
 
 void main() {
-  turnOffWritePolicy();
   testSetup();
 
   group('MapKeysIterable', () {

--- a/mobx/test/observable_set_test.dart
+++ b/mobx/test/observable_set_test.dart
@@ -8,6 +8,7 @@ import 'util.dart';
 
 void main() {
   turnOffWritePolicy();
+  testSetup();
 
   group('ObservableSet', () {
     test('generates a name if not given', () {

--- a/mobx/test/observable_set_test.dart
+++ b/mobx/test/observable_set_test.dart
@@ -7,7 +7,6 @@ import 'shared_mocks.dart';
 import 'util.dart';
 
 void main() {
-  turnOffWritePolicy();
   testSetup();
 
   group('ObservableSet', () {

--- a/mobx/test/observable_stream_test.dart
+++ b/mobx/test/observable_stream_test.dart
@@ -7,7 +7,6 @@ import 'package:test/test.dart';
 import 'util.dart';
 
 void main() {
-  turnOffWritePolicy();
   testSetup();
 
   group('ObservableStream', () {

--- a/mobx/test/observable_stream_test.dart
+++ b/mobx/test/observable_stream_test.dart
@@ -8,6 +8,7 @@ import 'util.dart';
 
 void main() {
   turnOffWritePolicy();
+  testSetup();
 
   group('ObservableStream', () {
     test('generates a name if not given', () {

--- a/mobx/test/observable_test.dart
+++ b/mobx/test/observable_test.dart
@@ -6,7 +6,6 @@ import 'shared_mocks.dart';
 import 'util.dart';
 
 void main() {
-  turnOffWritePolicy();
   testSetup();
 
   group('observable<T>', () {

--- a/mobx/test/observable_test.dart
+++ b/mobx/test/observable_test.dart
@@ -7,6 +7,7 @@ import 'util.dart';
 
 void main() {
   turnOffWritePolicy();
+  testSetup();
 
   group('observable<T>', () {
     test('basics work', () {

--- a/mobx/test/observable_value_test.dart
+++ b/mobx/test/observable_value_test.dart
@@ -6,7 +6,6 @@ import 'package:test/test.dart';
 import 'util.dart';
 
 void main() {
-  turnOffWritePolicy();
   testSetup();
 
   group('ObservableValue', () {

--- a/mobx/test/observable_value_test.dart
+++ b/mobx/test/observable_value_test.dart
@@ -7,6 +7,7 @@ import 'util.dart';
 
 void main() {
   turnOffWritePolicy();
+  testSetup();
 
   group('ObservableValue', () {
     test('basics work', () {

--- a/mobx/test/observe_test.dart
+++ b/mobx/test/observe_test.dart
@@ -5,6 +5,7 @@ import 'util.dart';
 
 void main() {
   turnOffWritePolicy();
+  testSetup();
 
   group('observe', () {
     test('works', () {

--- a/mobx/test/observe_test.dart
+++ b/mobx/test/observe_test.dart
@@ -4,7 +4,6 @@ import 'package:test/test.dart';
 import 'util.dart';
 
 void main() {
-  turnOffWritePolicy();
   testSetup();
 
   group('observe', () {

--- a/mobx/test/reaction_test.dart
+++ b/mobx/test/reaction_test.dart
@@ -8,7 +8,6 @@ import 'shared_mocks.dart';
 import 'util.dart';
 
 void main() {
-  turnOffWritePolicy();
   testSetup();
 
   group('Reaction', () {

--- a/mobx/test/reaction_test.dart
+++ b/mobx/test/reaction_test.dart
@@ -9,6 +9,7 @@ import 'util.dart';
 
 void main() {
   turnOffWritePolicy();
+  testSetup();
 
   group('Reaction', () {
     test('basics work', () {

--- a/mobx/test/reactive_policies_test.dart
+++ b/mobx/test/reactive_policies_test.dart
@@ -5,6 +5,7 @@ import 'util.dart';
 
 void main() {
   turnOffWritePolicy();
+  testSetup();
 
   group('when reactive-reads are enforced', () {
     setUp(() {

--- a/mobx/test/reactive_policies_test.dart
+++ b/mobx/test/reactive_policies_test.dart
@@ -4,7 +4,6 @@ import 'package:test/test.dart';
 import 'util.dart';
 
 void main() {
-  turnOffWritePolicy();
   testSetup();
 
   group('when reactive-reads are enforced', () {

--- a/mobx/test/spy_test.dart
+++ b/mobx/test/spy_test.dart
@@ -4,7 +4,6 @@ import 'package:mobx/mobx.dart';
 import 'util.dart';
 
 void main() {
-  turnOffWritePolicy();
   testSetup(throwReactionErrors: false);
 
   group('Spy', () {

--- a/mobx/test/spy_test.dart
+++ b/mobx/test/spy_test.dart
@@ -5,6 +5,7 @@ import 'util.dart';
 
 void main() {
   turnOffWritePolicy();
+  testSetup(throwReactionErrors: false);
 
   group('Spy', () {
     test('spies are disabled by default', () {

--- a/mobx/test/util.dart
+++ b/mobx/test/util.dart
@@ -9,15 +9,22 @@ import 'package:test/test.dart';
 /// order and the error will already have been rethrown.
 /// If you choose to set [throwReactionErrors] to false, failed expectations in observers will
 /// appear to pass!
+///
+/// [turnOffWritePolicy] is true by default.
 void testSetup({
   bool throwReactionErrors = true,
+  bool turnOffWritePolicy = true,
 }) {
   if (throwReactionErrors) {
     setupThrowReactionErrors();
   }
+
+  if (turnOffWritePolicy) {
+    setupTurnOffWritePolicy();
+  }
 }
 
-void turnOffWritePolicy() {
+void setupTurnOffWritePolicy() {
   setUp(() => mainContext.config =
       ReactiveConfig(writePolicy: ReactiveWritePolicy.never));
 

--- a/mobx/test/util.dart
+++ b/mobx/test/util.dart
@@ -1,6 +1,22 @@
 import 'package:mobx/mobx.dart';
 import 'package:test/test.dart';
 
+/// Run boilerplate test setups, with options.
+///
+/// [throwReactionErrors] is true by default, meaning that you will see errors in reactions,
+/// including failed expectations. You may need to turn this off to test other error handlers for
+/// reactions, as any added after this call won't be used, since the handlers are evaluated in
+/// order and the error will already have been rethrown.
+/// If you choose to set [throwReactionErrors] to false, failed expectations in observers will
+/// appear to pass!
+void testSetup({
+  bool throwReactionErrors = true,
+}) {
+  if (throwReactionErrors) {
+    setupThrowReactionErrors();
+  }
+}
+
 void turnOffWritePolicy() {
   setUp(() => mainContext.config =
       ReactiveConfig(writePolicy: ReactiveWritePolicy.never));
@@ -9,7 +25,7 @@ void turnOffWritePolicy() {
 }
 
 // Without invoking this setup, errors in reactions, *including expectation failures*, are ignored.
-void throwReactionErrors() {
+void setupThrowReactionErrors() {
   Dispose disposeReactionError;
 
   setUp(() => disposeReactionError = mainContext.onReactionError((_, rxn) {

--- a/mobx/test/util.dart
+++ b/mobx/test/util.dart
@@ -7,3 +7,14 @@ void turnOffWritePolicy() {
 
   tearDown(() => mainContext.config = ReactiveConfig.main);
 }
+
+// Without invoking this setup, errors in reactions, *including expectation failures*, are ignored.
+void throwReactionErrors() {
+  Dispose disposeReactionError;
+
+  setUp(() => disposeReactionError = mainContext.onReactionError((_, rxn) {
+    throw Exception(rxn.errorValue);
+  }));
+
+  tearDown(() => disposeReactionError());
+}

--- a/mobx/test/when_test.dart
+++ b/mobx/test/when_test.dart
@@ -7,7 +7,6 @@ import 'shared_mocks.dart';
 import 'util.dart';
 
 void main() {
-  turnOffWritePolicy();
   testSetup();
 
   group('when()', () {

--- a/mobx/test/when_test.dart
+++ b/mobx/test/when_test.dart
@@ -8,6 +8,7 @@ import 'util.dart';
 
 void main() {
   turnOffWritePolicy();
+  testSetup();
 
   group('when()', () {
     test('basics work', () {


### PR DESCRIPTION
This will allow expectations in observers to function.

Currently, test expectations written inside of observation handlers don't function. For example, try changing the integer used in the expectation around line 90 in computed_test.dart. Since expectation failures are implemented as a thrown exception, and reaction errors are swallowed unless there is an `onReactionError` handler, tests appear to pass even if the expectations inside of observers fail.

Probably this method call should become standard boilerplate, but I haven't added it to any files other than the one I was looking at while doing a separate PR (coming very shortly). I'm happy to discuss that further.