### PR TITLE
Perf/increase performance when spy is disabled

### DIFF
--- a/mobx/lib/src/api/observable_collections/observable_map.dart
+++ b/mobx/lib/src/api/observable_collections/observable_map.dart
@@ -73,7 +73,8 @@ class ObservableMap<K, V>
     _context.enforceReadPolicy(_atom);
 
     _atom.reportObserved();
-    return _map[key as K?];
+    final castedKey = key as K?;
+    return _map[castedKey];
   }
 
   @override

--- a/mobx/lib/src/core/atom_extensions.dart
+++ b/mobx/lib/src/core/atom_extensions.dart
@@ -10,7 +10,7 @@ extension AtomSpyReporter on Atom {
     context.spyReport(ObservableValueSpyEvent(this,
         newValue: newValue, oldValue: oldValue, name: name));
 
-    final actionName = context.isSpyEnabled ? '${name}_set' : null;
+    final actionName = context.isSpyEnabled ? '${name}_set' : name;
 
     // ignore: cascade_invocations
     context.conditionallyRunInAction(() {

--- a/mobx/lib/src/core/atom_extensions.dart
+++ b/mobx/lib/src/core/atom_extensions.dart
@@ -10,11 +10,13 @@ extension AtomSpyReporter on Atom {
     context.spyReport(ObservableValueSpyEvent(this,
         newValue: newValue, oldValue: oldValue, name: name));
 
+    final actionName = context.isSpyEnabled ? '${name}_set' : null;
+
     // ignore: cascade_invocations
     context.conditionallyRunInAction(() {
       setNewValue();
       reportChanged();
-    }, this, name: '${name}_set');
+    }, this, name: actionName);
 
     // ignore: cascade_invocations
     context.spyReport(EndedSpyEvent(type: 'observable', name: name));

--- a/mobx/test/action_controller_test.dart
+++ b/mobx/test/action_controller_test.dart
@@ -22,6 +22,7 @@ void main() {
       when(() => context.nameFor(any())).thenReturn('Test-Action');
       when(() => context.startAllowStateChanges(allow: any(named: 'allow')))
           .thenReturn(true);
+      when(() => context.isSpyEnabled).thenReturn(false);
 
       ActionController(context: context).startAction();
 
@@ -40,6 +41,7 @@ void main() {
       when(() => context.startAllowStateChanges(allow: any(named: 'allow')))
           .thenReturn(true);
       when(() => context.startUntracked()).thenReturn(prevDerivation);
+      when(() => context.isSpyEnabled).thenReturn(false);
 
       final runInfo = ActionRunInfo(
           name: 'test',

--- a/mobx/test/action_test.dart
+++ b/mobx/test/action_test.dart
@@ -157,11 +157,11 @@ void main() {
       act();
 
       mock.verifyInOrder([
-        //() => context.nameFor('Action'),
-        //() => context.startUntracked(),
-        //() => context.startBatch(),
-        //() => context.endBatch(),
-        //() => context.endUntracked(null)
+        () => context.nameFor('Action'),
+        () => context.startUntracked(),
+        () => context.startBatch(),
+        () => context.endBatch(),
+        () => context.endUntracked(null)
       ]);
     });
 

--- a/mobx/test/action_test.dart
+++ b/mobx/test/action_test.dart
@@ -151,16 +151,17 @@ void main() {
           .when(() =>
               context.startAllowStateChanges(allow: mock.any(named: 'allow')))
           .thenReturn(true);
+      mock.when(() => context.isSpyEnabled).thenReturn(false);
 
       final act = Action(fn, context: context);
       act();
 
       mock.verifyInOrder([
-        () => context.nameFor('Action'),
-        () => context.startUntracked(),
-        () => context.startBatch(),
-        () => context.endBatch(),
-        () => context.endUntracked(null)
+        //() => context.nameFor('Action'),
+        //() => context.startUntracked(),
+        //() => context.startBatch(),
+        //() => context.endBatch(),
+        //() => context.endUntracked(null)
       ]);
     });
 


### PR DESCRIPTION
## What
This PR increases [mobx](https://pub.dev/packages/mobx) performance by avoiding creating Strings and DateTime objects when _spying_ is off.

## Benchmarking code
```dart
import 'package:mobx/mobx.dart';

part 'main.g.dart';

class CounterStore = _CounterStoreBase with _$CounterStore;

abstract class _CounterStoreBase with Store {
  @observable
  int counter = 0;

  @action
  void increment() {
    counter++;
  }
}

void main(List<String> args) {
  final counter = CounterStore();
  final watch = Stopwatch()..start();
  for (var i = 0; i < 1000000; i++) {
    counter.increment();
  }
  watch.stop();
  print(watch.elapsedMilliseconds);
}
```

## Results

In my laptop, it went down from **~530ms** to shocking **~250ms** :laughing:.

You can also take a look at the bottom-up info taken from [Dart DevTools](https://dart.dev/tools/dart-devtools) bellow. Notice how our bottleneck reduced.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/7662016/146865978-3e6ceaab-22c5-435f-8765-222643bdc82b.png">
</td>
<td><img src="https://user-images.githubusercontent.com/7662016/146866037-7c22f31f-939a-4d3a-9a19-65b7422dbc4e.png">
</td>
</tr>
</table>