### PR TITLE
Bug fix for Computed with nullable values

### DIFF
--- a/mobx/lib/src/core/computed.dart
+++ b/mobx/lib/src/core/computed.dart
@@ -138,12 +138,14 @@ class Computed<T> extends Atom implements Derivation, ObservableValue<T> {
 
     final oldValue = _value;
     final wasSuspended = _dependenciesState == DerivationState.notTracking;
+    final hadCaughtException = _context._hasCaughtException(this);
 
     final newValue = computeValue(track: true);
 
-    final changed = wasSuspended ||
-        _context._hasCaughtException(this) ||
-        !_isEqual(oldValue, newValue);
+    final changedException =
+        hadCaughtException != _context._hasCaughtException(this);
+    final changed =
+        wasSuspended || changedException || !_isEqual(oldValue, newValue);
 
     if (changed) {
       _value = newValue;


### PR DESCRIPTION
Hello,

While working on my app, I noticed that Computed will sometimes not propagate changes in the following simplified use case:

```dart
final emailComputed = Computed<String?>((){
    final username = usernameObservable.value;
    final user = getUserOrThrow(username);
    return user?.email; // can be null
});
```

In the case where callback initially throws, then later recomputes successfully but returns `null`, the computed thinks that nothing changed. This is because there's no caught exception and the value before and after are both null. So it doesn't propagate changes, and any further derivations still think the computed has a caught error

This pull request fixes the bug and ensures that computed with nullable values will propagate changes after errors correctly. Thanks for your time!