### PR TITLE
docs: adds context configuration for spies

### DIFF
--- a/docs/docs/api/spy.mdx
+++ b/docs/docs/api/spy.mdx
@@ -23,8 +23,9 @@ Using the `spy()` method of a `ReactiveContext`, you can get notified of all act
 import 'package:mobx/mobx.dart';
 
 void main() {
-
-  // ...
+  mainContext.config = mainContext.config.clone(
+    isSpyEnabled: true,
+  );
 
   mainContext.spy((event) { /* ... */ });
 
@@ -33,6 +34,9 @@ void main() {
 ```
 
 In this case, we are setting up a spy right in the top-level `main()` method. This gives us visibility into MobX, right from the get-go.
+
+Notice that before we spy on events, we must firstly make sure we enable
+spying. Otherwise, we won't be able to capture any events.
 
 ### `ReactiveContext.spy()`
 
@@ -63,9 +67,10 @@ Let us setup the spy to do some logging of the MobX activities.
 ```dart {7}
 import 'package:mobx/mobx.dart';
 
-Future<void> main() async {
-
-  // ...
+void main() {
+  mainContext.config = mainContext.config.clone(
+    isSpyEnabled: true,
+  );
 
   mainContext.spy(print);
 

--- a/docs/docs/api/spy.mdx
+++ b/docs/docs/api/spy.mdx
@@ -35,8 +35,8 @@ void main() {
 
 In this case, we are setting up a spy right in the top-level `main()` method. This gives us visibility into MobX, right from the get-go.
 
-Notice that before we spy on events, we must firstly make sure we enable
-spying. Otherwise, we won't be able to capture any events.
+Notice that before we spy on events, we must first make sure that spying is
+enabled. Otherwise, we won't be able to capture any events.
 
 ### `ReactiveContext.spy()`
 

--- a/mobx/lib/src/api/observable_collections/observable_map.dart
+++ b/mobx/lib/src/api/observable_collections/observable_map.dart
@@ -73,7 +73,8 @@ class ObservableMap<K, V>
     _context.enforceReadPolicy(_atom);
 
     _atom.reportObserved();
-    return _map[(key as K?)];
+    final castedKey = key as K?;
+    return _map[castedKey];
   }
 
   @override


### PR DESCRIPTION
Hello :wave: 

I've noticed that the section about _spying_ in the docs is somewhat incomplete because **mainContext**'s `isSpyEnabled` defaults to false, so if the user bindly copy the samples they won't work.