### PR TITLE
Fixed self reference while passing parent to child

### DIFF
--- a/docs/src/guides/organizing-stores.mdx
+++ b/docs/src/guides/organizing-stores.mdx
@@ -135,8 +135,13 @@ If you organize stores in a hierarchy, you will have a root-Store and then a set
 
 ```dart
 // parent.dart
-
-final child = Child(parent: this);
+class Parent {
+  Parent(){
+    child = Child(parent: this);
+  }
+  
+  Child child;
+}
 ```
 
 ```dart


### PR DESCRIPTION
Hi, 

I found an error in the documentation. I was trying to replicate the exact code shown, but I was getting an error because I wasn't able to self reference the parent object as an argument to the child. To fix this I've initialized the child inside the parent's constructor, in that scope I was able to call the self reference and carry on coding. It took me a while to get this right as I'm a beginner in Mobx, so I think other beginners might have some trouble with that particular example as well.

Best regards, João Pinto.