### PR TITLE
docs: Replace deprecated Reference

### DIFF
--- a/docs/src/getting-started/index.mdx
+++ b/docs/src/getting-started/index.mdx
@@ -182,7 +182,7 @@ class MyHomePage extends StatelessWidget {
             Observer(
               builder: (_) => Text(
                     '${counter.value}',
-                    style: Theme.of(context).textTheme.display1,
+                    style: Theme.of(context).textTheme.headline4,
                   ),
             ),
           ],


### PR DESCRIPTION
Replace 'display1' with 'headline4'

![image](https://user-images.githubusercontent.com/33684625/90823989-fd8f7d80-e336-11ea-9f61-2c94d9af03db.png)
