### PR TITLE
Fix: AsyncAction behavior

### DIFF
--- a/mobx/CHANGELOG.md
+++ b/mobx/CHANGELOG.md
@@ -1,3 +1,28 @@
+## 2.0.7+5
+
+- Add flag `asyncActionBehavior` to `ReactiveConfig` to control the behavior of `@action` on `Future` methods.
+
+``` dart
+/// Notify all nested actions in the `Future` method. This is the old behavior of the mobx <= 2.0.7+2
+/// This is currently the default behavior of the `@action` on `Future` methods.
+abstract class _YourStore with Store {
+  @override
+  ReactiveContext get context {
+    return mainContext
+      ..config.clone(asyncActionBehavior: AsyncActionBehavior.notifyEachNested);
+  }
+}
+
+/// Notify only the last action in the `Future` method. This is the new behavior of the mobx >= 2.0.7+3
+abstract class _YourStore with Store {
+  @override
+  ReactiveContext get context {
+    return mainContext
+      ..config.clone(asyncActionBehavior: AsyncActionBehavior.notifyOnlyLast);
+  }
+}
+```
+
 ## 2.0.7+4
 fixes:
 - shortened `1.asObservable()` to `1.obs()` (same for boolean, double, String) - [@subzero911](https://github.com/subzero911)

--- a/mobx/lib/mobx.dart
+++ b/mobx/lib/mobx.dart
@@ -65,4 +65,4 @@ export 'package:mobx/src/core.dart'
 export 'package:mobx/src/core/atom_extensions.dart';
 
 /// The current version as per `pubspec.yaml`
-const version = '2.0.7+4';
+const version = '2.0.7+5';

--- a/mobx/lib/src/api/async.dart
+++ b/mobx/lib/src/api/async.dart
@@ -4,5 +4,6 @@ import 'package:mobx/src/api/context.dart';
 import 'package:mobx/src/core.dart';
 
 part 'async/async_action.dart';
+part 'async/async_action_helper.dart';
 part 'async/observable_future.dart';
 part 'async/observable_stream.dart';

--- a/mobx/lib/src/api/async/async_action.dart
+++ b/mobx/lib/src/api/async/async_action.dart
@@ -5,52 +5,19 @@ part of '../async.dart';
 ///
 /// You would rarely need to use this class directly. Instead, use the `@action` annotation along with
 /// the `mobx_codegen` package.
-class AsyncAction {
-  AsyncAction(String name, {ReactiveContext? context})
-      : this._(context ?? mainContext, name);
+abstract class AsyncAction {
+  factory AsyncAction(String name, {ReactiveContext? context}) {
+    context ??= mainContext;
 
-  AsyncAction._(ReactiveContext context, String name)
-      : _actions = ActionController(context: context, name: name);
-
-  final ActionController _actions;
-
-  Zone? _zoneField;
-  Zone get _zone {
-    if (_zoneField == null) {
-      final spec = ZoneSpecification(run: _run, runUnary: _runUnary);
-      _zoneField = Zone.current.fork(specification: spec);
-    }
-    return _zoneField!;
-  }
-
-  Future<R> run<R>(Future<R> Function() body) async {
-    final actionInfo = _actions.startAction(name: _actions.name);
-    try {
-      return await _zone.run(body);
-    } finally {
-      // @katis:
-      // Delay completion until next microtask completion.
-      // Needed to make sure that all mobx state changes are
-      // applied after `await run()` completes, not sure why.
-      await Future.microtask(_noOp);
-      _actions.endAction(actionInfo);
+    if (context.config.asyncActionBehavior ==
+        AsyncActionBehavior.notifyEachNested) {
+      return _NotifyEachNested(name, context: context);
+    } else {
+      return _NotifyOnlyLast(name, context: context);
     }
   }
 
-  static dynamic _noOp() => null;
-
-  R _run<R>(Zone self, ZoneDelegate parent, Zone zone, R Function() f) {
-    final result = parent.run(zone, f);
-    return result;
-  }
-
-  // Will be invoked for a catch clause that has a single argument: exception or
-  // when a result is produced
-  R _runUnary<R, A>(
-      Zone self, ZoneDelegate parent, Zone zone, R Function(A a) f, A a) {
-    final result = parent.runUnary(zone, f, a);
-    return result;
-  }
+  Future<R> run<R>(Future<R> Function() body) => throw UnimplementedError();
 
   // Will be invoked for a catch clause that has two arguments: exception and stacktrace
 //  R _runBinary<R, A, B>(Zone self, ZoneDelegate parent, Zone zone,

--- a/mobx/lib/src/api/async/async_action_helper.dart
+++ b/mobx/lib/src/api/async/async_action_helper.dart
@@ -1,0 +1,111 @@
+part of '../async.dart';
+
+class _NotifyAsyncAction implements AsyncAction {
+  _NotifyAsyncAction(String name, {ReactiveContext? context})
+      : this._(context ?? mainContext, name);
+
+  _NotifyAsyncAction._(ReactiveContext context, String name)
+      : _actions = ActionController(context: context, name: name);
+
+  final ActionController _actions;
+
+  Zone? _zoneField;
+
+  Zone get _zone {
+    if (_zoneField == null) {
+      final spec = ZoneSpecification(run: _run, runUnary: _runUnary);
+      _zoneField = Zone.current.fork(specification: spec);
+    }
+    return _zoneField!;
+  }
+
+  @override
+  Future<R> run<R>(Future<R> Function() body) {
+    throw UnimplementedError();
+  }
+
+  R _run<R>(Zone self, ZoneDelegate parent, Zone zone, R Function() f) {
+    throw UnimplementedError();
+  }
+
+  R _runUnary<R, A>(
+      Zone self, ZoneDelegate parent, Zone zone, R Function(A a) f, A a) {
+    throw UnimplementedError();
+  }
+}
+
+class _NotifyEachNested extends _NotifyAsyncAction {
+  _NotifyEachNested(super.name, {ReactiveContext? context});
+
+  @override
+  Future<R> run<R>(Future<R> Function() body) async {
+    try {
+      return await _zone.run(body);
+    } finally {
+      // @katis:
+      // Delay completion until next microtask completion.
+      // Needed to make sure that all mobx state changes are
+      // applied after `await run()` completes, not sure why.
+      await Future.microtask(_noOp);
+    }
+  }
+
+  @override
+  R _run<R>(Zone self, ZoneDelegate parent, Zone zone, R Function() f) {
+    final actionInfo = _actions.startAction();
+    try {
+      final result = parent.run(zone, f);
+      return result;
+    } finally {
+      _actions.endAction(actionInfo);
+    }
+  }
+
+  @override
+  R _runUnary<R, A>(
+      Zone self, ZoneDelegate parent, Zone zone, R Function(A a) f, A a) {
+    final actionInfo = _actions.startAction();
+    try {
+      final result = parent.runUnary(zone, f, a);
+      return result;
+    } finally {
+      _actions.endAction(actionInfo);
+    }
+  }
+
+  static dynamic _noOp() => null;
+}
+
+class _NotifyOnlyLast extends _NotifyAsyncAction {
+  _NotifyOnlyLast(super.name, {ReactiveContext? context});
+
+  @override
+  Future<R> run<R>(Future<R> Function() body) async {
+    final actionInfo = _actions.startAction(name: _actions.name);
+    try {
+      return await _zone.run(body);
+    } finally {
+      // @katis:
+      // Delay completion until next microtask completion.
+      // Needed to make sure that all mobx state changes are
+      // applied after `await run()` completes, not sure why.
+      await Future.microtask(_noOp);
+      _actions.endAction(actionInfo);
+    }
+  }
+
+  @override
+  R _run<R>(Zone self, ZoneDelegate parent, Zone zone, R Function() f) {
+    final result = parent.run(zone, f);
+    return result;
+  }
+
+  @override
+  R _runUnary<R, A>(
+      Zone self, ZoneDelegate parent, Zone zone, R Function(A a) f, A a) {
+    final result = parent.runUnary(zone, f, a);
+    return result;
+  }
+
+  static dynamic _noOp() => null;
+}

--- a/mobx/lib/src/core/context.dart
+++ b/mobx/lib/src/core/context.dart
@@ -53,6 +53,12 @@ enum ReactiveReadPolicy { always, never }
 /// `never`: Allow mutating observables outside actions
 enum ReactiveWritePolicy { observed, always, never }
 
+/// Defines the behavior for AsyncAction
+///
+/// `notifyEachNested`: Notify each nested action in `@action` of the `Future` method. This is the default.
+/// `notifyOnlyLast`: Notify the last action in `@action` of the `Future` method.
+enum AsyncActionBehavior { notifyEachNested, notifyOnlyLast }
+
 /// Configuration used by [ReactiveContext]
 class ReactiveConfig {
   ReactiveConfig({
@@ -61,6 +67,7 @@ class ReactiveConfig {
     this.readPolicy = ReactiveReadPolicy.never,
     this.maxIterations = 100,
     this.isSpyEnabled = false,
+    this.asyncActionBehavior = AsyncActionBehavior.notifyEachNested,
   });
 
   /// The main or default configuration used by [ReactiveContext]
@@ -86,19 +93,24 @@ class ReactiveConfig {
 
   final bool isSpyEnabled;
 
+  /// Set the behavior for the `AsyncAction`
+  final AsyncActionBehavior asyncActionBehavior;
+
   ReactiveConfig clone(
           {bool? disableErrorBoundaries,
           ReactiveWritePolicy? writePolicy,
           ReactiveReadPolicy? readPolicy,
           int? maxIterations,
-          bool? isSpyEnabled}) =>
+          bool? isSpyEnabled,
+          AsyncActionBehavior? asyncActionBehavior}) =>
       ReactiveConfig(
           disableErrorBoundaries:
               disableErrorBoundaries ?? this.disableErrorBoundaries,
           writePolicy: writePolicy ?? this.writePolicy,
           readPolicy: readPolicy ?? this.readPolicy,
           maxIterations: maxIterations ?? this.maxIterations,
-          isSpyEnabled: isSpyEnabled ?? this.isSpyEnabled);
+          isSpyEnabled: isSpyEnabled ?? this.isSpyEnabled,
+          asyncActionBehavior: asyncActionBehavior ?? this.asyncActionBehavior);
 }
 
 class ReactiveContext {

--- a/mobx/pubspec.yaml
+++ b/mobx/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mobx
-version: 2.0.7+4
+version: 2.0.7+5
 description: "MobX is a library for reactively managing the state of your applications. Use the power of observables, actions, and reactions to supercharge your Dart and Flutter apps."
 
 homepage: https://github.com/mobxjs/mobx.dart


### PR DESCRIPTION
Hello, 

I found this issue when I test my last PR. After doing some searching, I found that the PR #784 shouldn't be introduced without a breaking change version.

So I decided to fix this issue without breaking the code of the old users (who may be used this package since 2019 with PR #89) and allows anyone who wants to use new behavior (which is the official behavior of Mobx in the document).

I add an `asyncActionBehavior` flag to `ReactiveConfig` to control the behavior of `@action` on `Future` methods. This config is just needed for those who want to use new behavior to avoid breaking old users' code.

- New behavior:
``` dart
/// The same behavior with mobx >= 2.0.7+3
abstract class _YourStore with Store {
  @override
  ReactiveContext get context {
    return mainContext
      ..config.clone(asyncActionBehavior: AsyncActionBehavior.notifyOnlyLast);
  }
}
```

- Old behavior (currently users don't need to add this code): 
``` dart
/// The same behavior with mobx <= 2.0.7+2
abstract class _YourStore with Store {
  @override
  ReactiveContext get context {
    return mainContext
      ..config.clone(asyncActionBehavior: AsyncActionBehavior.notifyEachNested);
  }
}
```

Fixes: #834
Fixes: #836 
Fixes: #840

---
## Pull Request Checklist


- [x] If the changes are being made to code, ensure the **version in `pubspec.yaml`** is updated. 
- [x] Increment the **`major`/`minor`/`patch`/`patch-count`**, depending on the complexity of change
- [x] Add the necessary **unit tests** to ensure the coverage does not drop
- [x] Update the **Changelog** to include all changes made in this PR
- [x] Run the **`set:versions` command** using `npm` or `yarn`. You can find this command in the `package.json` file in the root directory
- [ ] Include the **necessary reviewers** for the PR
- [ ] Update the docs if there are any API changes or additions to functionality
