### PR TITLE
add issue_tracker links to pubspec

### DIFF
--- a/flutter_mobx/CHANGELOG.md
+++ b/flutter_mobx/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.6+2
+
+- Fixed issue in showing issue tracker link on pub.dev
+
 ## 2.0.6 - 2.0.6+1
 
 - Adding support for previous versions of Flutter SDK

--- a/flutter_mobx/lib/flutter_mobx.dart
+++ b/flutter_mobx/lib/flutter_mobx.dart
@@ -42,4 +42,4 @@ export 'package:flutter_mobx/src/stateful_observer_widget.dart';
 export 'package:flutter_mobx/src/stateless_observer_widget.dart';
 
 /// The version as per `pubspec.yaml`
-const version = '2.0.6+1';
+const version = '2.0.6+2';

--- a/flutter_mobx/pubspec.yaml
+++ b/flutter_mobx/pubspec.yaml
@@ -5,6 +5,7 @@ description:
 version: 2.0.6+1
 
 homepage: https://github.com/mobxjs/mobx.dart
+issue_tracker: https://github.com/mobxjs/mobx.dart/issues
 
 environment:
   sdk: ">=2.13.0 <3.0.0"

--- a/flutter_mobx/pubspec.yaml
+++ b/flutter_mobx/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_mobx
 description:
   Flutter integration for MobX. It provides a set of Observer widgets that automatically rebuild
   when the tracked observables change.
-version: 2.0.6+1
+version: 2.0.6+2
 
 homepage: https://github.com/mobxjs/mobx.dart
 issue_tracker: https://github.com/mobxjs/mobx.dart/issues

--- a/mobx/CHANGELOG.md
+++ b/mobx/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.7+6
+
+- Fixed issue in showing issue tracker link on pub.dev
+
 ## 2.0.7+5
 
 - revert #784 - [@amondnet](https://github.com/amondnet)

--- a/mobx/lib/mobx.dart
+++ b/mobx/lib/mobx.dart
@@ -65,4 +65,4 @@ export 'package:mobx/src/core.dart'
 export 'package:mobx/src/core/atom_extensions.dart';
 
 /// The current version as per `pubspec.yaml`
-const version = '2.0.7+5';
+const version = '2.0.7+6';

--- a/mobx/pubspec.yaml
+++ b/mobx/pubspec.yaml
@@ -1,12 +1,12 @@
 name: mobx
-version: 2.0.7+5
+version: 2.0.7+6
 description: "MobX is a library for reactively managing the state of your applications. Use the power of observables, actions, and reactions to supercharge your Dart and Flutter apps."
 
 homepage: https://github.com/mobxjs/mobx.dart
 issue_tracker: https://github.com/mobxjs/mobx.dart/issues
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
   meta: ^1.3.0

--- a/mobx/pubspec.yaml
+++ b/mobx/pubspec.yaml
@@ -3,6 +3,7 @@ version: 2.0.7+5
 description: "MobX is a library for reactively managing the state of your applications. Use the power of observables, actions, and reactions to supercharge your Dart and Flutter apps."
 
 homepage: https://github.com/mobxjs/mobx.dart
+issue_tracker: https://github.com/mobxjs/mobx.dart/issues
 
 environment:
   sdk: '>=2.17.0 <3.0.0'

--- a/mobx_codegen/CHANGELOG.md
+++ b/mobx_codegen/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.7+1
+
+- Fixed issue in showing issue tracker link on pub.dev
+
 ## 2.0.7
 
 - Update codegen templates to ignore newly recommended lint rules in generated code

--- a/mobx_codegen/lib/mobx_codegen.dart
+++ b/mobx_codegen/lib/mobx_codegen.dart
@@ -2,4 +2,4 @@ library mobx_codegen;
 
 export 'src/mobx_codegen_base.dart';
 
-const version = '2.0.7';
+const version = '2.0.7+1';

--- a/mobx_codegen/pubspec.yaml
+++ b/mobx_codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobx_codegen
 description: Code generator for MobX that adds support for annotating your code with @observable, @computed, @action and also creating Store classes.
-version: 2.0.7
+version: 2.0.7+1
 
 homepage: https://github.com/mobxjs/mobx.dart
 issue_tracker: https://github.com/mobxjs/mobx.dart/issues

--- a/mobx_codegen/pubspec.yaml
+++ b/mobx_codegen/pubspec.yaml
@@ -3,6 +3,7 @@ description: Code generator for MobX that adds support for annotating your code 
 version: 2.0.7
 
 homepage: https://github.com/mobxjs/mobx.dart
+issue_tracker: https://github.com/mobxjs/mobx.dart/issues
 
 environment:
   sdk: ">=2.13.0 <3.0.0"
@@ -24,4 +25,3 @@ dev_dependencies:
   logging: ^1.0.2
   mocktail: ^0.3.0
   test: ^1.20.1
-


### PR DESCRIPTION
pub.dev recently changed the logic for showing the View/report issues link 

---
## Pull Request Checklist


- [x] If the changes are being made to code, ensure the **version in `pubspec.yaml`** is updated. 
- [x] Increment the **`major`/`minor`/`patch`/`patch-count`**, depending on the complexity of change
- [ ] Add the necessary **unit tests** to ensure the coverage does not drop
- [x] Update the **Changelog** to include all changes made in this PR
- [x] Run the **`set:versions` command** using `npm` or `yarn`. You can find this command in the `package.json` file in the root directory
- [x] Include the **necessary reviewers** for the PR
- [ ] Update the docs if there are any API changes or additions to functionality
