### PR TITLE
fix: make readonly work with computed

### DIFF
--- a/mobx_codegen/lib/src/template/observable.dart
+++ b/mobx_codegen/lib/src/template/observable.dart
@@ -29,16 +29,30 @@ class ObservableTemplate {
     return name;
   }
 
-  @override
-  String toString() => """
-  final $atomName = Atom(name: '${storeTemplate.parentTypeName}.$name');
-
-  ${isReadOnly ? '' : '@override'}
+  String _buildGetters() {
+    final buffer = StringBuffer()..writeln();
+    if (!isReadOnly) {
+      buffer.writeln('  @override');
+    }
+    buffer.writeln('''
   $type get $getterName {
     $atomName.reportRead();
     return super.$name;
+  }''');
+    if (isReadOnly) {
+      buffer
+        ..writeln()
+        ..writeln('  @override')
+        ..write('  $type get $name => $getterName;')
+        ..writeln();
+    }
+    return buffer.toString();
   }
 
+  @override
+  String toString() => """
+  final $atomName = Atom(name: '${storeTemplate.parentTypeName}.$name');
+${_buildGetters()}
   @override
   set $name($type value) {
     $atomName.reportWrite(value, super.$name, () {

--- a/mobx_codegen/test/templates_test.dart
+++ b/mobx_codegen/test/templates_test.dart
@@ -107,14 +107,15 @@ void main() {
       expect(template.getterName, equals(template.name.nonPrivateName));
     });
 
-    test('renders template based on template data', () {
-      final template = ObservableTemplate(
-          storeTemplate: (MixinStoreTemplate()..parentTypeName = 'ParentName'),
-          atomName: '_atomFieldName',
-          type: 'FieldType',
-          name: 'fieldName');
-
-      expect(template.toString(), equals("""
+    group('renders template based on template data', () {
+      test('on public field', () {
+        final template = ObservableTemplate(
+            storeTemplate: (MixinStoreTemplate()..parentTypeName = 'ParentName'),
+            atomName: '_atomFieldName',
+            type: 'FieldType',
+            name: 'fieldName');
+        final output = template.toString();
+        expect(output, equals("""
   final _atomFieldName = Atom(name: 'ParentName.fieldName');
 
   @override
@@ -129,6 +130,36 @@ void main() {
       super.fieldName = value;
     });
   }"""));
+      });
+
+      test('on readonly field', () {
+        final template = ObservableTemplate(
+          storeTemplate: (MixinStoreTemplate()..parentTypeName = 'ParentName'),
+          atomName: '_atomFieldName',
+          type: 'FieldType',
+          name: '_fieldName', 
+          isPrivate: true,
+          isReadOnly: true,
+        );
+        final output = template.toString();
+        expect(output, equals("""
+  final _atomFieldName = Atom(name: 'ParentName._fieldName');
+
+  FieldType get fieldName {
+    _atomFieldName.reportRead();
+    return super._fieldName;
+  }
+
+  @override
+  FieldType get _fieldName => fieldName;
+
+  @override
+  set _fieldName(FieldType value) {
+    _atomFieldName.reportWrite(value, super._fieldName, () {
+      super._fieldName = value;
+    });
+  }"""));
+      });
     });
   });
 


### PR DESCRIPTION
# Problem

Because the generated getter was public and the store couldn't reference it, it could not use `@readonly` fields with `@computed`s.

**Your store**
```dart
@readonly
int _counter = 0;

@computed
bool get isEven => _counter % 2 == 0;
// ^ doesn't work because _counter is just a normal field
```

**Generated code**
```dart
int get counter {
  _$_counterAtom.reportRead();
  return super._counter;
}
```

# Solution

We generate also a private getter which overrides the default behavior. Because we reference the original getter which is reactive, we make it work. The generated code looks like this:

```dart
  int get counter {
    _$_counterAtom.reportRead();
    return super._counter;
  }

  @override
  int get _counter => counter;
```

Also closes #707.