### PR TITLE
Feat: Add simple version of type aliases and simple getter/setter

### DIFF
--- a/mobx/CHANGELOG.md
+++ b/mobx/CHANGELOG.md
@@ -1,3 +1,28 @@
+## 2.0.7+6
+
+Add flag `$newBehavior` to `@action` method to allow old users to continue using old behavior of the `AsyncAction` which mean the `Future` action. Read the issue [#834](https://github.com/mobxjs/mobx.dart/issues/834) for more details.
+
+``` dart
+// Old behavior
+@action
+Future someMethod() async {}
+
+// New behavior
+@action
+Future someMethod([$newBehavior = true]) async {} // With optional parameter
+// Or
+@action
+Future someMethod({$newBehavior = true}) async {} // With named parameter
+```
+
+Other parameters you can use as your purposes, just need to make sure the `$newBehavior = true` parameter is exist if you want to use the new behavior.
+
+If you want to use `AsyncAction` directly, you can do this:
+
+``` dart
+AsyncAction('name', contaxt: context, newBehavior = true);
+```
+
 ## 2.0.7+5
 
 - Add simple version of type aliases for all possible types:

--- a/mobx/CHANGELOG.md
+++ b/mobx/CHANGELOG.md
@@ -1,5 +1,33 @@
+## 2.0.7+5
+
+- Add simple version of type aliases for all possible types:
+
+``` dart
+final obsValue = 0.asObs; // = Observable<int>(0)
+final obsValue = ''.asObs; // = Observable<String>('')
+final obsValue = <String>[].asObs; // = ObservableList<String>();
+```
+
+- Add simple version of getter/setter for `Observable<T>` type:
+  - Get value: `final value = obsValue();`
+  - Set value: `obsValue('new value');`
+
+``` dart
+final obsValue = 'initial value'.asObs;
+
+// Get value instead of using `obsValue.value`
+print(obsValue()); // => print 'initial value'
+
+// Set value (Also wrapped with `runInAction` by default)
+// instead of using `runInAction(() => obsValue.value = 'new value');`
+obsValue('new value');
+print(obsValue()); // => print 'new value'
+```
+
 ## 2.0.7+4
+
 fixes:
+
 - shortened `1.asObservable()` to `1.obs()` (same for boolean, double, String) - [@subzero911](https://github.com/subzero911)
 - removed experimental typedefs from `2.0.7`
 
@@ -17,15 +45,19 @@ fixes:
   So instead of `Observable<int>` you can now write `ObservableInt`.
 - `.asObservable()` extension for primitive types.\
   Now you can easily convert literals to observables like:
+
   ```dart
   var name = ''.asObservable(); // infers ObservableString
   var counter = 0.asObservable(); // infers ObservableInt
   ```
+
 - `toggle()` method for `ObservableBool`. Lets you toggle the internal value of `ObservableBool`
+
   ```dart
   var lights = true.asObservable();
   lights.toggle(); // now it has a value of false
   ```
+
   Changes made by [@subzero911](https://github.com/subzero911)
 - Allow use custom context(#770) - @amondnet
 

--- a/mobx/lib/mobx.dart
+++ b/mobx/lib/mobx.dart
@@ -65,4 +65,4 @@ export 'package:mobx/src/core.dart'
 export 'package:mobx/src/core/atom_extensions.dart';
 
 /// The current version as per `pubspec.yaml`
-const version = '2.0.7+4';
+const version = '2.0.7+5';

--- a/mobx/lib/mobx.dart
+++ b/mobx/lib/mobx.dart
@@ -65,4 +65,4 @@ export 'package:mobx/src/core.dart'
 export 'package:mobx/src/core/atom_extensions.dart';
 
 /// The current version as per `pubspec.yaml`
-const version = '2.0.7+5';
+const version = '2.0.7+6';

--- a/mobx/lib/src/api/async/async_action.dart
+++ b/mobx/lib/src/api/async/async_action.dart
@@ -6,13 +6,16 @@ part of '../async.dart';
 /// You would rarely need to use this class directly. Instead, use the `@action` annotation along with
 /// the `mobx_codegen` package.
 class AsyncAction {
-  AsyncAction(String name, {ReactiveContext? context})
-      : this._(context ?? mainContext, name);
+  AsyncAction(String name, {ReactiveContext? context, bool newBehavior = false})
+      : this._(context ?? mainContext, name, newBehavior);
 
-  AsyncAction._(ReactiveContext context, String name)
+  AsyncAction._(ReactiveContext context, String name, this.newBehavior)
       : _actions = ActionController(context: context, name: name);
 
   final ActionController _actions;
+
+  // TODO: Remove this when new feature `asyncAction` is available
+  final bool newBehavior;
 
   Zone? _zoneField;
   Zone get _zone {
@@ -24,6 +27,10 @@ class AsyncAction {
   }
 
   Future<R> run<R>(Future<R> Function() body) async {
+    if (!newBehavior) {
+      return _runOld(body);
+    }
+
     final actionInfo = _actions.startAction(name: _actions.name);
     try {
       return await _zone.run(body);
@@ -40,6 +47,10 @@ class AsyncAction {
   static dynamic _noOp() => null;
 
   R _run<R>(Zone self, ZoneDelegate parent, Zone zone, R Function() f) {
+    if (!newBehavior) {
+      return __runOld(self, parent, zone, f);
+    }
+
     final result = parent.run(zone, f);
     return result;
   }
@@ -48,8 +59,53 @@ class AsyncAction {
   // when a result is produced
   R _runUnary<R, A>(
       Zone self, ZoneDelegate parent, Zone zone, R Function(A a) f, A a) {
+    if (!newBehavior) {
+      return __runUnaryOld(self, parent, zone, f, a);
+    }
+
     final result = parent.runUnary(zone, f, a);
     return result;
+  }
+
+  // TODO: Remove this when new feature `asyncAction` is available
+  Future<R> _runOld<R>(Future<R> Function() body) async {
+    // final actionInfo = _actions.startAction(name: _actions.name);
+    try {
+      return await _zone.run(body);
+    } finally {
+      // @katis:
+      // Delay completion until next microtask completion.
+      // Needed to make sure that all mobx state changes are
+      // applied after `await run()` completes, not sure why.
+      await Future.microtask(_noOp);
+      // _actions.endAction(actionInfo);
+    }
+  }
+
+  // TODO: Remove this when new feature `asyncAction` is available
+  R __runOld<R>(Zone self, ZoneDelegate parent, Zone zone, R Function() f) {
+    final actionInfo = _actions.startAction(name: '${_actions.name}(Zone.run)');
+    try {
+      final result = parent.run(zone, f);
+      return result;
+    } finally {
+      _actions.endAction(actionInfo);
+    }
+  }
+
+  // Will be invoked for a catch clause that has a single argument: exception or
+  // when a result is produced
+  // TODO: Remove this when new feature `asyncAction` is available
+  R __runUnaryOld<R, A>(
+      Zone self, ZoneDelegate parent, Zone zone, R Function(A a) f, A a) {
+    final actionInfo =
+        _actions.startAction(name: '${_actions.name}(Zone.runUnary)');
+    try {
+      final result = parent.runUnary(zone, f, a);
+      return result;
+    } finally {
+      _actions.endAction(actionInfo);
+    }
   }
 
   // Will be invoked for a catch clause that has two arguments: exception and stacktrace

--- a/mobx/lib/src/api/extensions.dart
+++ b/mobx/lib/src/api/extensions.dart
@@ -9,3 +9,4 @@ part 'extensions/observable_list_extension.dart';
 part 'extensions/observable_set_extension.dart';
 part 'extensions/observable_map_extension.dart';
 part 'extensions/primitive_types_extensions.dart';
+part 'extensions/observable_call_extension.dart';

--- a/mobx/lib/src/api/extensions/observable_call_extension.dart
+++ b/mobx/lib/src/api/extensions/observable_call_extension.dart
@@ -1,0 +1,10 @@
+part of '../extensions.dart';
+
+extension ObservableExtension<T> on Observable<T> {
+  T call([T? newValue]) {
+    if (newValue == null) return value;
+
+    runInAction(() => value = newValue);
+    return value;
+  }
+}

--- a/mobx/lib/src/api/extensions/observable_future_extension.dart
+++ b/mobx/lib/src/api/extensions/observable_future_extension.dart
@@ -4,4 +4,6 @@ part of '../extensions.dart';
 extension ObservableFutureExtension<T> on Future<T> {
   ObservableFuture<T> asObservable({ReactiveContext? context, String? name}) =>
       ObservableFuture<T>(this, context: context, name: name);
+
+  ObservableFuture<T> get asObs => ObservableFuture<T>(this);
 }

--- a/mobx/lib/src/api/extensions/observable_list_extension.dart
+++ b/mobx/lib/src/api/extensions/observable_list_extension.dart
@@ -4,4 +4,6 @@ part of '../extensions.dart';
 extension ObservableListExtension<T> on List<T> {
   ObservableList<T> asObservable({ReactiveContext? context, String? name}) =>
       ObservableList<T>.of(this, context: context, name: name);
+
+  ObservableList<T> get asObs => ObservableList<T>.of(this);
 }

--- a/mobx/lib/src/api/extensions/observable_map_extension.dart
+++ b/mobx/lib/src/api/extensions/observable_map_extension.dart
@@ -4,4 +4,6 @@ part of '../extensions.dart';
 extension ObservableMapExtension<K, V> on Map<K, V> {
   ObservableMap<K, V> asObservable({ReactiveContext? context, String? name}) =>
       ObservableMap<K, V>.of(this, context: context, name: name);
+
+  ObservableMap<K, V> get asObs => ObservableMap<K, V>.of(this);
 }

--- a/mobx/lib/src/api/extensions/observable_set_extension.dart
+++ b/mobx/lib/src/api/extensions/observable_set_extension.dart
@@ -4,4 +4,6 @@ part of '../extensions.dart';
 extension ObservableSetExtension<T> on Set<T> {
   ObservableSet<T> asObservable({ReactiveContext? context, String? name}) =>
       ObservableSet<T>.of(this, context: context, name: name);
+
+  ObservableSet<T> get asObs => ObservableSet<T>.of(this);
 }

--- a/mobx/lib/src/api/extensions/observable_stream_extension.dart
+++ b/mobx/lib/src/api/extensions/observable_stream_extension.dart
@@ -12,4 +12,6 @@ extension ObservableStreamExtension<T> on Stream<T> {
           cancelOnError: cancelOnError,
           context: context,
           name: name);
+
+  ObservableStream<T> get asObs => ObservableStream<T>(this);
 }

--- a/mobx/lib/src/api/extensions/primitive_types_extensions.dart
+++ b/mobx/lib/src/api/extensions/primitive_types_extensions.dart
@@ -5,6 +5,8 @@ extension IntExtension on int {
   Observable<int> obs({ReactiveContext? context, String? name}) {
     return Observable(this, context: context, name: name);
   }
+
+  Observable<int> get asObs => Observable(this);
 }
 
 extension BoolExtension on bool {
@@ -12,6 +14,8 @@ extension BoolExtension on bool {
   Observable<bool> obs({ReactiveContext? context, String? name}) {
     return Observable(this, context: context, name: name);
   }
+
+  Observable<bool> get asObs => Observable(this);
 }
 
 extension ObservableBoolExtension on Observable<bool> {
@@ -26,6 +30,8 @@ extension DoubleExtension on double {
   Observable<double> obs({ReactiveContext? context, String? name}) {
     return Observable(this, context: context, name: name);
   }
+
+  Observable<double> get asObs => Observable(this);
 }
 
 extension StringExtension on String {
@@ -33,4 +39,6 @@ extension StringExtension on String {
   Observable<String> obs({ReactiveContext? context, String? name}) {
     return Observable(this, context: context, name: name);
   }
+
+  Observable<String> get asObs => Observable(this);
 }

--- a/mobx/pubspec.yaml
+++ b/mobx/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mobx
-version: 2.0.7+4
+version: 2.0.7+5
 description: "MobX is a library for reactively managing the state of your applications. Use the power of observables, actions, and reactions to supercharge your Dart and Flutter apps."
 
 homepage: https://github.com/mobxjs/mobx.dart

--- a/mobx/pubspec.yaml
+++ b/mobx/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mobx
-version: 2.0.7+5
+version: 2.0.7+6
 description: "MobX is a library for reactively managing the state of your applications. Use the power of observables, actions, and reactions to supercharge your Dart and Flutter apps."
 
 homepage: https://github.com/mobxjs/mobx.dart

--- a/mobx/test/extensions/observable_call_extension_test.dart
+++ b/mobx/test/extensions/observable_call_extension_test.dart
@@ -1,0 +1,38 @@
+import 'package:mobx/src/api/action.dart';
+import 'package:mobx/src/api/extensions.dart';
+import 'package:mobx/src/api/reaction.dart';
+import 'package:test/test.dart';
+
+import '../util.dart';
+
+void main() {
+  testSetup();
+
+  group('ObservableCallExtensions', () {
+    test('Use call on Observable', () {
+      final x = 10.asObs;
+      final y = 20.asObs;
+
+      var executionCount = 0;
+      var total = 0;
+
+      final d = autorun((_) {
+        total = x() + y();
+        executionCount++;
+      });
+
+      runInAction(() {
+        x(100);
+        y(200);
+
+        expect(executionCount, equals(1)); // No notifications are fired
+      });
+
+      // Notifications are fired now
+      expect(executionCount, equals(2));
+      expect(total, equals(300));
+
+      d();
+    });
+  });
+}

--- a/mobx/test/extensions/observable_future_extension_test.dart
+++ b/mobx/test/extensions/observable_future_extension_test.dart
@@ -14,5 +14,10 @@ void main() {
       final future = Future.value(1);
       expect(future.asObservable(), isA<ObservableFuture>());
     });
+
+    test('Transform Future in ObservableFuture (Use .asObs)', () async {
+      final future = Future.value(1);
+      expect(future.asObs, isA<ObservableFuture>());
+    });
   });
 }

--- a/mobx/test/extensions/observable_list_extension_test.dart
+++ b/mobx/test/extensions/observable_list_extension_test.dart
@@ -12,5 +12,10 @@ void main() {
       final list = [];
       expect(list.asObservable(), isA<ObservableList>());
     });
+
+    test('Transform List in ObservableList (Use .asObs)', () async {
+      final list = [];
+      expect(list.asObs, isA<ObservableList>());
+    });
   });
 }

--- a/mobx/test/extensions/observable_map_extension_test.dart
+++ b/mobx/test/extensions/observable_map_extension_test.dart
@@ -12,5 +12,10 @@ void main() {
       final map = {};
       expect(map.asObservable(), isA<ObservableMap>());
     });
+
+    test('Transform Map in ObservableMap (Use .asObs)', () async {
+      final map = {};
+      expect(map.asObs, isA<ObservableMap>());
+    });
   });
 }

--- a/mobx/test/extensions/observable_set_extension_test.dart
+++ b/mobx/test/extensions/observable_set_extension_test.dart
@@ -12,5 +12,10 @@ void main() {
       final set = <dynamic>{};
       expect(set.asObservable(), isA<ObservableSet>());
     });
+
+    test('Transform Set in ObservableSet (Use .asObs)', () async {
+      final set = <dynamic>{};
+      expect(set.asObs, isA<ObservableSet>());
+    });
   });
 }

--- a/mobx/test/extensions/observable_stream_extension_test.dart
+++ b/mobx/test/extensions/observable_stream_extension_test.dart
@@ -14,5 +14,10 @@ void main() {
       const stream = Stream.empty();
       expect(stream.asObservable(), isA<ObservableStream>());
     });
+
+    test('Transform Stream in ObservableStream (Use .asObs)', () async {
+      const stream = Stream.empty();
+      expect(stream.asObs, isA<ObservableStream>());
+    });
   });
 }

--- a/mobx/test/extensions/primitive_types_extensions_test.dart
+++ b/mobx/test/extensions/primitive_types_extensions_test.dart
@@ -10,21 +10,25 @@ void main() {
     test('Transform Int into ObsInt', () {
       final count = 0;
       expect(count.obs(), isA<Observable<int>>());
+      expect(count.asObs, isA<Observable<int>>());
     });
 
     test('Transform Double into ObsDouble', () {
       final count = 0.0;
       expect(count.obs(), isA<Observable<double>>());
+      expect(count.asObs, isA<Observable<double>>());
     });
 
     test('Transform Bool into ObsBool', () {
       final flag = false;
       expect(flag.obs(), isA<Observable<bool>>());
+      expect(flag.asObs, isA<Observable<bool>>());
     });
 
     test('Transform String into ObsString', () {
       final str = '';
       expect(str.obs(), isA<Observable<String>>());
+      expect(str.asObs, isA<Observable<String>>());
     });
 
     test('Toggles ObservableBool', () {
@@ -32,6 +36,5 @@ void main() {
       flag.toggle();
       expect(flag.value, equals(true));
     });
-
   });
 }

--- a/mobx/test/spy_test.dart
+++ b/mobx/test/spy_test.dart
@@ -142,7 +142,7 @@ void main() {
 
       final actionCompleter = Completer();
       final microtaskCompleter = Completer();
-      AsyncAction('test').run(() async {
+      AsyncAction('test', newBehavior: true).run(() async {
         scheduleMicrotask(() {
           microtaskCompleter.complete();
         });

--- a/mobx_codegen/CHANGELOG.md
+++ b/mobx_codegen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.7+1
+
+- Support new flag `$newBehavior` for `@action` method. (>= mobx 2.0.7+6)
+
 ## 2.0.7
 
 - Update codegen templates to ignore newly recommended lint rules in generated code

--- a/mobx_codegen/lib/mobx_codegen.dart
+++ b/mobx_codegen/lib/mobx_codegen.dart
@@ -2,4 +2,4 @@ library mobx_codegen;
 
 export 'src/mobx_codegen_base.dart';
 
-const version = '2.0.7';
+const version = '2.0.7+1';

--- a/mobx_codegen/lib/src/template/async_action.dart
+++ b/mobx_codegen/lib/src/template/async_action.dart
@@ -1,4 +1,5 @@
 import 'package:mobx_codegen/src/template/method_override.dart';
+import 'package:mobx_codegen/src/template/params.dart';
 import 'package:mobx_codegen/src/template/store.dart';
 
 class AsyncActionTemplate {
@@ -23,9 +24,31 @@ class AsyncActionTemplate {
       ? 'ObservableFuture${method.returnTypeArgs}($_methodCall)'
       : _methodCall;
 
+  String get _newBehavior {
+    bool? isNewBehavior;
+
+    for (final list in method.params.templates) {
+      for (final ParamTemplate param in list.templates) {
+        if (param.name == '\$newBehavior') {
+          isNewBehavior = param.defaultValue == 'true';
+
+          break;
+        }
+      }
+
+      if (isNewBehavior != null) break;
+    }
+
+    if (isNewBehavior == true) {
+      return ', newBehavior: $isNewBehavior';
+    }
+
+    return '';
+  }
+
   @override
   String toString() => """
-  late final $_actionField = AsyncAction('${storeTemplate.parentTypeName}.${method.name}', context: context);
+  late final $_actionField = AsyncAction('${storeTemplate.parentTypeName}.${method.name}', context: context$_newBehavior);
 
   @override
   $_futureType${method.returnTypeArgs} ${method.name}${method.typeParams}(${method.params}) {

--- a/mobx_codegen/pubspec.yaml
+++ b/mobx_codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobx_codegen
 description: Code generator for MobX that adds support for annotating your code with @observable, @computed, @action and also creating Store classes.
-version: 2.0.7
+version: 2.0.7+1
 
 homepage: https://github.com/mobxjs/mobx.dart
 

--- a/mobx_codegen/test/generator_usage_test.dart
+++ b/mobx_codegen/test/generator_usage_test.dart
@@ -116,6 +116,38 @@ abstract class _TestStore with Store {
     // ignore: only_throw_errors
     throw 'TEST ERROR';
   }
+
+  @action
+  Future<void> oldAsyncAction(String param1) async {
+    batchItem1 = 'item1';
+    await Future.delayed(const Duration(milliseconds: 10));
+    batchItem2 = 'item2';
+    batchItem3 = 'item3';
+    await Future.delayed(const Duration(milliseconds: 10));
+    batchItem4 = 'item4';
+  }
+
+  @action
+  Future<void> newAsyncActionOptionalParam(String param1,
+      [$newBehavior = true]) async {
+    batchItem1 = 'item1';
+    await Future.delayed(const Duration(milliseconds: 10));
+    batchItem2 = 'item2';
+    batchItem3 = 'item3';
+    await Future.delayed(const Duration(milliseconds: 10));
+    batchItem4 = 'item4';
+  }
+
+  @action
+  Future<void> newAsyncActionNamedParam(String param1,
+      {$newBehavior = true}) async {
+    batchItem1 = 'item1';
+    await Future.delayed(const Duration(milliseconds: 10));
+    batchItem2 = 'item2';
+    batchItem3 = 'item3';
+    await Future.delayed(const Duration(milliseconds: 10));
+    batchItem4 = 'item4';
+  }
 }
 
 void main() {

--- a/mobx_codegen/test/generator_usage_test.g.dart
+++ b/mobx_codegen/test/generator_usage_test.g.dart
@@ -6,7 +6,7 @@ part of 'generator_usage_test.dart';
 // StoreGenerator
 // **************************************************************************
 
-// ignore_for_file: non_constant_identifier_names, unnecessary_brace_in_string_interps, unnecessary_lambdas, prefer_expression_function_bodies, lines_longer_than_80_chars, avoid_as, avoid_annotating_with_dynamic
+// ignore_for_file: non_constant_identifier_names, unnecessary_brace_in_string_interps, unnecessary_lambdas, prefer_expression_function_bodies, lines_longer_than_80_chars, avoid_as, avoid_annotating_with_dynamic, no_leading_underscores_for_local_identifiers
 
 mixin _$TestStore on _TestStore, Store {
   Computed<String>? _$fieldsComputed;
@@ -203,6 +203,38 @@ mixin _$TestStore on _TestStore, Store {
   @override
   Future<void> throwsError() {
     return _$throwsErrorAsyncAction.run(() => super.throwsError());
+  }
+
+  late final _$oldAsyncActionAsyncAction =
+      AsyncAction('_TestStore.oldAsyncAction', context: context);
+
+  @override
+  Future<void> oldAsyncAction(String param1) {
+    return _$oldAsyncActionAsyncAction.run(() => super.oldAsyncAction(param1));
+  }
+
+  late final _$newAsyncActionOptionalParamAsyncAction = AsyncAction(
+      '_TestStore.newAsyncActionOptionalParam',
+      context: context,
+      newBehavior: true);
+
+  @override
+  Future<void> newAsyncActionOptionalParam(String param1,
+      [dynamic $newBehavior = true]) {
+    return _$newAsyncActionOptionalParamAsyncAction
+        .run(() => super.newAsyncActionOptionalParam(param1, $newBehavior));
+  }
+
+  late final _$newAsyncActionNamedParamAsyncAction = AsyncAction(
+      '_TestStore.newAsyncActionNamedParam',
+      context: context,
+      newBehavior: true);
+
+  @override
+  Future<void> newAsyncActionNamedParam(String param1,
+      {dynamic $newBehavior = true}) {
+    return _$newAsyncActionNamedParamAsyncAction.run(() =>
+        super.newAsyncActionNamedParam(param1, $newBehavior: $newBehavior));
   }
 
   late final _$_TestStoreActionController =


### PR DESCRIPTION
Hello,

I think this package is so good but it has a bit of complexity when I always need to use `codegen` every time I have something change on the variables or methods. I found an effective way to use this plugin like:

``` dart
// Declare
final myVar = Observable('');

// My widget
Observer((_) => Text(myVar.value));

// Change the value
runInAction((_) => myVar.value = 'new value');

// Function
Future doSomething() async {
   runInAction((_) => myVar.value = 'wait');
   await Future.delayed(Duration(second: 3));
   runInAction((_) => myVar.value = 'done');
}
```

I also found it still has a bit of complication, so I create this PR to reduce the code like the below:
``` dart
// Declare
final myVar = ''.asObs; // Or ''.obs(), can also be 0.asObs, <String>[].asObs,...

// My widget
Observer((_) => Text(myVar()));

// Change the value
myVar('new value'); // This method also implement the runInAction in it.

// Function
Future doSomething() async {
   myVar('wait');
   await Future.delayed(Duration(second: 3));
   myVar('done');
}
```

I like the `.obs` but it's just used by the last PR. I also found the workaround for the `AsyncAction` issues discussed here #834 but I think it should be separated to another PR, it also causes the current test issues.

---
## Pull Request Checklist


- [x] If the changes are being made to code, ensure the **version in `pubspec.yaml`** is updated. 
- [x] Increment the **`major`/`minor`/`patch`/`patch-count`**, depending on the complexity of change
- [x] Add the necessary **unit tests** to ensure the coverage does not drop
- [x] Update the **Changelog** to include all changes made in this PR
- [x] Run the **`set:versions` command** using `npm` or `yarn`. You can find this command in the `package.json` file in the root directory
- [ ] Include the **necessary reviewers** for the PR
- [ ] Update the docs if there are any API changes or additions to functionality
