### PR TITLE
Fix cheat-sheet doc

### DIFF
--- a/docs/docs/guides/cheat-sheet.mdx
+++ b/docs/docs/guides/cheat-sheet.mdx
@@ -91,7 +91,7 @@ abstract class _Contact with Store {
 
   // highlight-next-line
   @computed
-  String get fullName() => '$firstName, $lastName';
+  String get fullName => '$firstName, $lastName';
 
   ObservableList<String> phoneNumbers = ObservableList.of([]);
 


### PR DESCRIPTION
Fixing doc, the previous one prompt `Getters must be declared without a parameter list.`