### PR TITLE
"Observer child not in immediate context is not rebuilt" test added

### DIFF
--- a/flutter_mobx/CHANGELOG.md
+++ b/flutter_mobx/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.6+6
+- test "Observer child not in immediate context is not rebuilt" added - [@subzero911](https://github.com/subzero911)
+
 ## 2.0.6+3 - 2.0.6+5
 
 - Moved the version into its own file (`version.dart`) and exported from the main library file

--- a/flutter_mobx/pubspec.yaml
+++ b/flutter_mobx/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_mobx
 description:
   Flutter integration for MobX. It provides a set of Observer widgets that automatically rebuild
   when the tracked observables change.
-version: 2.0.6+5
+version: 2.0.6+6
 
 homepage: https://github.com/mobxjs/mobx.dart
 issue_tracker: https://github.com/mobxjs/mobx.dart/issues

--- a/flutter_mobx/test/flutter_mobx_test.dart
+++ b/flutter_mobx/test/flutter_mobx_test.dart
@@ -9,8 +9,7 @@ import 'package:mocktail/mocktail.dart';
 import 'helpers.dart';
 
 void main() {
-  setUp(() => mainContext.config =
-      ReactiveConfig(writePolicy: ReactiveWritePolicy.never));
+  setUp(() => mainContext.config = ReactiveConfig(writePolicy: ReactiveWritePolicy.never));
 
   tearDown(() => mainContext.config = ReactiveConfig.main);
 
@@ -18,8 +17,7 @@ void main() {
     expect(version, isNotNull);
   });
 
-  testWidgets('Observer re-renders when observed state changes',
-      (tester) async {
+  testWidgets('Observer re-renders when observed state changes', (tester) async {
     final message = Observable('Click');
 
     final key = UniqueKey();
@@ -27,8 +25,7 @@ void main() {
     await tester.pumpWidget(Observer(
         builder: (context) => GestureDetector(
               onTap: () => message.value = 'Clicked',
-              child: Text(message.value,
-                  key: key, textDirection: TextDirection.ltr),
+              child: Text(message.value, key: key, textDirection: TextDirection.ltr),
             )));
 
     expect(tester.widget<Text>(find.byKey(key)).data, equals('Click'));
@@ -40,8 +37,7 @@ void main() {
     expect(tester.widget<Text>(find.byKey(key)).data, equals('Clicked'));
   });
 
-  testWidgets("Observer doesn't re-render when observed state doesn't change",
-      (tester) async {
+  testWidgets("Observer doesn't re-render when observed state doesn't change", (tester) async {
     var renderCount = 0;
 
     final i = Observable(0);
@@ -59,19 +55,42 @@ void main() {
     expect(renderCount, equals(1));
   });
 
+  testWidgets("Observer child not in immediate context is not rebuilt", (tester) async {
+    final message = Observable('Click');
+    final key = UniqueKey();
+
+    await tester.pumpWidget(
+      Observer(
+        builder: (context) {
+          return GestureDetector(
+            onTap: () => message.value = 'Clicked',
+            child: Builder(builder: (context) { // [Text] is dropped out of [Observer]'s context
+              return Text(message.value, key: key, textDirection: TextDirection.ltr);
+            }),
+          );
+        },
+      ),
+    );
+
+    expect(tester.widget<Text>(find.byKey(key)).data, equals('Click'));
+
+    await tester.tap(find.byKey(key));
+    expect(message.value, equals('Clicked'));
+
+    await tester.pump();
+    expect(tester.widget<Text>(find.byKey(key)).data, equals('Click')); // child text did not change
+  });
+
   testWidgets('Observer build should call reaction.track', (tester) async {
     final mock = MockReaction();
     when(() => mock.hasObservables).thenReturn(true);
 
-    await tester.pumpWidget(
-        TestObserver(mock, builder: (context) => const Placeholder()));
+    await tester.pumpWidget(TestObserver(mock, builder: (context) => const Placeholder()));
 
     verify(() => mock.track(voidFn));
   });
 
-  testWidgets(
-      'Observer should throw exception if exceptions occur inside the reaction',
-      (tester) async {
+  testWidgets('Observer should throw exception if exceptions occur inside the reaction', (tester) async {
     dynamic exception;
 
     final prevOnError = FlutterError.onError;
@@ -98,12 +117,10 @@ void main() {
 
     expect(tester.firstWidget(find.byWidget(widget)), equals(widget));
 
-    expect(exception.message,
-        'Error happened when building Observer, but it was captured since disableErrorBoundaries==true');
+    expect(exception.message, 'Error happened when building Observer, but it was captured since disableErrorBoundaries==true');
   });
 
-  testWidgets('Observer should report Flutter errors during invalidation',
-      (tester) async {
+  testWidgets('Observer should report Flutter errors during invalidation', (tester) async {
     final mobXException = await _testThrowingObserver(
       tester,
       FlutterError('setState() failed!'),
@@ -113,8 +130,7 @@ void main() {
     expect((mobXException.exception as FlutterError).stackTrace, isNotNull);
   });
 
-  testWidgets('Observer should report non-Flutter errors during invalidation',
-      (tester) async {
+  testWidgets('Observer should report non-Flutter errors during invalidation', (tester) async {
     final mobXException = await _testThrowingObserver(
       tester,
       StateError('Something else happened'),
@@ -122,8 +138,7 @@ void main() {
     expect(mobXException.exception, isInstanceOf<StateError>());
   });
 
-  testWidgets('Observer should report exceptions during invalidation',
-      (tester) async {
+  testWidgets('Observer should report exceptions during invalidation', (tester) async {
     final exception = await _testThrowingObserver(
       tester,
       Exception('Some exception'),
@@ -135,16 +150,14 @@ void main() {
     final mock = MockReaction();
     when(() => mock.hasObservables).thenReturn(true);
 
-    await tester.pumpWidget(
-        TestObserver(mock, builder: (context) => const Placeholder()));
+    await tester.pumpWidget(TestObserver(mock, builder: (context) => const Placeholder()));
 
     await tester.pumpWidget(const Placeholder());
 
     verify(mock.dispose);
   });
 
-  testWidgets("Release mode, the reaction's default name is widget.toString()",
-      (tester) async {
+  testWidgets("Release mode, the reaction's default name is widget.toString()", (tester) async {
     debugAddStackTraceInObserverName = false;
     addTearDown(() => debugAddStackTraceInObserverName = true);
 
@@ -161,9 +174,7 @@ void main() {
     expect(element.reaction.name, equals('$observer'));
   });
 
-  testWidgets(
-      "Debug mode inserts the caller's stack frame in the reaction's name",
-      (tester) async {
+  testWidgets("Debug mode inserts the caller's stack frame in the reaction's name", (tester) async {
     final observer = LoggingObserver(
       builder: (_) => Container(),
     );
@@ -190,8 +201,7 @@ void main() {
     );
   });
 
-  testWidgets('debugFindConstructingStackFrame has friendly output',
-      (tester) async {
+  testWidgets('debugFindConstructingStackFrame has friendly output', (tester) async {
     final observer = Observer(builder: (_) => Container());
     expect(
       observer.debugConstructingStackFrame,
@@ -199,8 +209,7 @@ void main() {
     );
   });
 
-  testWidgets('Observer should log when there are no observables in builder',
-      (tester) async {
+  testWidgets('Observer should log when there are no observables in builder', (tester) async {
     final observer = LoggingObserver(
       builder: (_) => const Placeholder(),
     );
@@ -209,8 +218,7 @@ void main() {
     expect(observer.previousLog, isNotNull);
   });
 
-  testWidgets('Observer should NOT log when there are observables in builder',
-      (tester) async {
+  testWidgets('Observer should NOT log when there are observables in builder', (tester) async {
     final x = Observable(0);
     final observer = LoggingObserver(builder: (context) {
       x.value;
@@ -266,9 +274,7 @@ void main() {
     expect(find.byType(Container), findsOneWidget);
   });
 
-  testWidgets(
-      'The `setState() or markNeedsBuild() called during build` error is resolved',
-      (tester) async {
+  testWidgets('The `setState() or markNeedsBuild() called during build` error is resolved', (tester) async {
     // ignore: prefer_const_constructors
     await tester.pumpWidget(_ObserverRebuildTestMyApp());
 
@@ -280,10 +286,8 @@ void main() {
 
     await tester.pumpAndSettle();
 
-    expect(find.textContaining('One read status: FutureStatus.pending'),
-        findsOneWidget);
-    expect(find.textContaining('TwoChild read status: FutureStatus.pending'),
-        findsOneWidget);
+    expect(find.textContaining('One read status: FutureStatus.pending'), findsOneWidget);
+    expect(find.textContaining('TwoChild read status: FutureStatus.pending'), findsOneWidget);
   });
 
   group('ReactionBuilder', () {
@@ -291,8 +295,7 @@ void main() {
 
     testWidgets('Reaction is disposed on dispose', (tester) async {});
 
-    testWidgets('Given child is returned as part of the build method',
-        (tester) async {});
+    testWidgets('Given child is returned as part of the build method', (tester) async {});
   });
 }
 
@@ -345,8 +348,7 @@ class _ObserverRebuildTestMyApp extends StatefulWidget {
   const _ObserverRebuildTestMyApp({Key? key}) : super(key: key);
 
   @override
-  State<_ObserverRebuildTestMyApp> createState() =>
-      _ObserverRebuildTestMyAppState();
+  State<_ObserverRebuildTestMyApp> createState() => _ObserverRebuildTestMyAppState();
 }
 
 class _ObserverRebuildTestMyAppState extends State<_ObserverRebuildTestMyApp> {
@@ -371,8 +373,7 @@ class _ObserverRebuildTestMyAppState extends State<_ObserverRebuildTestMyApp> {
 class _ObserverRebuildTestOne extends StatelessWidget {
   final _ObserverRebuildTestMyStore store;
 
-  const _ObserverRebuildTestOne({Key? key, required this.store})
-      : super(key: key);
+  const _ObserverRebuildTestOne({Key? key, required this.store}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -383,9 +384,7 @@ class _ObserverRebuildTestOne extends StatelessWidget {
           // print('One.Observer.build');
           return Text('One read status: ${store.status}');
         }),
-        TextButton(
-            onPressed: () => store.showTwo = true,
-            child: const Text('click me')),
+        TextButton(onPressed: () => store.showTwo = true, child: const Text('click me')),
       ],
     );
   }
@@ -394,8 +393,7 @@ class _ObserverRebuildTestOne extends StatelessWidget {
 class _ObserverRebuildTestTwo extends StatelessWidget {
   final _ObserverRebuildTestMyStore store;
 
-  const _ObserverRebuildTestTwo({Key? key, required this.store})
-      : super(key: key);
+  const _ObserverRebuildTestTwo({Key? key, required this.store}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -412,16 +410,13 @@ class _ObserverRebuildTestTwo extends StatelessWidget {
 class _ObserverRebuildTestTwoChild extends StatefulWidget {
   final _ObserverRebuildTestMyStore store;
 
-  const _ObserverRebuildTestTwoChild({Key? key, required this.store})
-      : super(key: key);
+  const _ObserverRebuildTestTwoChild({Key? key, required this.store}) : super(key: key);
 
   @override
-  _ObserverRebuildTestTwoChildState createState() =>
-      _ObserverRebuildTestTwoChildState();
+  _ObserverRebuildTestTwoChildState createState() => _ObserverRebuildTestTwoChildState();
 }
 
-class _ObserverRebuildTestTwoChildState
-    extends State<_ObserverRebuildTestTwoChild> {
+class _ObserverRebuildTestTwoChildState extends State<_ObserverRebuildTestTwoChild> {
   @override
   void initState() {
     super.initState();
@@ -439,8 +434,7 @@ class _ObserverRebuildTestTwoChildState
   }
 }
 
-class _ObserverRebuildTestMyStore = __ObserverRebuildTestMyStore
-    with _$_ObserverRebuildTestMyStore;
+class _ObserverRebuildTestMyStore = __ObserverRebuildTestMyStore with _$_ObserverRebuildTestMyStore;
 
 abstract class __ObserverRebuildTestMyStore with Store {
   @observable


### PR DESCRIPTION
Added a test checking that Observer's child not in immediate context will not be rebuilt

related to PR https://github.com/mobxjs/mobx.dart/pull/909 , issue https://github.com/mobxjs/mobx.dart/issues/551

---
## Pull Request Checklist


- [x] If the changes are being made to code, ensure the **version in `pubspec.yaml`** is updated. 
- [x] Increment the **`major`/`minor`/`patch`/`patch-count`**, depending on the complexity of change
- [x] Add the necessary **unit tests** to ensure the coverage does not drop
- [x] Update the **Changelog** to include all changes made in this PR, organized by version
- [x] Run the **`melo run set_version` command** from the root directory
- [x] Include the **necessary reviewers** for the PR
- [ ] Update the docs if there are any API changes or additions to functionality
