### PR TITLE
Allow a custom equals parameter for Computed.

### DIFF
--- a/mobx/pubspec.yaml
+++ b/mobx/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   meta: ^1.1.6
 
 dev_dependencies:
+  collection: ^1.0.0
   coverage: ^0.13.9
   fake_async: ^1.0.1
   mockito: ^4.1.1


### PR DESCRIPTION
Create a custom `equals` parameter for Computed, like what exists already for Observable.

Currently, Computed uses `==` to determine if the value changed. This creates an option to override that with a different EqualityComparator. 