### PR TITLE
renamed asObservable() to toObs()

### DIFF
--- a/docs/docs/guides/cheat-sheet.mdx
+++ b/docs/docs/guides/cheat-sheet.mdx
@@ -124,11 +124,11 @@ MobX also comes with a set of wrapper-classes that add the reactive behavior. Th
 
 > ### Reactive Extensions
 >
-> You can convert plain `List`, `Map`, `Set`, `Future` and `Stream` instances into an observable version with the `asObservable()` extension method.
+> You can convert plain `List`, `Map`, `Set`, `Future` and `Stream` instances into an observable version with the `toObs()` extension method.
 > For example, in the code-snippet above, you could do:
 >
 > ```dart
-> ObservableList<String> phoneNumbers = [].asObservable();
+> ObservableList<String> phoneNumbers = [].toObs();
 > ```
 
 ## Don't underestimate the @computed

--- a/mobx/CHANGELOG.md
+++ b/mobx/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.7+3
+- `asObservable()` renamed to shorter `toObs()` - [@subzero911](https://github.com/subzero911)
+
 ## 2.0.7+1 - 2.0.7+2
 
 - Package upgrades

--- a/mobx/lib/mobx.dart
+++ b/mobx/lib/mobx.dart
@@ -65,4 +65,4 @@ export 'package:mobx/src/core.dart'
 export 'package:mobx/src/core/atom_extensions.dart';
 
 /// The current version as per `pubspec.yaml`
-const version = '2.0.7+2';
+const version = '2.0.7+3';

--- a/mobx/lib/src/api/extensions/observable_future_extension.dart
+++ b/mobx/lib/src/api/extensions/observable_future_extension.dart
@@ -3,8 +3,7 @@ part of '../extensions.dart';
 /// Turn the Future into an ObservableFuture.
 extension ObservableFutureExtension<T> on Future<T> {
   @Deprecated('Use toObs() instead')
-  ObservableFuture<T> asObservable({ReactiveContext? context, String? name}) =>
-      ObservableFuture<T>(this, context: context, name: name);
+  ObservableFuture<T> asObservable({ReactiveContext? context, String? name})  => toObs(context: context, name: name);
 
   ObservableFuture<T> toObs({ReactiveContext? context, String? name}) =>
       ObservableFuture<T>(this, context: context, name: name);

--- a/mobx/lib/src/api/extensions/observable_future_extension.dart
+++ b/mobx/lib/src/api/extensions/observable_future_extension.dart
@@ -2,6 +2,10 @@ part of '../extensions.dart';
 
 /// Turn the Future into an ObservableFuture.
 extension ObservableFutureExtension<T> on Future<T> {
+  @Deprecated('Use toObs() instead')
   ObservableFuture<T> asObservable({ReactiveContext? context, String? name}) =>
+      ObservableFuture<T>(this, context: context, name: name);
+
+  ObservableFuture<T> toObs({ReactiveContext? context, String? name}) =>
       ObservableFuture<T>(this, context: context, name: name);
 }

--- a/mobx/lib/src/api/extensions/observable_list_extension.dart
+++ b/mobx/lib/src/api/extensions/observable_list_extension.dart
@@ -2,6 +2,10 @@ part of '../extensions.dart';
 
 /// Turn the List into an ObservableList.
 extension ObservableListExtension<T> on List<T> {
+  @Deprecated('Use toObs() instead')
   ObservableList<T> asObservable({ReactiveContext? context, String? name}) =>
+      ObservableList<T>.of(this, context: context, name: name);
+
+  ObservableList<T> toObs({ReactiveContext? context, String? name}) =>
       ObservableList<T>.of(this, context: context, name: name);
 }

--- a/mobx/lib/src/api/extensions/observable_list_extension.dart
+++ b/mobx/lib/src/api/extensions/observable_list_extension.dart
@@ -3,8 +3,7 @@ part of '../extensions.dart';
 /// Turn the List into an ObservableList.
 extension ObservableListExtension<T> on List<T> {
   @Deprecated('Use toObs() instead')
-  ObservableList<T> asObservable({ReactiveContext? context, String? name}) =>
-      ObservableList<T>.of(this, context: context, name: name);
+  ObservableList<T> asObservable({ReactiveContext? context, String? name})  => toObs(context: context, name: name);
 
   ObservableList<T> toObs({ReactiveContext? context, String? name}) =>
       ObservableList<T>.of(this, context: context, name: name);

--- a/mobx/lib/src/api/extensions/observable_map_extension.dart
+++ b/mobx/lib/src/api/extensions/observable_map_extension.dart
@@ -3,8 +3,7 @@ part of '../extensions.dart';
 /// Turn the Map into an ObservableMap.
 extension ObservableMapExtension<K, V> on Map<K, V> {
   @Deprecated('Use toObs() instead')
-  ObservableMap<K, V> asObservable({ReactiveContext? context, String? name}) =>
-      ObservableMap<K, V>.of(this, context: context, name: name);
+  ObservableMap<K, V> asObservable({ReactiveContext? context, String? name})  => toObs(context: context, name: name);
 
   ObservableMap<K, V> toObs({ReactiveContext? context, String? name}) =>
       ObservableMap<K, V>.of(this, context: context, name: name);

--- a/mobx/lib/src/api/extensions/observable_map_extension.dart
+++ b/mobx/lib/src/api/extensions/observable_map_extension.dart
@@ -2,6 +2,10 @@ part of '../extensions.dart';
 
 /// Turn the Map into an ObservableMap.
 extension ObservableMapExtension<K, V> on Map<K, V> {
+  @Deprecated('Use toObs() instead')
   ObservableMap<K, V> asObservable({ReactiveContext? context, String? name}) =>
+      ObservableMap<K, V>.of(this, context: context, name: name);
+
+  ObservableMap<K, V> toObs({ReactiveContext? context, String? name}) =>
       ObservableMap<K, V>.of(this, context: context, name: name);
 }

--- a/mobx/lib/src/api/extensions/observable_set_extension.dart
+++ b/mobx/lib/src/api/extensions/observable_set_extension.dart
@@ -2,6 +2,10 @@ part of '../extensions.dart';
 
 /// Turn the Set into an ObservableSet.
 extension ObservableSetExtension<T> on Set<T> {
+  @Deprecated('Use toObs() instead')
   ObservableSet<T> asObservable({ReactiveContext? context, String? name}) =>
+      ObservableSet<T>.of(this, context: context, name: name);
+
+  ObservableSet<T> toObs({ReactiveContext? context, String? name}) =>
       ObservableSet<T>.of(this, context: context, name: name);
 }

--- a/mobx/lib/src/api/extensions/observable_set_extension.dart
+++ b/mobx/lib/src/api/extensions/observable_set_extension.dart
@@ -3,8 +3,7 @@ part of '../extensions.dart';
 /// Turn the Set into an ObservableSet.
 extension ObservableSetExtension<T> on Set<T> {
   @Deprecated('Use toObs() instead')
-  ObservableSet<T> asObservable({ReactiveContext? context, String? name}) =>
-      ObservableSet<T>.of(this, context: context, name: name);
+  ObservableSet<T> asObservable({ReactiveContext? context, String? name})  => toObs(context: context, name: name);
 
   ObservableSet<T> toObs({ReactiveContext? context, String? name}) =>
       ObservableSet<T>.of(this, context: context, name: name);

--- a/mobx/lib/src/api/extensions/observable_stream_extension.dart
+++ b/mobx/lib/src/api/extensions/observable_stream_extension.dart
@@ -2,7 +2,19 @@ part of '../extensions.dart';
 
 /// Turn the Stream into an ObservableStream.
 extension ObservableStreamExtension<T> on Stream<T> {
+  @Deprecated('Use toObs() instead')  
   ObservableStream<T> asObservable(
+          {T? initialValue,
+          bool cancelOnError = false,
+          ReactiveContext? context,
+          String? name}) =>
+      ObservableStream<T>(this,
+          initialValue: initialValue,
+          cancelOnError: cancelOnError,
+          context: context,
+          name: name);
+
+  ObservableStream<T> toObs(
           {T? initialValue,
           bool cancelOnError = false,
           ReactiveContext? context,

--- a/mobx/lib/src/api/extensions/observable_stream_extension.dart
+++ b/mobx/lib/src/api/extensions/observable_stream_extension.dart
@@ -2,26 +2,25 @@ part of '../extensions.dart';
 
 /// Turn the Stream into an ObservableStream.
 extension ObservableStreamExtension<T> on Stream<T> {
-  @Deprecated('Use toObs() instead')  
-  ObservableStream<T> asObservable(
-          {T? initialValue,
-          bool cancelOnError = false,
-          ReactiveContext? context,
-          String? name}) =>
-      ObservableStream<T>(this,
-          initialValue: initialValue,
-          cancelOnError: cancelOnError,
-          context: context,
-          name: name);
+  @Deprecated('Use toObs() instead')
+  ObservableStream<T> asObservable({
+    T? initialValue,
+    bool cancelOnError = false,
+    ReactiveContext? context,
+    String? name,
+  }) => toObs(context: context, name: name);
 
-  ObservableStream<T> toObs(
-          {T? initialValue,
-          bool cancelOnError = false,
-          ReactiveContext? context,
-          String? name}) =>
-      ObservableStream<T>(this,
-          initialValue: initialValue,
-          cancelOnError: cancelOnError,
-          context: context,
-          name: name);
+  ObservableStream<T> toObs({
+    T? initialValue,
+    bool cancelOnError = false,
+    ReactiveContext? context,
+    String? name,
+  }) =>
+      ObservableStream<T>(
+        this,
+        initialValue: initialValue,
+        cancelOnError: cancelOnError,
+        context: context,
+        name: name,
+      );
 }

--- a/mobx/lib/src/api/extensions/primitive_types_extensions.dart
+++ b/mobx/lib/src/api/extensions/primitive_types_extensions.dart
@@ -3,9 +3,7 @@ part of '../extensions.dart';
 /// turns an int into ObservableInt
 extension IntExtension on int {
   @Deprecated('Use toObs() instead')
-  ObservableInt asObservable({ReactiveContext? context, String? name}) {
-    return Observable(this, context: context, name: name);
-  }
+  ObservableInt asObservable({ReactiveContext? context, String? name}) => toObs(context: context, name: name);
 
   ObservableInt toObs({ReactiveContext? context, String? name}) {
     return Observable(this, context: context, name: name);
@@ -15,9 +13,7 @@ extension IntExtension on int {
 /// turns a bool into ObservableBool
 extension BoolExtension on bool {
   @Deprecated('Use toObs() instead')
-  ObservableBool asObservable({ReactiveContext? context, String? name}) {
-    return Observable(this, context: context, name: name);
-  }
+  ObservableBool asObservable({ReactiveContext? context, String? name}) => toObs(context: context, name: name);
 
   ObservableBool toObs({ReactiveContext? context, String? name}) {
     return Observable(this, context: context, name: name);
@@ -34,9 +30,7 @@ extension ObservableBoolExtension on ObservableBool {
 /// turns a double into ObservableDouble
 extension DoubleExtension on double {
   @Deprecated('Use toObs() instead')
-  ObservableDouble asObservable({ReactiveContext? context, String? name}) {
-    return Observable(this, context: context, name: name);
-  }
+  ObservableDouble asObservable({ReactiveContext? context, String? name}) => toObs(context: context, name: name);
 
   ObservableDouble toObs({ReactiveContext? context, String? name}) {
     return Observable(this, context: context, name: name);
@@ -46,9 +40,7 @@ extension DoubleExtension on double {
 /// turns a String into ObservableString
 extension StringExtension on String {
   @Deprecated('Use toObs() instead')
-  ObservableString asObservable({ReactiveContext? context, String? name}) {
-    return Observable(this, context: context, name: name);
-  }
+  ObservableString asObservable({ReactiveContext? context, String? name}) => toObs(context: context, name: name);
 
   ObservableString toObs({ReactiveContext? context, String? name}) {
     return Observable(this, context: context, name: name);

--- a/mobx/lib/src/api/extensions/primitive_types_extensions.dart
+++ b/mobx/lib/src/api/extensions/primitive_types_extensions.dart
@@ -2,14 +2,24 @@ part of '../extensions.dart';
 
 /// turns an int into ObservableInt
 extension IntExtension on int {
+  @Deprecated('Use toObs() instead')
   ObservableInt asObservable({ReactiveContext? context, String? name}) {
+    return Observable(this, context: context, name: name);
+  }
+
+  ObservableInt toObs({ReactiveContext? context, String? name}) {
     return Observable(this, context: context, name: name);
   }
 }
 
 /// turns a bool into ObservableBool
 extension BoolExtension on bool {
+  @Deprecated('Use toObs() instead')
   ObservableBool asObservable({ReactiveContext? context, String? name}) {
+    return Observable(this, context: context, name: name);
+  }
+
+  ObservableBool toObs({ReactiveContext? context, String? name}) {
     return Observable(this, context: context, name: name);
   }
 }
@@ -23,14 +33,24 @@ extension ObservableBoolExtension on ObservableBool {
 
 /// turns a double into ObservableDouble
 extension DoubleExtension on double {
+  @Deprecated('Use toObs() instead')
   ObservableDouble asObservable({ReactiveContext? context, String? name}) {
+    return Observable(this, context: context, name: name);
+  }
+
+  ObservableDouble toObs({ReactiveContext? context, String? name}) {
     return Observable(this, context: context, name: name);
   }
 }
 
 /// turns a String into ObservableString
 extension StringExtension on String {
+  @Deprecated('Use toObs() instead')
   ObservableString asObservable({ReactiveContext? context, String? name}) {
+    return Observable(this, context: context, name: name);
+  }
+
+  ObservableString toObs({ReactiveContext? context, String? name}) {
     return Observable(this, context: context, name: name);
   }
 }

--- a/mobx/pubspec.yaml
+++ b/mobx/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mobx
-version: 2.0.7+2
+version: 2.0.7+3
 description: "MobX is a library for reactively managing the state of your applications. Use the power of observables, actions, and reactions to supercharge your Dart and Flutter apps."
 
 homepage: https://github.com/mobxjs/mobx.dart

--- a/mobx/test/extensions/observable_future_extension_test.dart
+++ b/mobx/test/extensions/observable_future_extension_test.dart
@@ -12,7 +12,7 @@ void main() {
   group('ObservableFutureExtension', () {
     test('Transform Future in ObservableFuture', () async {
       final future = Future.value(1);
-      expect(future.asObservable(), isA<ObservableFuture>());
+      expect(future.toObs(), isA<ObservableFuture>());
     });
   });
 }

--- a/mobx/test/extensions/observable_list_extension_test.dart
+++ b/mobx/test/extensions/observable_list_extension_test.dart
@@ -10,7 +10,7 @@ void main() {
   group('ObservableListExtension', () {
     test('Transform List in ObservableList', () async {
       final list = [];
-      expect(list.asObservable(), isA<ObservableList>());
+      expect(list.toObs(), isA<ObservableList>());
     });
   });
 }

--- a/mobx/test/extensions/observable_set_extension_test.dart
+++ b/mobx/test/extensions/observable_set_extension_test.dart
@@ -10,7 +10,7 @@ void main() {
   group('ObservableSetExtension', () {
     test('Transform Set in ObservableSet', () async {
       final set = <dynamic>{};
-      expect(set.asObservable(), isA<ObservableSet>());
+      expect(set.toObs(), isA<ObservableSet>());
     });
   });
 }

--- a/mobx/test/extensions/observable_stream_extension_test.dart
+++ b/mobx/test/extensions/observable_stream_extension_test.dart
@@ -12,7 +12,7 @@ void main() {
   group('ObservableStreamExtension', () {
     test('Transform Stream in ObservableStream', () async {
       const stream = Stream.empty();
-      expect(stream.asObservable(), isA<ObservableStream>());
+      expect(stream.toObs(), isA<ObservableStream>());
     });
   });
 }

--- a/mobx/test/extensions/primitive_types_extensions_test.dart
+++ b/mobx/test/extensions/primitive_types_extensions_test.dart
@@ -9,26 +9,26 @@ void main() {
   group('PrimitiveTypesExtensions', () {
     test('Transform Int into ObservableInt', () {
       final count = 0;
-      expect(count.asObservable(), isA<ObservableInt>());
+      expect(count.toObs(), isA<ObservableInt>());
     });
 
     test('Transform Double into ObservableDouble', () {
       final count = 0.0;
-      expect(count.asObservable(), isA<ObservableDouble>());
+      expect(count.toObs(), isA<ObservableDouble>());
     });
 
     test('Transform Bool into ObservableBool', () {
       final flag = false;
-      expect(flag.asObservable(), isA<ObservableBool>());
+      expect(flag.toObs(), isA<ObservableBool>());
     });
 
     test('Transform String into ObservableString', () {
       final str = '';
-      expect(str.asObservable(), isA<ObservableString>());
+      expect(str.toObs(), isA<ObservableString>());
     });
 
     test('Toggles ObservableBool', () {
-      final flag = false.asObservable();
+      final flag = false.toObs();
       flag.toggle();
       expect(flag.value, equals(true));
     });


### PR DESCRIPTION
Hello.
I was thinking about `.asObservable()`, it looks clumsy. It's not funny to write `1.asObservable()` (and no big difference with `Observable(1)`).
Also, `as` looks like a **cast**, but actually it's a wrapping a value into `Observable()` (or creating an ObservableList from List).
I wanted a shorter and meaningful name. In GetX there's an `.obs` getter, but a line `var x = 1.obs;` is not obvious.
So I've chosen `toObs()`, it has the most native feel (like `.toList()`)