### PR TITLE
Provide more debugging context for `setState() or markNeedsBuild() called during build`

### DIFF
--- a/flutter_mobx/lib/src/observer_widget_mixin.dart
+++ b/flutter_mobx/lib/src/observer_widget_mixin.dart
@@ -66,7 +66,14 @@ mixin ObserverElementMixin on ComponentElement {
     super.mount(parent, newSlot);
   }
 
-  void invalidate() => markNeedsBuild();
+  void invalidate() {
+    try {
+      markNeedsBuild();
+    } on FlutterError {
+      _widget.log('invalidate() has error (reaction.name=${reaction.name})');
+      rethrow;
+    }
+  }
 
   @override
   Widget build() {

--- a/flutter_mobx/lib/src/observer_widget_mixin.dart
+++ b/flutter_mobx/lib/src/observer_widget_mixin.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:mobx/mobx.dart';
+
 // ignore: implementation_imports
 import 'package:mobx/src/core.dart' show ReactionImpl;
 
@@ -61,19 +62,13 @@ mixin ObserverElementMixin on ComponentElement {
         library: 'flutter_mobx',
         exception: e,
         stack: e is Error ? e.stackTrace : null,
+        context: ErrorDescription('From reaction of ${_widget.getName()} of type $runtimeType.'),
       ));
     }) as ReactionImpl;
     super.mount(parent, newSlot);
   }
 
-  void invalidate() {
-    try {
-      markNeedsBuild();
-    } on FlutterError {
-      _widget.log('invalidate() has error (reaction.name=${reaction.name})');
-      rethrow;
-    }
-  }
+  void invalidate() => markNeedsBuild();
 
   @override
   Widget build() {


### PR DESCRIPTION
Close https://github.com/mobxjs/mobx.dart/issues/754