### PR TITLE
Observable extensions

### DIFF
--- a/mobx/CHANGELOG.md
+++ b/mobx/CHANGELOG.md
@@ -8,7 +8,7 @@
   var name = ''.asObservable(); // infers ObservableString
   var counter = 0.asObservable(); // infers ObservableInt
   ```
-- `toggle()` method for ObservableBool. Lets you toggle the internal value of ObservableBool
+- `toggle()` method for `ObservableBool`. Lets you toggle the internal value of `ObservableBool`
   ```dart
   var lights = true.asObservable();
   lights.toggle(); // now it has a value of false

--- a/mobx/CHANGELOG.md
+++ b/mobx/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 2.0.7
+
+- Type aliases for primitive types.\
+  So instead of `Observable<int>` you can now write `ObservableInt`.
+- `.asObservable()` extension for primitive types.\
+  Now you can easily convert literals to observables like:
+  ```dart
+  var name = ''.asObservable(); // infers ObservableString
+  var counter = 0.asObservable(); // infers ObservableInt
+  ```
+- `toggle()` method for ObservableBool. Lets you toggle the internal value of ObservableBool
+  ```dart
+  var lights = true.asObservable();
+  lights.toggle(); // now it has a value of false
+  ```
+  Changes made by [@subzero911](https://github.com/subzero911)
+
 ## 2.0.6 - 2.0.6+1
 
 - Improved performance when spying is disabled. Thanks to @Ascenio.

--- a/mobx/lib/mobx.dart
+++ b/mobx/lib/mobx.dart
@@ -65,4 +65,4 @@ export 'package:mobx/src/core.dart'
 export 'package:mobx/src/core/atom_extensions.dart';
 
 /// The current version as per `pubspec.yaml`
-const version = '2.0.6+1';
+const version = '2.0.7';

--- a/mobx/lib/src/api/extensions.dart
+++ b/mobx/lib/src/api/extensions.dart
@@ -1,5 +1,6 @@
 import '../core.dart';
 import 'async.dart';
+import 'action.dart';
 import 'observable_collections.dart';
 
 part 'extensions/observable_stream_extension.dart';

--- a/mobx/lib/src/api/extensions.dart
+++ b/mobx/lib/src/api/extensions.dart
@@ -7,3 +7,4 @@ part 'extensions/observable_future_extension.dart';
 part 'extensions/observable_list_extension.dart';
 part 'extensions/observable_set_extension.dart';
 part 'extensions/observable_map_extension.dart';
+part 'extensions/primitive_types_extensions.dart';

--- a/mobx/lib/src/api/extensions/primitive_types_extensions.dart
+++ b/mobx/lib/src/api/extensions/primitive_types_extensions.dart
@@ -1,5 +1,6 @@
 part of '../extensions.dart';
 
+
 extension ObservableIntExtension on int {
   ObservableInt asObservable({ReactiveContext? context, String? name}) {
     return Observable(this, context: context, name: name);
@@ -11,11 +12,20 @@ extension ObservableBoolExtension on bool {
     return Observable(this, context: context, name: name);
   }
 }
+
+/// lets you toggle the internal value of ObservableBool
+extension ObservableBoolToggle on ObservableBool {
+  void toggle() {
+    runInAction(() => value = !value);
+  }
+}
+
 extension ObservableDoubleExtension on double {
   ObservableDouble asObservable({ReactiveContext? context, String? name}) {
     return Observable(this, context: context, name: name);
   }
 }
+
 extension ObservableStringExtension on String {
   ObservableString asObservable({ReactiveContext? context, String? name}) {
     return Observable(this, context: context, name: name);

--- a/mobx/lib/src/api/extensions/primitive_types_extensions.dart
+++ b/mobx/lib/src/api/extensions/primitive_types_extensions.dart
@@ -1,32 +1,32 @@
 part of '../extensions.dart';
 
 
-extension ObservableIntExtension on int {
+extension IntExtension on int {
   ObservableInt asObservable({ReactiveContext? context, String? name}) {
     return Observable(this, context: context, name: name);
   }
 }
 
-extension ObservableBoolExtension on bool {
+extension BoolExtension on bool {
   ObservableBool asObservable({ReactiveContext? context, String? name}) {
     return Observable(this, context: context, name: name);
   }
 }
 
 /// lets you toggle the internal value of ObservableBool
-extension ObservableBoolToggle on ObservableBool {
+extension ObservableBoolExtension on ObservableBool {
   void toggle() {
     runInAction(() => value = !value);
   }
 }
 
-extension ObservableDoubleExtension on double {
+extension DoubleExtension on double {
   ObservableDouble asObservable({ReactiveContext? context, String? name}) {
     return Observable(this, context: context, name: name);
   }
 }
 
-extension ObservableStringExtension on String {
+extension StringExtension on String {
   ObservableString asObservable({ReactiveContext? context, String? name}) {
     return Observable(this, context: context, name: name);
   }

--- a/mobx/lib/src/api/extensions/primitive_types_extensions.dart
+++ b/mobx/lib/src/api/extensions/primitive_types_extensions.dart
@@ -1,12 +1,13 @@
 part of '../extensions.dart';
 
-
+/// turns an int into ObservableInt
 extension IntExtension on int {
   ObservableInt asObservable({ReactiveContext? context, String? name}) {
     return Observable(this, context: context, name: name);
   }
 }
 
+/// turns a bool into ObservableBool
 extension BoolExtension on bool {
   ObservableBool asObservable({ReactiveContext? context, String? name}) {
     return Observable(this, context: context, name: name);
@@ -20,12 +21,14 @@ extension ObservableBoolExtension on ObservableBool {
   }
 }
 
+/// turns a double into ObservableDouble
 extension DoubleExtension on double {
   ObservableDouble asObservable({ReactiveContext? context, String? name}) {
     return Observable(this, context: context, name: name);
   }
 }
 
+/// turns a String into ObservableString
 extension StringExtension on String {
   ObservableString asObservable({ReactiveContext? context, String? name}) {
     return Observable(this, context: context, name: name);

--- a/mobx/lib/src/api/extensions/primitive_types_extensions.dart
+++ b/mobx/lib/src/api/extensions/primitive_types_extensions.dart
@@ -1,0 +1,23 @@
+part of '../extensions.dart';
+
+extension ObservableIntExtension on int {
+  ObservableInt asObservable({ReactiveContext? context, String? name}) {
+    return Observable(this, context: context, name: name);
+  }
+}
+
+extension ObservableBoolExtension on bool {
+  ObservableBool asObservable({ReactiveContext? context, String? name}) {
+    return Observable(this, context: context, name: name);
+  }
+}
+extension ObservableDoubleExtension on double {
+  ObservableDouble asObservable({ReactiveContext? context, String? name}) {
+    return Observable(this, context: context, name: name);
+  }
+}
+extension ObservableStringExtension on String {
+  ObservableString asObservable({ReactiveContext? context, String? name}) {
+    return Observable(this, context: context, name: name);
+  }
+}

--- a/mobx/lib/src/core.dart
+++ b/mobx/lib/src/core.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 import 'dart:collection';
 
-import 'package:mobx/mobx.dart';
-import 'package:mobx/src/utils.dart';
+import '../mobx.dart';
+import 'utils.dart';
 
 part 'core/action.dart';
 part 'core/atom.dart';
@@ -15,9 +15,10 @@ part 'core/observable.dart';
 part 'core/observable_value.dart';
 part 'core/reaction.dart';
 part 'core/reaction_helper.dart';
+part 'core/spy.dart';
+part 'core/typedefs.dart';
 part 'interceptable.dart';
 part 'listenable.dart';
-part 'core/spy.dart';
 
 /// An Exception class to capture MobX specific exceptions
 class MobXException extends Error implements Exception {

--- a/mobx/lib/src/core/typedefs.dart
+++ b/mobx/lib/src/core/typedefs.dart
@@ -1,0 +1,7 @@
+part of '../core.dart';
+
+/// aliases for primitive types
+typedef ObservableInt = Observable<int>;
+typedef ObservableDouble = Observable<double>;
+typedef ObservableBool = Observable<bool>;
+typedef ObservableString = Observable<String>;

--- a/mobx/pubspec.yaml
+++ b/mobx/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mobx
-version: 2.0.6+1
+version: 2.0.7
 description: "MobX is a library for reactively managing the state of your applications. Use the power of observables, actions, and reactions to supercharge your Dart and Flutter apps."
 
 homepage: https://github.com/mobxjs/mobx.dart

--- a/mobx/pubspec.yaml
+++ b/mobx/pubspec.yaml
@@ -5,7 +5,7 @@ description: "MobX is a library for reactively managing the state of your applic
 homepage: https://github.com/mobxjs/mobx.dart
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.13.0 <3.0.0'
 
 dependencies:
   meta: ^1.3.0

--- a/mobx/test/extensions/primitive_types_extensions_test.dart
+++ b/mobx/test/extensions/primitive_types_extensions_test.dart
@@ -1,0 +1,37 @@
+import 'package:mobx/mobx.dart';
+import 'package:test/test.dart';
+
+import '../util.dart';
+
+void main() {
+  testSetup();
+
+  group('PrimitiveTypesExtensions', () {
+    test('Transform Int into ObservableInt', () {
+      final count = 0;
+      expect(count.asObservable(), isA<ObservableInt>());
+    });
+
+    test('Transform Double into ObservableDouble', () {
+      final count = 0.0;
+      expect(count.asObservable(), isA<ObservableDouble>());
+    });
+
+    test('Transform Bool into ObservableBool', () {
+      final flag = false;
+      expect(flag.asObservable(), isA<ObservableBool>());
+    });
+
+    test('Transform String into ObservableString', () {
+      final str = '';
+      expect(str.asObservable(), isA<ObservableString>());
+    });
+
+    test('Toggles ObservableBool', () {
+      final flag = false.asObservable();
+      flag.toggle();
+      expect(flag.value, equals(true));
+    });
+
+  });
+}


### PR DESCRIPTION
Dear MobX maintainers, I created some extensions to make a code more concise. I hope you find them useful.
1. Type aliases for primitive types.
So instead of `Observable<int>` you can now write `ObservableInt`.
But it uses the Dart 2.13 feature "type aliases", so I bumped sdk constraints in pubspec to min 2.13
2. `asObservable()` extensions for primitive types. Now you can easily convert literals to observables like:
```dart
var name = ''.asObservable(); // infers ObservableString
var counter = 0.asObservable(); // infers ObservableInt
```
3. `toggle()` method for ObservableBool. Lets you toggle the internal value of ObservableBool
```dart
var lights = true.asObservable();
lights.toggle(); // now it has a value of false
```