### PR TITLE
StoreConfig parameter to report only changed writes for an observable.

### DIFF
--- a/mobx/lib/src/api/annotations.dart
+++ b/mobx/lib/src/api/annotations.dart
@@ -1,9 +1,13 @@
 /// Declares configuration of a Store class.
-/// Currently the only configuration used is boolean to indicate generation of toString method (true), or not (false)
+/// Currently the only configurations used are:
+/// - boolean to indicate generation of toString method (true), or not (false)
+/// - boolean to indicate whether to report writes to observables when the value is equal.
+///   Defaults to true.
 
 class StoreConfig {
-  const StoreConfig({this.hasToString = true});
+  const StoreConfig({this.hasToString = true, this.reportOnEqualSet = true});
   final bool hasToString;
+  final bool reportOnEqualSet;
 }
 
 /// Internal class only used for code-generation with `mobx_codegen`.

--- a/mobx_codegen/lib/src/store_class_visitor.dart
+++ b/mobx_codegen/lib/src/store_class_visitor.dart
@@ -62,7 +62,9 @@ class StoreClassVisitor extends SimpleElementVisitor {
           .addIf(!element.isAbstract, element.name);
     }
     // if the class is annotated to generate toString() method we add the information to the _storeTemplate
-    _storeTemplate.generateToString = hasGeneratedToString(element);
+    _storeTemplate
+      ..generateToString = hasGeneratedToString(element)
+      ..reportOnEqualSet = shouldreportOnEqualSet(element);
   }
 
   @override
@@ -209,6 +211,15 @@ bool hasGeneratedToString(ClassElement classElement) {
     final annotation =
         _toStringAnnotationChecker.firstAnnotationOfExact(classElement);
     return annotation.getField('hasToString').toBoolValue();
+  }
+  return true;
+}
+
+bool shouldreportOnEqualSet(ClassElement classElement) {
+  if (isStoreConfigAnnotatedStoreClass(classElement)) {
+    final annotation =
+    _toStringAnnotationChecker.firstAnnotationOfExact(classElement);
+    return annotation.getField('reportOnEqualSet').toBoolValue();
   }
   return true;
 }

--- a/mobx_codegen/lib/src/template/observable.dart
+++ b/mobx_codegen/lib/src/template/observable.dart
@@ -19,8 +19,11 @@ class ObservableTemplate {
 
   @override
   set $name($type value) {
-    $atomName.reportWrite(value, super.$name, () {
-      super.$name = value;
-    });
+    final oldValue = super.$name;
+    if (_reportOnEqualSet || value != oldValue) {
+      $atomName.reportWrite(value, super.$name, () {
+        super.$name = value;
+      });
+    }
   }""";
 }

--- a/mobx_codegen/lib/src/template/store.dart
+++ b/mobx_codegen/lib/src/template/store.dart
@@ -35,6 +35,8 @@ abstract class StoreTemplate {
   final List<String> toStringList = [];
 
   bool generateToString = false;
+  bool reportOnEqualSet = true;
+
   String _actionControllerName;
   String get actionControllerName =>
       _actionControllerName ??= '_\$${parentTypeName}ActionController';
@@ -42,6 +44,16 @@ abstract class StoreTemplate {
   String get actionControllerField => actions.isEmpty
       ? ''
       : "final $actionControllerName = ActionController(name: '$parentTypeName');";
+
+  // Any other StoreConfig level boolean configurations could be placed here,
+  // if they create flags in the generated code.
+  Map<String, bool> get staticConfigurations =>
+      { 'reportOnEqualSet': reportOnEqualSet };
+
+  String get staticConfigurationFields =>
+      staticConfigurations.entries
+          .map((entry) => 'static const _${entry.key} = ${entry.value};')
+          .join('\n');
 
   String get toStringMethod {
     if (!generateToString) {
@@ -72,6 +84,8 @@ ${allStrings.join(',\n')}
   }
 
   String get storeBody => '''
+  $staticConfigurationFields
+  
   $computeds
 
   $observables

--- a/mobx_codegen/test/data/valid_generic_store_input_notify_on_equal_set_false.dart
+++ b/mobx_codegen/test/data/valid_generic_store_input_notify_on_equal_set_false.dart
@@ -1,0 +1,16 @@
+library generator_sample;
+
+import 'package:mobx/mobx.dart';
+
+part 'generator_sample.g.dart';
+
+class Item<A extends num> = _Item<A> with _$Item<A>;
+
+@StoreConfig(hasToString: false, reportOnEqualSet: false)
+abstract class _Item<T extends num> with Store {
+  @observable
+  T value;
+
+  @observable
+  List<T> values;
+}

--- a/mobx_codegen/test/data/valid_generic_store_output_notify_on_equal_set_false.dart
+++ b/mobx_codegen/test/data/valid_generic_store_output_notify_on_equal_set_false.dart
@@ -1,5 +1,5 @@
 mixin _$Item<T extends num> on _Item<T>, Store {
-  static const _reportOnEqualSet = true;
+  static const _reportOnEqualSet = false;
 
   final _$valueAtom = Atom(name: '_Item.value');
 

--- a/mobx_codegen/test/data/valid_import_prefixed_output.dart
+++ b/mobx_codegen/test/data/valid_import_prefixed_output.dart
@@ -1,4 +1,6 @@
 mixin _$User<T extends io.Process> on UserBase<T>, Store {
+  static const _reportOnEqualSet = true;
+
   Computed<io.File> _$biographyNotesComputed;
 
   @override
@@ -17,9 +19,12 @@ mixin _$User<T extends io.Process> on UserBase<T>, Store {
 
   @override
   set names(List<String> value) {
-    _$namesAtom.reportWrite(value, super.names, () {
-      super.names = value;
-    });
+    final oldValue = super.names;
+    if (_reportOnEqualSet || value != oldValue) {
+      _$namesAtom.reportWrite(value, super.names, () {
+        super.names = value;
+      });
+    }
   }
 
   final _$filesAtom = Atom(name: 'UserBase.files');
@@ -32,9 +37,12 @@ mixin _$User<T extends io.Process> on UserBase<T>, Store {
 
   @override
   set files(List<io.File> value) {
-    _$filesAtom.reportWrite(value, super.files, () {
-      super.files = value;
-    });
+    final oldValue = super.files;
+    if (_reportOnEqualSet || value != oldValue) {
+      _$filesAtom.reportWrite(value, super.files, () {
+        super.files = value;
+      });
+    }
   }
 
   final _$processesAtom = Atom(name: 'UserBase.processes');
@@ -47,9 +55,12 @@ mixin _$User<T extends io.Process> on UserBase<T>, Store {
 
   @override
   set processes(List<T> value) {
-    _$processesAtom.reportWrite(value, super.processes, () {
-      super.processes = value;
-    });
+    final oldValue = super.processes;
+    if (_reportOnEqualSet || value != oldValue) {
+      _$processesAtom.reportWrite(value, super.processes, () {
+        super.processes = value;
+      });
+    }
   }
 
   final _$biographyAtom = Atom(name: 'UserBase.biography');
@@ -62,9 +73,12 @@ mixin _$User<T extends io.Process> on UserBase<T>, Store {
 
   @override
   set biography(io.File value) {
-    _$biographyAtom.reportWrite(value, super.biography, () {
-      super.biography = value;
-    });
+    final oldValue = super.biography;
+    if (_reportOnEqualSet || value != oldValue) {
+      _$biographyAtom.reportWrite(value, super.biography, () {
+        super.biography = value;
+      });
+    }
   }
 
   final _$friendWithImplicitTypeArgumentAtom =
@@ -78,10 +92,13 @@ mixin _$User<T extends io.Process> on UserBase<T>, Store {
 
   @override
   set friendWithImplicitTypeArgument(User<io.Process> value) {
-    _$friendWithImplicitTypeArgumentAtom
-        .reportWrite(value, super.friendWithImplicitTypeArgument, () {
-      super.friendWithImplicitTypeArgument = value;
-    });
+    final oldValue = super.friendWithImplicitTypeArgument;
+    if (_reportOnEqualSet || value != oldValue) {
+      _$friendWithImplicitTypeArgumentAtom
+          .reportWrite(value, super.friendWithImplicitTypeArgument, () {
+        super.friendWithImplicitTypeArgument = value;
+      });
+    }
   }
 
   final _$friendWithExplicitTypeArgumentAtom =
@@ -95,10 +112,13 @@ mixin _$User<T extends io.Process> on UserBase<T>, Store {
 
   @override
   set friendWithExplicitTypeArgument(User<T> value) {
-    _$friendWithExplicitTypeArgumentAtom
-        .reportWrite(value, super.friendWithExplicitTypeArgument, () {
-      super.friendWithExplicitTypeArgument = value;
-    });
+    final oldValue = super.friendWithExplicitTypeArgument;
+    if (_reportOnEqualSet || value != oldValue) {
+      _$friendWithExplicitTypeArgumentAtom
+          .reportWrite(value, super.friendWithExplicitTypeArgument, () {
+        super.friendWithExplicitTypeArgument = value;
+      });
+    }
   }
 
   final _$callbackAtom = Atom(name: 'UserBase.callback');
@@ -111,9 +131,12 @@ mixin _$User<T extends io.Process> on UserBase<T>, Store {
 
   @override
   set callback(void Function(io.File, {T another}) value) {
-    _$callbackAtom.reportWrite(value, super.callback, () {
-      super.callback = value;
-    });
+    final oldValue = super.callback;
+    if (_reportOnEqualSet || value != oldValue) {
+      _$callbackAtom.reportWrite(value, super.callback, () {
+        super.callback = value;
+      });
+    }
   }
 
   final _$callback2Atom = Atom(name: 'UserBase.callback2');
@@ -126,9 +149,12 @@ mixin _$User<T extends io.Process> on UserBase<T>, Store {
 
   @override
   set callback2(io.File Function(String, [int, io.File]) value) {
-    _$callback2Atom.reportWrite(value, super.callback2, () {
-      super.callback2 = value;
-    });
+    final oldValue = super.callback2;
+    if (_reportOnEqualSet || value != oldValue) {
+      _$callback2Atom.reportWrite(value, super.callback2, () {
+        super.callback2 = value;
+      });
+    }
   }
 
   final _$localTypedefCallbackAtom =
@@ -142,10 +168,13 @@ mixin _$User<T extends io.Process> on UserBase<T>, Store {
 
   @override
   set localTypedefCallback(ValueCallback<io.Process> value) {
-    _$localTypedefCallbackAtom.reportWrite(value, super.localTypedefCallback,
-        () {
-      super.localTypedefCallback = value;
-    });
+    final oldValue = super.localTypedefCallback;
+    if (_reportOnEqualSet || value != oldValue) {
+      _$localTypedefCallbackAtom.reportWrite(value, super.localTypedefCallback,
+          () {
+        super.localTypedefCallback = value;
+      });
+    }
   }
 
   final _$prefixedTypedefCallbackAtom =
@@ -159,10 +188,13 @@ mixin _$User<T extends io.Process> on UserBase<T>, Store {
 
   @override
   set prefixedTypedefCallback(io.BadCertificateCallback value) {
-    _$prefixedTypedefCallbackAtom
-        .reportWrite(value, super.prefixedTypedefCallback, () {
-      super.prefixedTypedefCallback = value;
-    });
+    final oldValue = super.prefixedTypedefCallback;
+    if (_reportOnEqualSet || value != oldValue) {
+      _$prefixedTypedefCallbackAtom
+          .reportWrite(value, super.prefixedTypedefCallback, () {
+        super.prefixedTypedefCallback = value;
+      });
+    }
   }
 
   @override

--- a/mobx_codegen/test/data/valid_output.dart
+++ b/mobx_codegen/test/data/valid_output.dart
@@ -1,4 +1,6 @@
 mixin _$User on UserBase, Store {
+  static const _reportOnEqualSet = true;
+
   Computed<String> _$fullNameComputed;
 
   @override
@@ -16,9 +18,12 @@ mixin _$User on UserBase, Store {
 
   @override
   set firstName(String value) {
-    _$firstNameAtom.reportWrite(value, super.firstName, () {
-      super.firstName = value;
-    });
+    final oldValue = super.firstName;
+    if (_reportOnEqualSet || value != oldValue) {
+      _$firstNameAtom.reportWrite(value, super.firstName, () {
+        super.firstName = value;
+      });
+    }
   }
 
   final _$middleNameAtom = Atom(name: 'UserBase.middleName');
@@ -31,9 +36,12 @@ mixin _$User on UserBase, Store {
 
   @override
   set middleName(String value) {
-    _$middleNameAtom.reportWrite(value, super.middleName, () {
-      super.middleName = value;
-    });
+    final oldValue = super.middleName;
+    if (_reportOnEqualSet || value != oldValue) {
+      _$middleNameAtom.reportWrite(value, super.middleName, () {
+        super.middleName = value;
+      });
+    }
   }
 
   final _$lastNameAtom = Atom(name: 'UserBase.lastName');
@@ -46,9 +54,12 @@ mixin _$User on UserBase, Store {
 
   @override
   set lastName(String value) {
-    _$lastNameAtom.reportWrite(value, super.lastName, () {
-      super.lastName = value;
-    });
+    final oldValue = super.lastName;
+    if (_reportOnEqualSet || value != oldValue) {
+      _$lastNameAtom.reportWrite(value, super.lastName, () {
+        super.lastName = value;
+      });
+    }
   }
 
   final _$friendAtom = Atom(name: 'UserBase.friend');
@@ -61,9 +72,12 @@ mixin _$User on UserBase, Store {
 
   @override
   set friend(User value) {
-    _$friendAtom.reportWrite(value, super.friend, () {
-      super.friend = value;
-    });
+    final oldValue = super.friend;
+    if (_reportOnEqualSet || value != oldValue) {
+      _$friendAtom.reportWrite(value, super.friend, () {
+        super.friend = value;
+      });
+    }
   }
 
   final _$callbackAtom = Atom(name: 'UserBase.callback');
@@ -76,9 +90,12 @@ mixin _$User on UserBase, Store {
 
   @override
   set callback(void Function() value) {
-    _$callbackAtom.reportWrite(value, super.callback, () {
-      super.callback = value;
-    });
+    final oldValue = super.callback;
+    if (_reportOnEqualSet || value != oldValue) {
+      _$callbackAtom.reportWrite(value, super.callback, () {
+        super.callback = value;
+      });
+    }
   }
 
   final _$callback2Atom = Atom(name: 'UserBase.callback2');
@@ -91,9 +108,12 @@ mixin _$User on UserBase, Store {
 
   @override
   set callback2(VoidCallback value) {
-    _$callback2Atom.reportWrite(value, super.callback2, () {
-      super.callback2 = value;
-    });
+    final oldValue = super.callback2;
+    if (_reportOnEqualSet || value != oldValue) {
+      _$callback2Atom.reportWrite(value, super.callback2, () {
+        super.callback2 = value;
+      });
+    }
   }
 
   final _$_testUsersAtom = Atom(name: 'UserBase._testUsers');
@@ -106,9 +126,12 @@ mixin _$User on UserBase, Store {
 
   @override
   set _testUsers(List<User> value) {
-    _$_testUsersAtom.reportWrite(value, super._testUsers, () {
-      super._testUsers = value;
-    });
+    final oldValue = super._testUsers;
+    if (_reportOnEqualSet || value != oldValue) {
+      _$_testUsersAtom.reportWrite(value, super._testUsers, () {
+        super._testUsers = value;
+      });
+    }
   }
 
   @override

--- a/mobx_codegen/test/data/valid_output_annotation_store_config_has_to_string.dart
+++ b/mobx_codegen/test/data/valid_output_annotation_store_config_has_to_string.dart
@@ -9,6 +9,8 @@ part of generator_sample;
 // ignore_for_file: non_constant_identifier_names, unnecessary_lambdas, prefer_expression_function_bodies, lines_longer_than_80_chars, avoid_as, avoid_annotating_with_dynamic
 
 mixin _$User on UserBase, Store {
+  static const _reportOnEqualSet = true;
+
   Computed<String> _$fullNameComputed;
 
   @override
@@ -32,9 +34,12 @@ mixin _$User on UserBase, Store {
 
   @override
   set firstName(String value) {
-    _$firstNameAtom.reportWrite(value, super.firstName, () {
-      super.firstName = value;
-    });
+    final oldValue = super.firstName;
+    if (_reportOnEqualSet || value != oldValue) {
+      _$firstNameAtom.reportWrite(value, super.firstName, () {
+        super.firstName = value;
+      });
+    }
   }
 
   final _$middleNameAtom = Atom(name: 'UserBase.middleName');
@@ -47,9 +52,12 @@ mixin _$User on UserBase, Store {
 
   @override
   set middleName(String value) {
-    _$middleNameAtom.reportWrite(value, super.middleName, () {
-      super.middleName = value;
-    });
+    final oldValue = super.middleName;
+    if (_reportOnEqualSet || value != oldValue) {
+      _$middleNameAtom.reportWrite(value, super.middleName, () {
+        super.middleName = value;
+      });
+    }
   }
 
   final _$lastNameAtom = Atom(name: 'UserBase.lastName');
@@ -62,9 +70,12 @@ mixin _$User on UserBase, Store {
 
   @override
   set lastName(String value) {
-    _$lastNameAtom.reportWrite(value, super.lastName, () {
-      super.lastName = value;
-    });
+    final oldValue = super.lastName;
+    if (_reportOnEqualSet || value != oldValue) {
+      _$lastNameAtom.reportWrite(value, super.lastName, () {
+        super.lastName = value;
+      });
+    }
   }
 
   final _$friendAtom = Atom(name: 'UserBase.friend');
@@ -77,9 +88,12 @@ mixin _$User on UserBase, Store {
 
   @override
   set friend(User value) {
-    _$friendAtom.reportWrite(value, super.friend, () {
-      super.friend = value;
-    });
+    final oldValue = super.friend;
+    if (_reportOnEqualSet || value != oldValue) {
+      _$friendAtom.reportWrite(value, super.friend, () {
+        super.friend = value;
+      });
+    }
   }
 
   final _$callbackAtom = Atom(name: 'UserBase.callback');
@@ -92,9 +106,12 @@ mixin _$User on UserBase, Store {
 
   @override
   set callback(void Function() value) {
-    _$callbackAtom.reportWrite(value, super.callback, () {
-      super.callback = value;
-    });
+    final oldValue = super.callback;
+    if (_reportOnEqualSet || value != oldValue) {
+      _$callbackAtom.reportWrite(value, super.callback, () {
+        super.callback = value;
+      });
+    }
   }
 
   final _$callback2Atom = Atom(name: 'UserBase.callback2');
@@ -107,9 +124,12 @@ mixin _$User on UserBase, Store {
 
   @override
   set callback2(VoidCallback value) {
-    _$callback2Atom.reportWrite(value, super.callback2, () {
-      super.callback2 = value;
-    });
+    final oldValue = super.callback2;
+    if (_reportOnEqualSet || value != oldValue) {
+      _$callback2Atom.reportWrite(value, super.callback2, () {
+        super.callback2 = value;
+      });
+    }
   }
 
   final _$_testUsersAtom = Atom(name: 'UserBase._testUsers');
@@ -122,9 +142,12 @@ mixin _$User on UserBase, Store {
 
   @override
   set _testUsers(List<User> value) {
-    _$_testUsersAtom.reportWrite(value, super._testUsers, () {
-      super._testUsers = value;
-    });
+    final oldValue = super._testUsers;
+    if (_reportOnEqualSet || value != oldValue) {
+      _$_testUsersAtom.reportWrite(value, super._testUsers, () {
+        super._testUsers = value;
+      });
+    }
   }
 
   @override

--- a/mobx_codegen/test/mobx_codegen_test.dart
+++ b/mobx_codegen/test/mobx_codegen_test.dart
@@ -38,6 +38,10 @@ void main() {
       await compareFiles('./data/valid_input_annotation_store_config_has_to_string.dart', './data/valid_output_annotation_store_config_has_to_string.dart');
     });
 
+    test('generates for a class mixing Store with annotation @StoreConfig(hasToString: true)', () async {
+      await compareFiles('./data/valid_input_annotation_store_config_has_to_string.dart', './data/valid_output_annotation_store_config_has_to_string.dart');
+    });
+
     createTests([
       const TestInfo(
           description: 'invalid output is handled',
@@ -51,6 +55,10 @@ void main() {
           description: 'generates types with import prefixes correctly',
           source: './data/valid_import_prefixed_input.dart',
           output: './data/valid_import_prefixed_output.dart'),
+      const TestInfo(
+          description: 'generates for a generic class mixing Store with reportOnEqualSet false',
+          source: './data/valid_generic_store_input_notify_on_equal_set_false.dart',
+          output: './data/valid_generic_store_output_notify_on_equal_set_false.dart'),
     ]);
   });
 }

--- a/mobx_codegen/test/templates_test.dart
+++ b/mobx_codegen/test/templates_test.dart
@@ -117,9 +117,12 @@ void main() {
 
   @override
   set fieldName(FieldType value) {
-    _atomFieldName.reportWrite(value, super.fieldName, () {
-      super.fieldName = value;
-    });
+    final oldValue = super.fieldName;
+    if (_reportOnEqualSet || value != oldValue) {
+      _atomFieldName.reportWrite(value, super.fieldName, () {
+        super.fieldName = value;
+      });
+    }
   }"""));
     });
   });


### PR DESCRIPTION
Sets up a parameter in StoreConfig to turn off reporting a write if you've set an observable value that is equal to the old value. It will default to reporting the write, since that's the current behavior.

For example:
```dart
class Foo = _Foo with _$Foo;

abstract class _Foo with Store {
  @observable
  int value;
}

var foo = Foo();
foo.value = 1;
autorun((_) => print(foo.value.toString()));
foo.value = 1; // prints '1'

// ....

class Bar = _Bar with _$Bar;

@StoreConfig(reportOnEqualSet: false)
abstract class _Bar with Store {
  @observable
  int value;
}

var bar = Bar();
bar.value = 1;
autorun((_) => print(bar.value.toString()));
bar.value = 1; // doesn't print anything, because 1 == 1.
```

A few notes:
- The vast majority of the code change is to the test outputs, which should probably be ignored unless/until you're good with the rest of it.
- This does not use any custom equals from Observable, since codegen is upstream of that and I'm not really sure how we would use it.
- This mostly covers the original purpose of #450, but it doesn't address the eventual landing point, of allowing a custom equals parameter in the field-level annotation. I'm not able to bite that off right now and this feels like an easier way to get most of the value. I don't think it makes it much harder to accomplish the field-level annotation later, but it might to some extent.
- If the new value is equal to the old, it doesn't report the write, but it also doesn't set the underlying value. Probably in most cases that won't matter (the two are `==` after all), but if it does matter it wasn't clear to me whether it's better to set the new value and not report it, or not set it at all. Either could be confusing.

I think this is a useful modification, since I'd rather not have unnecessary rebuilds when something is set to an equal value. But I won't be offended if you don't like the path this took and would rather not include it.