### PR TITLE
match reaction and createReaction signatures

### DIFF
--- a/mobx/lib/src/api/reaction.dart
+++ b/mobx/lib/src/api/reaction.dart
@@ -51,7 +51,7 @@ ReactionDisposer reaction<T>(T Function(Reaction) fn, void Function(T) effect,
         EqualityComparer<T> equals,
         ReactiveContext context,
         void Function(Object, Reaction) onError}) =>
-    createReaction(context ?? mainContext, fn, effect,
+    createReaction<T>(context ?? mainContext, fn, effect,
         name: name,
         delay: delay,
         equals: equals,

--- a/mobx/lib/src/core/reaction_helper.dart
+++ b/mobx/lib/src/core/reaction_helper.dart
@@ -70,7 +70,7 @@ ReactionDisposer createReaction<T>(
     {String name,
     int delay,
     bool fireImmediately,
-    EqualityComparer equals,
+    EqualityComparer<T> equals,
     void Function(Object, Reaction) onError}) {
   ReactionImpl rxn;
 


### PR DESCRIPTION
Fixes reaction with equals, expecting `bool (dynamic, dynamic)`, but should be `bool (T, T)`.

Only relevant if one has following in their `analysis_options.yaml`:

```yaml
analyzer:
  strong-mode:
    implicit-dynamic: false
```

Currently:

```dart
import 'package:mobx/mobx.dart';

void main() {
  final greeting = Observable('Hello World');
  reaction<String>( // <--------------------- NOTE: explicit type
    (_) => greeting.value,
    (msg) => print(msg),
    equals: (a, b) => a == b,
  );
  runInAction(() => greeting.value = 'Hello MobX');
}
```

yields

```
Unhandled exception:
type '(String, String) => bool' is not a subtype of type '(dynamic, dynamic) => bool'
#0      reaction (package:mobx/src/api/reaction.dart:57:17)
#1      main (file:///private/tmp/dart/main.dart:5:3)
#2      _startIsolate.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:301:19)
#3      _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:168:12)
```

`all_tests.dart` is passing
