### PR TITLE
bump analyzer version to >=0.39.1 <0.50.0

### DIFF
--- a/mobx_codegen/CHANGELOG.md
+++ b/mobx_codegen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+- Upgraded our `analyzer` dependency's to support a range from **0.39.1**, up to latest **0.40.x** in order to be compatible with other packages.
+
 ## 1.1.0+2
 
 - Reformatting for improving the pub.dev score

--- a/mobx_codegen/lib/mobx_codegen.dart
+++ b/mobx_codegen/lib/mobx_codegen.dart
@@ -2,4 +2,4 @@ library mobx_codegen;
 
 export 'src/mobx_codegen_base.dart';
 
-const version = '1.1.0+2';
+const version = '1.1.1';

--- a/mobx_codegen/pubspec.yaml
+++ b/mobx_codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobx_codegen
 description: Code generator for MobX that adds support for annotating your code with @observable, @computed, @action and also creating Store classes.
-version: 1.1.0+2
+version: 1.1.1
 
 homepage: https://github.com/mobxjs/mobx.dart
 

--- a/mobx_codegen/pubspec.yaml
+++ b/mobx_codegen/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
-  analyzer: ">=0.38.5 <0.40.0"
+  analyzer: ">=0.39.1 <0.50.0"
   build: ^1.1.4
   build_resolvers: ^1.3.2
   meta: ^1.1.0


### PR DESCRIPTION
Removed support for deprecated APIs and analyzer version for 0.40.x series.
#354 is to support the analyzer lower bound removal.
