### PR TITLE
Expose [ReactionImpl.track] return value, cleanup [ObserverWidgetMixin]

### DIFF
--- a/flutter_mobx/test/helpers.dart
+++ b/flutter_mobx/test/helpers.dart
@@ -9,9 +9,10 @@ final voidFn = () {};
 
 class MockReaction extends Mock implements ReactionImpl {
   @override
-  void track(Function fn) {
-    fn(); // Explicitly invoke this
+  T? track<T>(T Function() fn) {
+    final result = fn(); // Explicitly invoke this
     super.noSuchMethod(Invocation.method(#track, [voidFn]));
+    return result;
   }
 
   @override

--- a/mobx/lib/src/core/reaction.dart
+++ b/mobx/lib/src/core/reaction.dart
@@ -70,7 +70,7 @@ class ReactionImpl implements Reaction {
     _context.endBatch();
   }
 
-  void track(void Function() fn) {
+  T? track<T>(T Function() fn) {
     _context.startBatch();
 
     final notify = _context.isSpyEnabled;
@@ -81,7 +81,7 @@ class ReactionImpl implements Reaction {
     }
 
     _isRunning = true;
-    _context.trackDerivation(this, fn);
+    final result = _context.trackDerivation(this, fn);
     _isRunning = false;
 
     if (_isDisposed) {
@@ -100,6 +100,7 @@ class ReactionImpl implements Reaction {
     }
 
     _context.endBatch();
+    return result;
   }
 
   @override


### PR DESCRIPTION
Hello.

Could we expose `ReactionImpl.track`'s return value, like `ReactiveContext.trackDerivation`?

I have uses for the return value and defining a function with something like `reaction.track(() => somethingAbove = callback())` seems too dirty for this.