### PR TITLE
Feat: Allow use custom context

### DIFF
--- a/mobx/lib/src/api/store.dart
+++ b/mobx/lib/src/api/store.dart
@@ -1,7 +1,12 @@
+import 'package:mobx/mobx.dart';
+
 /// The `Store` mixin is primarily meant for code-generation and used as part of the
 /// `mobx_codegen` package.
 ///
 /// A class using this mixin is considered a MobX store and `mobx_codegen`
 /// weaves the code needed to simplify the usage of MobX. It will detect annotations like
 /// `@observables`, `@computed` and `@action` and generate the code needed to support these behaviors.
-mixin Store {}
+mixin Store {
+  /// Override this method to use a custom context.
+  ReactiveContext get context => mainContext;
+}

--- a/mobx/test/all_tests.dart
+++ b/mobx/test/all_tests.dart
@@ -32,6 +32,7 @@ import 'observe_test.dart' as observe_test;
 import 'reaction_test.dart' as reaction_test;
 import 'reactive_policies_test.dart' as reactive_policies_test;
 import 'spy_test.dart' as spy_test;
+import 'store_test.dart' as store_test;
 import 'when_test.dart' as when_test;
 
 void main() {
@@ -71,4 +72,5 @@ void main() {
   annotations_test.main();
 
   spy_test.main();
+  store_test.main();
 }

--- a/mobx/test/store_test.dart
+++ b/mobx/test/store_test.dart
@@ -1,0 +1,12 @@
+import 'package:mobx/mobx.dart';
+import 'package:test/test.dart';
+
+class TestStore with Store {}
+
+void main() {
+  group('Store', () {
+    test('can get context', () {
+      expect(TestStore().context, mainContext) ;
+    });
+  });
+}

--- a/mobx/test/store_test.dart
+++ b/mobx/test/store_test.dart
@@ -3,10 +3,23 @@ import 'package:test/test.dart';
 
 class TestStore with Store {}
 
+final customContext = ReactiveContext();
+
+class CustomStore with Store {
+  @override
+  ReactiveContext get context => customContext;
+}
+
 void main() {
   group('Store', () {
     test('can get context', () {
-      expect(TestStore().context, mainContext) ;
+      final store = TestStore();
+      expect(store.context, mainContext);
+    });
+
+    test('Store with custom context', () {
+      final store = CustomStore();
+      expect(store.context, customContext);
     });
   });
 }

--- a/mobx_codegen/lib/src/template/async_action.dart
+++ b/mobx_codegen/lib/src/template/async_action.dart
@@ -25,7 +25,7 @@ class AsyncActionTemplate {
 
   @override
   String toString() => """
-  final $_actionField = AsyncAction('${storeTemplate.parentTypeName}.${method.name}');
+  late final $_actionField = AsyncAction('${storeTemplate.parentTypeName}.${method.name}', context: context);
 
   @override
   $_futureType${method.returnTypeArgs} ${method.name}${method.typeParams}(${method.params}) {

--- a/mobx_codegen/lib/src/template/observable.dart
+++ b/mobx_codegen/lib/src/template/observable.dart
@@ -50,7 +50,7 @@ class ObservableTemplate {
 
   @override
   String toString() => """
-  final $atomName = Atom(name: '${storeTemplate.parentTypeName}.$name');
+  late final $atomName = Atom(name: '${storeTemplate.parentTypeName}.$name', context: context);
 
 ${_buildGetters()}
 

--- a/mobx_codegen/lib/src/template/observable_future.dart
+++ b/mobx_codegen/lib/src/template/observable_future.dart
@@ -11,6 +11,6 @@ class ObservableFutureTemplate {
   @override
   ObservableFuture${method.returnTypeArgs} ${method.name}${method.typeParams}(${method.params}) {
     final _\$future = super.${method.name}${method.typeArgs}(${method.args});
-    return ObservableFuture${method.returnTypeArgs}(_\$future);
+    return ObservableFuture${method.returnTypeArgs}(_\$future, context: context);
   }""";
 }

--- a/mobx_codegen/lib/src/template/observable_stream.dart
+++ b/mobx_codegen/lib/src/template/observable_stream.dart
@@ -11,6 +11,6 @@ class ObservableStreamTemplate {
   @override
   ObservableStream${method.returnTypeArgs} ${method.name}${method.typeParams}(${method.params}) {
     final _\$stream = super.${method.name}${method.typeArgs}(${method.args});
-    return ObservableStream${method.returnTypeArgs}(_\$stream);
+    return ObservableStream${method.returnTypeArgs}(_\$stream, context: context);
   }""";
 }

--- a/mobx_codegen/lib/src/template/store.dart
+++ b/mobx_codegen/lib/src/template/store.dart
@@ -42,7 +42,7 @@ abstract class StoreTemplate {
 
   String get actionControllerField => actions.isEmpty
       ? ''
-      : "final $actionControllerName = ActionController(name: '$parentTypeName');";
+      : "late final $actionControllerName = ActionController(name: '$parentTypeName', context: context);";
 
   String get toStringMethod {
     if (!generateToString) {

--- a/mobx_codegen/pubspec.yaml
+++ b/mobx_codegen/pubspec.yaml
@@ -12,7 +12,8 @@ dependencies:
   build: ^2.2.1
   build_resolvers: ^2.0.6
   meta: ^1.3.0
-  mobx: ^2.0.5
+  mobx: #^2.0.5
+    path: ../mobx
   path: ^1.8.0
   source_gen: ^1.2.1
 

--- a/mobx_codegen/pubspec.yaml
+++ b/mobx_codegen/pubspec.yaml
@@ -12,8 +12,7 @@ dependencies:
   build: ^2.2.1
   build_resolvers: ^2.0.6
   meta: ^1.3.0
-  mobx: #^2.0.5
-    path: ../mobx
+  mobx: ^2.0.5
   path: ^1.8.0
   source_gen: ^1.2.1
 
@@ -25,3 +24,7 @@ dev_dependencies:
   logging: ^1.0.2
   mocktail: ^0.2.0
   test: ^1.20.1
+
+dependency_overrides:
+  mobx:
+    path: ../mobx

--- a/mobx_codegen/test/all_tests.dart
+++ b/mobx_codegen/test/all_tests.dart
@@ -5,6 +5,7 @@ import 'mobx_codegen_test.dart' as mobx_codegen_test;
 import 'store_class_visitor_test.dart' as store_class_visitor_test;
 import 'templates_test.dart' as templates_test;
 import 'util_test.dart' as util_test;
+import 'store_with_custom_context.dart' as store_with_custom_context;
 
 void main() {
   generator_usage_test.main();
@@ -14,4 +15,5 @@ void main() {
   store_class_visitor_test.main();
   mobx_codegen_test.main();
   util_test.main();
+  store_with_custom_context.main();
 }

--- a/mobx_codegen/test/data/valid_generic_store_output.dart
+++ b/mobx_codegen/test/data/valid_generic_store_output.dart
@@ -1,5 +1,5 @@
 mixin _$Item<T extends num> on _Item<T>, Store {
-  final _$value1Atom = Atom(name: '_Item.value1');
+  late final _$value1Atom = Atom(name: '_Item.value1', context: context);
 
   @override
   T get value1 {
@@ -14,7 +14,7 @@ mixin _$Item<T extends num> on _Item<T>, Store {
     });
   }
 
-  final _$value2Atom = Atom(name: '_Item.value2');
+  late final _$value2Atom = Atom(name: '_Item.value2', context: context);
 
   @override
   T? get value2 {
@@ -29,7 +29,7 @@ mixin _$Item<T extends num> on _Item<T>, Store {
     });
   }
 
-  final _$values1Atom = Atom(name: '_Item.values1');
+  late final _$values1Atom = Atom(name: '_Item.values1', context: context);
 
   @override
   List<T> get values1 {
@@ -44,7 +44,7 @@ mixin _$Item<T extends num> on _Item<T>, Store {
     });
   }
 
-  final _$values2Atom = Atom(name: '_Item.values2');
+  late final _$values2Atom = Atom(name: '_Item.values2', context: context);
 
   @override
   List<T> get values2 {

--- a/mobx_codegen/test/data/valid_import_prefixed_output.dart
+++ b/mobx_codegen/test/data/valid_import_prefixed_output.dart
@@ -14,7 +14,7 @@ mixin _$User<T extends io.Process> on UserBase<T>, Store {
           name: 'UserBase.biographyNotesNullable'))
       .value;
 
-  final _$namesAtom = Atom(name: 'UserBase.names');
+  late final _$namesAtom = Atom(name: 'UserBase.names', context: context);
 
   @override
   List<String> get names {
@@ -29,7 +29,7 @@ mixin _$User<T extends io.Process> on UserBase<T>, Store {
     });
   }
 
-  final _$filesAtom = Atom(name: 'UserBase.files');
+  late final _$filesAtom = Atom(name: 'UserBase.files', context: context);
 
   @override
   List<io.File> get files {
@@ -44,7 +44,8 @@ mixin _$User<T extends io.Process> on UserBase<T>, Store {
     });
   }
 
-  final _$filesNullableAtom = Atom(name: 'UserBase.filesNullable');
+  late final _$filesNullableAtom =
+  Atom(name: 'UserBase.filesNullable', context: context);
 
   @override
   List<io.File?> get filesNullable {
@@ -59,7 +60,8 @@ mixin _$User<T extends io.Process> on UserBase<T>, Store {
     });
   }
 
-  final _$processesAtom = Atom(name: 'UserBase.processes');
+  late final _$processesAtom =
+  Atom(name: 'UserBase.processes', context: context);
 
   @override
   List<T> get processes {
@@ -74,7 +76,8 @@ mixin _$User<T extends io.Process> on UserBase<T>, Store {
     });
   }
 
-  final _$biographyAtom = Atom(name: 'UserBase.biography');
+  late final _$biographyAtom =
+  Atom(name: 'UserBase.biography', context: context);
 
   @override
   io.File get biography {
@@ -89,7 +92,8 @@ mixin _$User<T extends io.Process> on UserBase<T>, Store {
     });
   }
 
-  final _$biographyNullableAtom = Atom(name: 'UserBase.biographyNullable');
+  late final _$biographyNullableAtom =
+  Atom(name: 'UserBase.biographyNullable', context: context);
 
   @override
   io.File? get biographyNullable {
@@ -104,8 +108,8 @@ mixin _$User<T extends io.Process> on UserBase<T>, Store {
     });
   }
 
-  final _$friendWithImplicitTypeArgumentAtom =
-  Atom(name: 'UserBase.friendWithImplicitTypeArgument');
+  late final _$friendWithImplicitTypeArgumentAtom =
+  Atom(name: 'UserBase.friendWithImplicitTypeArgument', context: context);
 
   @override
   User<io.Process> get friendWithImplicitTypeArgument {
@@ -121,8 +125,9 @@ mixin _$User<T extends io.Process> on UserBase<T>, Store {
     });
   }
 
-  final _$friendWithImplicitTypeArgumentNullableAtom =
-  Atom(name: 'UserBase.friendWithImplicitTypeArgumentNullable');
+  late final _$friendWithImplicitTypeArgumentNullableAtom = Atom(
+      name: 'UserBase.friendWithImplicitTypeArgumentNullable',
+      context: context);
 
   @override
   User<io.Process>? get friendWithImplicitTypeArgumentNullable {
@@ -138,8 +143,8 @@ mixin _$User<T extends io.Process> on UserBase<T>, Store {
     });
   }
 
-  final _$friendWithExplicitTypeArgumentAtom =
-  Atom(name: 'UserBase.friendWithExplicitTypeArgument');
+  late final _$friendWithExplicitTypeArgumentAtom =
+  Atom(name: 'UserBase.friendWithExplicitTypeArgument', context: context);
 
   @override
   User<T> get friendWithExplicitTypeArgument {
@@ -155,8 +160,9 @@ mixin _$User<T extends io.Process> on UserBase<T>, Store {
     });
   }
 
-  final _$friendWithExplicitTypeArgumentNullableAtom =
-  Atom(name: 'UserBase.friendWithExplicitTypeArgumentNullable');
+  late final _$friendWithExplicitTypeArgumentNullableAtom = Atom(
+      name: 'UserBase.friendWithExplicitTypeArgumentNullable',
+      context: context);
 
   @override
   User<T>? get friendWithExplicitTypeArgumentNullable {
@@ -172,7 +178,7 @@ mixin _$User<T extends io.Process> on UserBase<T>, Store {
     });
   }
 
-  final _$callbackAtom = Atom(name: 'UserBase.callback');
+  late final _$callbackAtom = Atom(name: 'UserBase.callback', context: context);
 
   @override
   void Function(io.File, {T another}) get callback {
@@ -187,7 +193,8 @@ mixin _$User<T extends io.Process> on UserBase<T>, Store {
     });
   }
 
-  final _$callbackNullableAtom = Atom(name: 'UserBase.callbackNullable');
+  late final _$callbackNullableAtom =
+  Atom(name: 'UserBase.callbackNullable', context: context);
 
   @override
   void Function(io.File?, {T? another}) get callbackNullable {
@@ -202,7 +209,8 @@ mixin _$User<T extends io.Process> on UserBase<T>, Store {
     });
   }
 
-  final _$callback2Atom = Atom(name: 'UserBase.callback2');
+  late final _$callback2Atom =
+  Atom(name: 'UserBase.callback2', context: context);
 
   @override
   io.File Function(String, [int, io.File]) get callback2 {
@@ -217,7 +225,8 @@ mixin _$User<T extends io.Process> on UserBase<T>, Store {
     });
   }
 
-  final _$callback2NullableAtom = Atom(name: 'UserBase.callback2Nullable');
+  late final _$callback2NullableAtom =
+  Atom(name: 'UserBase.callback2Nullable', context: context);
 
   @override
   io.File? Function(String?, [int?, io.File?]) get callback2Nullable {
@@ -232,8 +241,8 @@ mixin _$User<T extends io.Process> on UserBase<T>, Store {
     });
   }
 
-  final _$localTypedefCallbackAtom =
-  Atom(name: 'UserBase.localTypedefCallback');
+  late final _$localTypedefCallbackAtom =
+  Atom(name: 'UserBase.localTypedefCallback', context: context);
 
   @override
   ValueCallback<io.Process> get localTypedefCallback {
@@ -249,8 +258,8 @@ mixin _$User<T extends io.Process> on UserBase<T>, Store {
         });
   }
 
-  final _$localTypedefCallbackNullableAtom =
-  Atom(name: 'UserBase.localTypedefCallbackNullable');
+  late final _$localTypedefCallbackNullableAtom =
+  Atom(name: 'UserBase.localTypedefCallbackNullable', context: context);
 
   @override
   ValueCallback<io.Process?> get localTypedefCallbackNullable {
@@ -266,8 +275,8 @@ mixin _$User<T extends io.Process> on UserBase<T>, Store {
     });
   }
 
-  final _$prefixedTypedefCallbackAtom =
-  Atom(name: 'UserBase.prefixedTypedefCallback');
+  late final _$prefixedTypedefCallbackAtom =
+  Atom(name: 'UserBase.prefixedTypedefCallback', context: context);
 
   @override
   io.BadCertificateCallback get prefixedTypedefCallback {
@@ -283,8 +292,8 @@ mixin _$User<T extends io.Process> on UserBase<T>, Store {
     });
   }
 
-  final _$prefixedTypedefCallbackNullableAtom =
-  Atom(name: 'UserBase.prefixedTypedefCallbackNullable');
+  late final _$prefixedTypedefCallbackNullableAtom =
+  Atom(name: 'UserBase.prefixedTypedefCallbackNullable', context: context);
 
   @override
   io.BadCertificateCallback? get prefixedTypedefCallbackNullable {
@@ -303,20 +312,20 @@ mixin _$User<T extends io.Process> on UserBase<T>, Store {
   @override
   ObservableFuture<io.File> futureBiography() {
     final _$future = super.futureBiography();
-    return ObservableFuture<io.File>(_$future);
+    return ObservableFuture<io.File>(_$future, context: context);
   }
 
   @override
   ObservableFuture<io.File?> futureBiographyNullable() {
     final _$future = super.futureBiographyNullable();
-    return ObservableFuture<io.File?>(_$future);
+    return ObservableFuture<io.File?>(_$future, context: context);
   }
 
   @override
   ObservableStream<T> loadDirectory<T extends io.Directory>(String arg1,
       {T directory}) {
     final _$stream = super.loadDirectory<T>(arg1, directory: directory);
-    return ObservableStream<T>(_$stream);
+    return ObservableStream<T>(_$stream, context: context);
   }
 
   @override
@@ -324,10 +333,11 @@ mixin _$User<T extends io.Process> on UserBase<T>, Store {
       String? arg1,
       {T? directory}) {
     final _$stream = super.loadDirectoryNullable<T>(arg1, directory: directory);
-    return ObservableStream<T?>(_$stream);
+    return ObservableStream<T?>(_$stream, context: context);
   }
 
-  final _$UserBaseActionController = ActionController(name: 'UserBase');
+  late final _$UserBaseActionController =
+  ActionController(name: 'UserBase', context: context);
 
   @override
   void updateBiography(io.File newBiography) {

--- a/mobx_codegen/test/data/valid_late_variables_output.dart
+++ b/mobx_codegen/test/data/valid_late_variables_output.dart
@@ -1,5 +1,6 @@
 mixin _$TestStore on _TestStore, Store {
-  final _$usernameAtom = Atom(name: '_TestStore.username');
+  late final _$usernameAtom =
+  Atom(name: '_TestStore.username', context: context);
 
   @override
   String get username {

--- a/mobx_codegen/test/data/valid_output.dart
+++ b/mobx_codegen/test/data/valid_output.dart
@@ -13,7 +13,8 @@ mixin _$User on UserBase, Store {
           name: 'UserBase.fullNameNullable'))
       .value;
 
-  final _$firstNameAtom = Atom(name: 'UserBase.firstName');
+  late final _$firstNameAtom =
+  Atom(name: 'UserBase.firstName', context: context);
 
   @override
   String get firstName {
@@ -28,7 +29,8 @@ mixin _$User on UserBase, Store {
     });
   }
 
-  final _$firstNameNullableAtom = Atom(name: 'UserBase.firstNameNullable');
+  late final _$firstNameNullableAtom =
+  Atom(name: 'UserBase.firstNameNullable', context: context);
 
   @override
   String? get firstNameNullable {
@@ -43,7 +45,8 @@ mixin _$User on UserBase, Store {
     });
   }
 
-  final _$middleNameAtom = Atom(name: 'UserBase.middleName');
+  late final _$middleNameAtom =
+  Atom(name: 'UserBase.middleName', context: context);
 
   @override
   String get middleName {
@@ -58,7 +61,7 @@ mixin _$User on UserBase, Store {
     });
   }
 
-  final _$lastNameAtom = Atom(name: 'UserBase.lastName');
+  late final _$lastNameAtom = Atom(name: 'UserBase.lastName', context: context);
 
   @override
   String get lastName {
@@ -73,7 +76,7 @@ mixin _$User on UserBase, Store {
     });
   }
 
-  final _$friendAtom = Atom(name: 'UserBase.friend');
+  late final _$friendAtom = Atom(name: 'UserBase.friend', context: context);
 
   @override
   User get friend {
@@ -88,7 +91,8 @@ mixin _$User on UserBase, Store {
     });
   }
 
-  final _$friendNullableAtom = Atom(name: 'UserBase.friendNullable');
+  late final _$friendNullableAtom =
+  Atom(name: 'UserBase.friendNullable', context: context);
 
   @override
   User? get friendNullable {
@@ -103,7 +107,7 @@ mixin _$User on UserBase, Store {
     });
   }
 
-  final _$callbackAtom = Atom(name: 'UserBase.callback');
+  late final _$callbackAtom = Atom(name: 'UserBase.callback', context: context);
 
   @override
   void Function() get callback {
@@ -118,7 +122,8 @@ mixin _$User on UserBase, Store {
     });
   }
 
-  final _$callbackNullableAtom = Atom(name: 'UserBase.callbackNullable');
+  late final _$callbackNullableAtom =
+  Atom(name: 'UserBase.callbackNullable', context: context);
 
   @override
   void Function() get callbackNullable {
@@ -133,7 +138,8 @@ mixin _$User on UserBase, Store {
     });
   }
 
-  final _$callback2Atom = Atom(name: 'UserBase.callback2');
+  late final _$callback2Atom =
+  Atom(name: 'UserBase.callback2', context: context);
 
   @override
   VoidCallback get callback2 {
@@ -148,7 +154,8 @@ mixin _$User on UserBase, Store {
     });
   }
 
-  final _$callback2NullableAtom = Atom(name: 'UserBase.callback2Nullable');
+  late final _$callback2NullableAtom =
+  Atom(name: 'UserBase.callback2Nullable', context: context);
 
   @override
   VoidCallback? get callback2Nullable {
@@ -163,7 +170,8 @@ mixin _$User on UserBase, Store {
     });
   }
 
-  final _$_testUsersAtom = Atom(name: 'UserBase._testUsers');
+  late final _$_testUsersAtom =
+  Atom(name: 'UserBase._testUsers', context: context);
 
   @override
   List<User> get _testUsers {
@@ -181,48 +189,49 @@ mixin _$User on UserBase, Store {
   @override
   ObservableFuture<String> foobar() {
     final _$future = super.foobar();
-    return ObservableFuture<String>(_$future);
+    return ObservableFuture<String>(_$future, context: context);
   }
 
   @override
   ObservableFuture<String?> foobarNullable() {
     final _$future = super.foobarNullable();
-    return ObservableFuture<String?>(_$future);
+    return ObservableFuture<String?>(_$future, context: context);
   }
 
   @override
   ObservableStream<T> loadStuff<T>(String arg1, {T value}) {
     final _$stream = super.loadStuff<T>(arg1, value: value);
-    return ObservableStream<T>(_$stream);
+    return ObservableStream<T>(_$stream, context: context);
   }
 
   @override
   ObservableStream<T?> loadStuffNullable<T>(String arg1, {T value}) {
     final _$stream = super.loadStuffNullable<T>(arg1, value: value);
-    return ObservableStream<T?>(_$stream);
+    return ObservableStream<T?>(_$stream, context: context);
   }
 
   @override
   ObservableStream<String> asyncGenerator() {
     final _$stream = super.asyncGenerator();
-    return ObservableStream<String>(_$stream);
+    return ObservableStream<String>(_$stream, context: context);
   }
 
   @override
   ObservableStream<String> asyncGeneratorNullable() {
     final _$stream = super.asyncGeneratorNullable();
-    return ObservableStream<String>(_$stream);
+    return ObservableStream<String>(_$stream, context: context);
   }
 
-  final _$fetchUsersAsyncAction = AsyncAction('UserBase.fetchUsers');
+  late final _$fetchUsersAsyncAction =
+  AsyncAction('UserBase.fetchUsers', context: context);
 
   @override
   Future<List<User>> fetchUsers() {
     return _$fetchUsersAsyncAction.run(() => super.fetchUsers());
   }
 
-  final _$fetchUsersNullableAsyncAction =
-  AsyncAction('UserBase.fetchUsersNullable');
+  late final _$fetchUsersNullableAsyncAction =
+  AsyncAction('UserBase.fetchUsersNullable', context: context);
 
   @override
   Future<List<User>> fetchUsersNullable() {
@@ -230,8 +239,8 @@ mixin _$User on UserBase, Store {
         .run(() => super.fetchUsersNullable());
   }
 
-  final _$setAsyncFirstNameNullableAsyncAction =
-  AsyncAction('UserBase.setAsyncFirstNameNullable');
+  late final _$setAsyncFirstNameNullableAsyncAction =
+  AsyncAction('UserBase.setAsyncFirstNameNullable', context: context);
 
   @override
   Future<void> setAsyncFirstNameNullable() {
@@ -239,16 +248,16 @@ mixin _$User on UserBase, Store {
         .run(() => super.setAsyncFirstNameNullable());
   }
 
-  final _$setAsyncFirstNameAsyncAction =
-  AsyncAction('UserBase.setAsyncFirstName');
+  late final _$setAsyncFirstNameAsyncAction =
+  AsyncAction('UserBase.setAsyncFirstName', context: context);
 
   @override
   Future<void> setAsyncFirstName() {
     return _$setAsyncFirstNameAsyncAction.run(() => super.setAsyncFirstName());
   }
 
-  final _$setAsyncFirstName2AsyncAction =
-  AsyncAction('UserBase.setAsyncFirstName2');
+  late final _$setAsyncFirstName2AsyncAction =
+  AsyncAction('UserBase.setAsyncFirstName2', context: context);
 
   @override
   ObservableFuture<void> setAsyncFirstName2() {
@@ -256,8 +265,8 @@ mixin _$User on UserBase, Store {
         _$setAsyncFirstName2AsyncAction.run(() => super.setAsyncFirstName2()));
   }
 
-  final _$setAsyncFirstName2NullableAsyncAction =
-  AsyncAction('UserBase.setAsyncFirstName2Nullable');
+  late final _$setAsyncFirstName2NullableAsyncAction =
+  AsyncAction('UserBase.setAsyncFirstName2Nullable', context: context);
 
   @override
   ObservableFuture<void> setAsyncFirstName2Nullable() {
@@ -265,7 +274,8 @@ mixin _$User on UserBase, Store {
         .run(() => super.setAsyncFirstName2Nullable()));
   }
 
-  final _$UserBaseActionController = ActionController(name: 'UserBase');
+  late final _$UserBaseActionController =
+  ActionController(name: 'UserBase', context: context);
 
   @override
   void updateNames({required String firstName, String lastName}) {

--- a/mobx_codegen/test/data/valid_output_annotation_store_config_has_to_string.dart
+++ b/mobx_codegen/test/data/valid_output_annotation_store_config_has_to_string.dart
@@ -23,7 +23,8 @@ mixin _$User on UserBase, Store {
           name: 'UserBase.fullNameNullable'))
       .value;
 
-  final _$firstNameAtom = Atom(name: 'UserBase.firstName');
+  late final _$firstNameAtom =
+  Atom(name: 'UserBase.firstName', context: context);
 
   @override
   String get firstName {
@@ -38,7 +39,8 @@ mixin _$User on UserBase, Store {
     });
   }
 
-  final _$firstNameNullableAtom = Atom(name: 'UserBase.firstNameNullable');
+  late final _$firstNameNullableAtom =
+  Atom(name: 'UserBase.firstNameNullable', context: context);
 
   @override
   String? get firstNameNullable {
@@ -53,7 +55,8 @@ mixin _$User on UserBase, Store {
     });
   }
 
-  final _$middleNameAtom = Atom(name: 'UserBase.middleName');
+  late final _$middleNameAtom =
+  Atom(name: 'UserBase.middleName', context: context);
 
   @override
   String get middleName {
@@ -68,7 +71,7 @@ mixin _$User on UserBase, Store {
     });
   }
 
-  final _$lastNameAtom = Atom(name: 'UserBase.lastName');
+  late final _$lastNameAtom = Atom(name: 'UserBase.lastName', context: context);
 
   @override
   String get lastName {
@@ -83,7 +86,7 @@ mixin _$User on UserBase, Store {
     });
   }
 
-  final _$friendAtom = Atom(name: 'UserBase.friend');
+  late final _$friendAtom = Atom(name: 'UserBase.friend', context: context);
 
   @override
   User get friend {
@@ -98,7 +101,8 @@ mixin _$User on UserBase, Store {
     });
   }
 
-  final _$friendNullableAtom = Atom(name: 'UserBase.friendNullable');
+  late final _$friendNullableAtom =
+  Atom(name: 'UserBase.friendNullable', context: context);
 
   @override
   User? get friendNullable {
@@ -113,7 +117,7 @@ mixin _$User on UserBase, Store {
     });
   }
 
-  final _$callbackAtom = Atom(name: 'UserBase.callback');
+  late final _$callbackAtom = Atom(name: 'UserBase.callback', context: context);
 
   @override
   void Function() get callback {
@@ -128,7 +132,8 @@ mixin _$User on UserBase, Store {
     });
   }
 
-  final _$callbackNullableAtom = Atom(name: 'UserBase.callbackNullable');
+  late final _$callbackNullableAtom =
+  Atom(name: 'UserBase.callbackNullable', context: context);
 
   @override
   void Function() get callbackNullable {
@@ -143,7 +148,8 @@ mixin _$User on UserBase, Store {
     });
   }
 
-  final _$callback2Atom = Atom(name: 'UserBase.callback2');
+  late final _$callback2Atom =
+  Atom(name: 'UserBase.callback2', context: context);
 
   @override
   VoidCallback get callback2 {
@@ -158,7 +164,8 @@ mixin _$User on UserBase, Store {
     });
   }
 
-  final _$callback2NullableAtom = Atom(name: 'UserBase.callback2Nullable');
+  late final _$callback2NullableAtom =
+  Atom(name: 'UserBase.callback2Nullable', context: context);
 
   @override
   VoidCallback? get callback2Nullable {
@@ -173,7 +180,8 @@ mixin _$User on UserBase, Store {
     });
   }
 
-  final _$_testUsersAtom = Atom(name: 'UserBase._testUsers');
+  late final _$_testUsersAtom =
+  Atom(name: 'UserBase._testUsers', context: context);
 
   @override
   List<User> get _testUsers {
@@ -191,48 +199,49 @@ mixin _$User on UserBase, Store {
   @override
   ObservableFuture<String> foobar() {
     final _$future = super.foobar();
-    return ObservableFuture<String>(_$future);
+    return ObservableFuture<String>(_$future, context: context);
   }
 
   @override
   ObservableFuture<String?> foobarNullable() {
     final _$future = super.foobarNullable();
-    return ObservableFuture<String?>(_$future);
+    return ObservableFuture<String?>(_$future, context: context);
   }
 
   @override
   ObservableStream<T> loadStuff<T>(String arg1, {T value}) {
     final _$stream = super.loadStuff<T>(arg1, value: value);
-    return ObservableStream<T>(_$stream);
+    return ObservableStream<T>(_$stream, context: context);
   }
 
   @override
   ObservableStream<T?> loadStuffNullable<T>(String arg1, {T value}) {
     final _$stream = super.loadStuffNullable<T>(arg1, value: value);
-    return ObservableStream<T?>(_$stream);
+    return ObservableStream<T?>(_$stream, context: context);
   }
 
   @override
   ObservableStream<String> asyncGenerator() {
     final _$stream = super.asyncGenerator();
-    return ObservableStream<String>(_$stream);
+    return ObservableStream<String>(_$stream, context: context);
   }
 
   @override
   ObservableStream<String> asyncGeneratorNullable() {
     final _$stream = super.asyncGeneratorNullable();
-    return ObservableStream<String>(_$stream);
+    return ObservableStream<String>(_$stream, context: context);
   }
 
-  final _$fetchUsersAsyncAction = AsyncAction('UserBase.fetchUsers');
+  late final _$fetchUsersAsyncAction =
+  AsyncAction('UserBase.fetchUsers', context: context);
 
   @override
   Future<List<User>> fetchUsers() {
     return _$fetchUsersAsyncAction.run(() => super.fetchUsers());
   }
 
-  final _$fetchUsersNullableAsyncAction =
-  AsyncAction('UserBase.fetchUsersNullable');
+  late final _$fetchUsersNullableAsyncAction =
+  AsyncAction('UserBase.fetchUsersNullable', context: context);
 
   @override
   Future<List<User>> fetchUsersNullable() {
@@ -240,8 +249,8 @@ mixin _$User on UserBase, Store {
         .run(() => super.fetchUsersNullable());
   }
 
-  final _$setAsyncFirstNameNullableAsyncAction =
-  AsyncAction('UserBase.setAsyncFirstNameNullable');
+  late final _$setAsyncFirstNameNullableAsyncAction =
+  AsyncAction('UserBase.setAsyncFirstNameNullable', context: context);
 
   @override
   Future<void> setAsyncFirstNameNullable() {
@@ -249,16 +258,16 @@ mixin _$User on UserBase, Store {
         .run(() => super.setAsyncFirstNameNullable());
   }
 
-  final _$setAsyncFirstNameAsyncAction =
-  AsyncAction('UserBase.setAsyncFirstName');
+  late final _$setAsyncFirstNameAsyncAction =
+  AsyncAction('UserBase.setAsyncFirstName', context: context);
 
   @override
   Future<void> setAsyncFirstName() {
     return _$setAsyncFirstNameAsyncAction.run(() => super.setAsyncFirstName());
   }
 
-  final _$setAsyncFirstName2AsyncAction =
-  AsyncAction('UserBase.setAsyncFirstName2');
+  late final _$setAsyncFirstName2AsyncAction =
+  AsyncAction('UserBase.setAsyncFirstName2', context: context);
 
   @override
   ObservableFuture<void> setAsyncFirstName2() {
@@ -266,8 +275,8 @@ mixin _$User on UserBase, Store {
         _$setAsyncFirstName2AsyncAction.run(() => super.setAsyncFirstName2()));
   }
 
-  final _$setAsyncFirstName2NullableAsyncAction =
-  AsyncAction('UserBase.setAsyncFirstName2Nullable');
+  late final _$setAsyncFirstName2NullableAsyncAction =
+  AsyncAction('UserBase.setAsyncFirstName2Nullable', context: context);
 
   @override
   ObservableFuture<void> setAsyncFirstName2Nullable() {
@@ -275,7 +284,8 @@ mixin _$User on UserBase, Store {
         .run(() => super.setAsyncFirstName2Nullable()));
   }
 
-  final _$UserBaseActionController = ActionController(name: 'UserBase');
+  late final _$UserBaseActionController =
+  ActionController(name: 'UserBase', context: context);
 
   @override
   void updateNames({required String firstName, String lastName}) {

--- a/mobx_codegen/test/generator_usage_test.g.dart
+++ b/mobx_codegen/test/generator_usage_test.g.dart
@@ -23,7 +23,7 @@ mixin _$TestStore on _TestStore, Store {
               name: '_TestStore.batchedItems'))
           .value;
 
-  final _$field1Atom = Atom(name: '_TestStore.field1');
+  late final _$field1Atom = Atom(name: '_TestStore.field1', context: context);
 
   @override
   String get field1 {
@@ -38,7 +38,7 @@ mixin _$TestStore on _TestStore, Store {
     });
   }
 
-  final _$field2Atom = Atom(name: '_TestStore.field2');
+  late final _$field2Atom = Atom(name: '_TestStore.field2', context: context);
 
   @override
   String? get field2 {
@@ -53,7 +53,7 @@ mixin _$TestStore on _TestStore, Store {
     });
   }
 
-  final _$stuffAtom = Atom(name: '_TestStore.stuff');
+  late final _$stuffAtom = Atom(name: '_TestStore.stuff', context: context);
 
   @override
   String get stuff {
@@ -68,7 +68,8 @@ mixin _$TestStore on _TestStore, Store {
     });
   }
 
-  final _$batchItem1Atom = Atom(name: '_TestStore.batchItem1');
+  late final _$batchItem1Atom =
+      Atom(name: '_TestStore.batchItem1', context: context);
 
   @override
   String get batchItem1 {
@@ -83,7 +84,8 @@ mixin _$TestStore on _TestStore, Store {
     });
   }
 
-  final _$batchItem2Atom = Atom(name: '_TestStore.batchItem2');
+  late final _$batchItem2Atom =
+      Atom(name: '_TestStore.batchItem2', context: context);
 
   @override
   String get batchItem2 {
@@ -98,7 +100,8 @@ mixin _$TestStore on _TestStore, Store {
     });
   }
 
-  final _$batchItem3Atom = Atom(name: '_TestStore.batchItem3');
+  late final _$batchItem3Atom =
+      Atom(name: '_TestStore.batchItem3', context: context);
 
   @override
   String get batchItem3 {
@@ -113,7 +116,8 @@ mixin _$TestStore on _TestStore, Store {
     });
   }
 
-  final _$batchItem4Atom = Atom(name: '_TestStore.batchItem4');
+  late final _$batchItem4Atom =
+      Atom(name: '_TestStore.batchItem4', context: context);
 
   @override
   String get batchItem4 {
@@ -128,7 +132,8 @@ mixin _$TestStore on _TestStore, Store {
     });
   }
 
-  final _$errorFieldAtom = Atom(name: '_TestStore.errorField');
+  late final _$errorFieldAtom =
+      Atom(name: '_TestStore.errorField', context: context);
 
   @override
   String get errorField {
@@ -146,35 +151,37 @@ mixin _$TestStore on _TestStore, Store {
   @override
   ObservableFuture<String> future() {
     final _$future = super.future();
-    return ObservableFuture<String>(_$future);
+    return ObservableFuture<String>(_$future, context: context);
   }
 
   @override
   ObservableFuture<String> asyncMethod() {
     final _$future = super.asyncMethod();
-    return ObservableFuture<String>(_$future);
+    return ObservableFuture<String>(_$future, context: context);
   }
 
   @override
   ObservableStream<String> asyncGenerator() {
     final _$stream = super.asyncGenerator();
-    return ObservableStream<String>(_$stream);
+    return ObservableStream<String>(_$stream, context: context);
   }
 
   @override
   ObservableStream<String> stream() {
     final _$stream = super.stream();
-    return ObservableStream<String>(_$stream);
+    return ObservableStream<String>(_$stream, context: context);
   }
 
-  final _$loadStuffAsyncAction = AsyncAction('_TestStore.loadStuff');
+  late final _$loadStuffAsyncAction =
+      AsyncAction('_TestStore.loadStuff', context: context);
 
   @override
   Future<void> loadStuff() {
     return _$loadStuffAsyncAction.run(() => super.loadStuff());
   }
 
-  final _$loadStuff2AsyncAction = AsyncAction('_TestStore.loadStuff2');
+  late final _$loadStuff2AsyncAction =
+      AsyncAction('_TestStore.loadStuff2', context: context);
 
   @override
   ObservableFuture<void> loadStuff2() {
@@ -182,21 +189,24 @@ mixin _$TestStore on _TestStore, Store {
         _$loadStuff2AsyncAction.run(() => super.loadStuff2()));
   }
 
-  final _$batchedChangesAsyncAction = AsyncAction('_TestStore.batchedChanges');
+  late final _$batchedChangesAsyncAction =
+      AsyncAction('_TestStore.batchedChanges', context: context);
 
   @override
   Future<void> batchedChanges() {
     return _$batchedChangesAsyncAction.run(() => super.batchedChanges());
   }
 
-  final _$throwsErrorAsyncAction = AsyncAction('_TestStore.throwsError');
+  late final _$throwsErrorAsyncAction =
+      AsyncAction('_TestStore.throwsError', context: context);
 
   @override
   Future<void> throwsError() {
     return _$throwsErrorAsyncAction.run(() => super.throwsError());
   }
 
-  final _$_TestStoreActionController = ActionController(name: '_TestStore');
+  late final _$_TestStoreActionController =
+      ActionController(name: '_TestStore', context: context);
 
   @override
   void setFields(String field1, String field2) {

--- a/mobx_codegen/test/store_with_custom_context.dart
+++ b/mobx_codegen/test/store_with_custom_context.dart
@@ -1,0 +1,24 @@
+import 'package:mobx/mobx.dart';
+import 'package:test/test.dart';
+
+part 'store_with_custom_context.g.dart';
+
+class CustomContextStore = _CustomContextStore with _$CustomContextStore;
+
+final ReactiveContext customContext = ReactiveContext();
+
+abstract class _CustomContextStore with Store {
+  @observable
+  late String name;
+
+  @override
+  ReactiveContext get context => customContext;
+}
+
+void main() {
+  test('use custom context', () {
+    final store = CustomContextStore();
+
+    expect(store._$nameAtom.context, equals(customContext));
+  });
+}

--- a/mobx_codegen/test/store_with_custom_context.g.dart
+++ b/mobx_codegen/test/store_with_custom_context.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'nested_store.dart';
+part of 'store_with_custom_context.dart';
 
 // **************************************************************************
 // StoreGenerator
@@ -8,8 +8,9 @@ part of 'nested_store.dart';
 
 // ignore_for_file: non_constant_identifier_names, unnecessary_brace_in_string_interps, unnecessary_lambdas, prefer_expression_function_bodies, lines_longer_than_80_chars, avoid_as, avoid_annotating_with_dynamic
 
-mixin _$NestedStore on _NestedStore, Store {
-  late final _$nameAtom = Atom(name: '_NestedStore.name', context: context);
+mixin _$CustomContextStore on _CustomContextStore, Store {
+  late final _$nameAtom =
+      Atom(name: '_CustomContextStore.name', context: context);
 
   @override
   String get name {

--- a/mobx_codegen/test/templates_test.dart
+++ b/mobx_codegen/test/templates_test.dart
@@ -24,7 +24,10 @@ void main() {
 
   group('Rows', () {
     test('Rows toString joins non empty strings on their own lines', () {
-      final rows = Rows()..add('first')..add('')..add('third');
+      final rows = Rows()
+        ..add('first')
+        ..add('')
+        ..add('third');
 
       expect(rows.toString(), equals('first\nthird'));
     });
@@ -110,13 +113,14 @@ void main() {
     group('renders template based on template data', () {
       test('on public field', () {
         final template = ObservableTemplate(
-            storeTemplate: (MixinStoreTemplate()..parentTypeName = 'ParentName'),
+            storeTemplate: (MixinStoreTemplate()
+              ..parentTypeName = 'ParentName'),
             atomName: '_atomFieldName',
             type: 'FieldType',
             name: 'fieldName');
         final output = template.toString();
         expect(output, equals("""
-  final _atomFieldName = Atom(name: 'ParentName.fieldName');
+  late final _atomFieldName = Atom(name: 'ParentName.fieldName', context: context);
 
   @override
   FieldType get fieldName {
@@ -137,13 +141,13 @@ void main() {
           storeTemplate: (MixinStoreTemplate()..parentTypeName = 'ParentName'),
           atomName: '_atomFieldName',
           type: 'FieldType',
-          name: '_fieldName', 
+          name: '_fieldName',
           isPrivate: true,
           isReadOnly: true,
         );
         final output = template.toString();
         expect(output, equals("""
-  final _atomFieldName = Atom(name: 'ParentName._fieldName');
+  late final _atomFieldName = Atom(name: 'ParentName._fieldName', context: context);
 
   FieldType get fieldName {
     _atomFieldName.reportRead();
@@ -293,7 +297,7 @@ void main() {
   @override
   ObservableFuture<T> fetchData<T, S extends String>(T arg1, [S arg2 = "arg2value", String arg3], {String namedArg1 = "default", int namedArg2 = 3}) {
     final _\$future = super.fetchData<T, S>(arg1, arg2, arg3, namedArg1: namedArg1, namedArg2: namedArg2);
-    return ObservableFuture<T>(_\$future);
+    return ObservableFuture<T>(_\$future, context: context);
   }"""));
     });
   });


### PR DESCRIPTION
close https://github.com/mobxjs/mobx.dart/issues/718


```dart
class CustomContextStore = _CustomContextStore with _$CustomContextStore;

final ReactiveContext customContext = ReactiveContext();

abstract class _CustomContextStore with Store {
  @observable
  late String name;

  @override
  ReactiveContext get context => customContext;
}
```


```dart
mixin _$CustomContextStore on _CustomContextStore, Store {
  late final _$nameAtom =
      Atom(name: '_CustomContextStore.name', context: context);

  @override
  String get name {
    _$nameAtom.reportRead();
    return super.name;
  }

  @override
  set name(String value) {
    _$nameAtom.reportWrite(value, super.name, () {
      super.name = value;
    });
  }

  @override
  String toString() {
    return '''
name: ${name}
    ''';
  }
}
```