### PR TITLE
Fix: ObservableStream.listen() should also keep observable values updated

### DIFF
--- a/mobx/lib/src/api/observable_collections.dart
+++ b/mobx/lib/src/api/observable_collections.dart
@@ -3,7 +3,6 @@ import 'dart:math';
 
 import 'package:meta/meta.dart';
 import 'package:mobx/mobx.dart';
-import 'package:mobx/src/core.dart';
 
 part 'observable_collections/observable_list.dart';
 part 'observable_collections/observable_map.dart';

--- a/mobx/test/autorun_test.dart
+++ b/mobx/test/autorun_test.dart
@@ -1,6 +1,5 @@
 import 'package:fake_async/fake_async.dart';
 import 'package:mobx/mobx.dart';
-import 'package:mobx/src/api/reaction.dart';
 import 'package:mocktail/mocktail.dart' as mock;
 import 'package:test/test.dart';
 

--- a/mobx/test/computed_test.dart
+++ b/mobx/test/computed_test.dart
@@ -1,6 +1,5 @@
 import 'package:collection/collection.dart';
 import 'package:mobx/mobx.dart' hide when;
-import 'package:mobx/src/api/context.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 

--- a/mobx/test/observable_list_test.dart
+++ b/mobx/test/observable_list_test.dart
@@ -2,7 +2,6 @@ import 'dart:math';
 
 import 'package:mobx/mobx.dart';
 import 'package:mobx/src/api/observable_collections.dart';
-import 'package:mobx/src/core.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 

--- a/mobx/test/observable_stream_test.dart
+++ b/mobx/test/observable_stream_test.dart
@@ -433,31 +433,31 @@ void main() {
           })),
       'where': (s) => s.where((n) => n != 2)
     }.forEach(testStreamCombinator);
-  });
 
-  <String, Case>{
-    'any': futureCase((s) => s.any((v) => v > 3), true),
-    'contains': futureCase((s) => s.contains(3), true),
-    'drain': futureCase((s) => s.drain<int>(3), 3),
-    'elementAt': futureCase((s) => s.elementAt(2), 2),
-    'every': futureCase((s) => s.every((n) => n < 100), true),
-    'first': futureCase((s) => s.first, 0),
-    'firstWhere': futureCase((s) => s.firstWhere((n) => n == 2), 2),
-    'fold': futureCase((s) => s.fold<int>(0, (a, b) => a + b), 45),
-    'forEach': futureCase((s) => s.forEach((n) {}), null as dynamic),
-    'isEmpty': futureCase((s) => s.isEmpty, false),
-    'join': futureCase((s) => s.join(' '), '0 1 2 3 4 5 6 7 8 9'),
-    'last': futureCase((s) => s.last, 9),
-    'lastWhere': futureCase((s) => s.lastWhere((n) => n <= 8), 8),
-    'length': futureCase((s) => s.length, 10),
-    'pipe': futureCase(
-        (s) => s.pipe(StreamController.broadcast()), null as dynamic),
-    'reduce': futureCase((s) => s.reduce((a, b) => a + b), 45),
-    'single': futureCase((s) => s.single, 0, length: 1),
-    'singleWhere': futureCase((s) => s.singleWhere((n) => n == 8), 8),
-    'toList': futureCase((s) => s.toList(), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
-    'toSet': futureCase((s) => s.toSet(), {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}),
-  }.forEach(testStreamToFutureCombinator);
+    <String, Case>{
+      'any': futureCase((s) => s.any((v) => v > 3), true),
+      'contains': futureCase((s) => s.contains(3), true),
+      'drain': futureCase((s) => s.drain<int>(3), 3),
+      'elementAt': futureCase((s) => s.elementAt(2), 2),
+      'every': futureCase((s) => s.every((n) => n < 100), true),
+      'first': futureCase((s) => s.first, 0),
+      'firstWhere': futureCase((s) => s.firstWhere((n) => n == 2), 2),
+      'fold': futureCase((s) => s.fold<int>(0, (a, b) => a + b), 45),
+      'forEach': futureCase((s) => s.forEach((n) {}), null as dynamic),
+      'isEmpty': futureCase((s) => s.isEmpty, false),
+      'join': futureCase((s) => s.join(' '), '0 1 2 3 4 5 6 7 8 9'),
+      'last': futureCase((s) => s.last, 9),
+      'lastWhere': futureCase((s) => s.lastWhere((n) => n <= 8), 8),
+      'length': futureCase((s) => s.length, 10),
+      'pipe': futureCase(
+          (s) => s.pipe(StreamController.broadcast()), null as dynamic),
+      'reduce': futureCase((s) => s.reduce((a, b) => a + b), 45),
+      'single': futureCase((s) => s.single, 0, length: 1),
+      'singleWhere': futureCase((s) => s.singleWhere((n) => n == 8), 8),
+      'toList': futureCase((s) => s.toList(), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+      'toSet': futureCase((s) => s.toSet(), {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}),
+    }.forEach(testStreamToFutureCombinator);
+  });
 }
 
 Case<F> futureCase<

--- a/mobx/test/observable_stream_test.dart
+++ b/mobx/test/observable_stream_test.dart
@@ -3,8 +3,6 @@
 import 'dart:async';
 
 import 'package:mobx/mobx.dart';
-import 'package:mobx/src/api/async.dart';
-import 'package:mobx/src/api/reaction.dart';
 import 'package:test/test.dart';
 
 import 'util.dart';

--- a/mobx/test/observable_test.dart
+++ b/mobx/test/observable_test.dart
@@ -6,6 +6,7 @@ import 'shared_mocks.dart';
 import 'util.dart';
 
 // ignore_for_file: unnecessary_lambdas
+// ignore_for_file: unnecessary_type_check
 
 void main() {
   testSetup();

--- a/mobx_codegen/lib/src/type_names.dart
+++ b/mobx_codegen/lib/src/type_names.dart
@@ -78,8 +78,8 @@ class LibraryScopedNameFinder {
     if (type is FunctionType) {
       // If we're dealing with a typedef, we let it undergo the standard name
       // lookup. Otherwise, we special case the function naming.
-      if (type.aliasElement is TypeAliasElement) {
-        typeElement = type.aliasElement!.aliasedElement?.enclosingElement;
+      if (type.alias?.element is TypeAliasElement) {
+        typeElement = type.alias!.element.aliasedElement?.enclosingElement;
       } else {
         return _getFunctionTypeName(type);
       }
@@ -125,7 +125,7 @@ class LibraryScopedNameFinder {
     if (type is ParameterizedType) {
       genericTypes = type.typeArguments;
     } else if (type is FunctionType) {
-      genericTypes = type.aliasArguments;
+      genericTypes = type.alias?.typeArguments;
     }
 
     if (genericTypes != null && genericTypes.isNotEmpty) {


### PR DESCRIPTION
Hello! 

This PR addresses a TODO in ObservableStream where its observable values (valueType, data, status) are not updated if they are not observed by MobX, even if the underlying stream is emitting events already because `listen()` was called. 
For example:

```dart
final stream = ObservableStream(sourceStream);
final sub = stream.listen(null); // stream starts running

// ...later

print(stream.value) // read outside reaction, still prints null even though stream has emitted values
```

As a side effect, it's now possible to listen to a single-subscription stream *and* observe its values in a reaction, at the same time :) Previously, trying to do both would throw. Note that to comply with the single-subscription stream contract, calling `cancel` on the subscription will also stop further updates to observable values.

Other changes for single-subscription streams:
- InitialValue is also emitted as the first value for subscriptions. This means calling `listen` and observing `value` should both emit the exact same list of values
- Added a `close` method to force close the observable stream. This is only needed in some cases for single-sub streams because if the subscription is paused and never resumed, the parent stream cannot close correctly. See explanation in docs / tests

For broadcast source streams, there should be mostly no difference, other than the observable values should now always be updated (as long as there is at least one mobx observer or stream subscription). 

All existing tests still pass and I added new ones to cover the above behaviors. I needed this fix for an edge case in my app and so far after testing, things work as expected. Let me know if you agree with the above behaviors or if you think there needs to be other changes. Thanks!