### PR TITLE
chore: typo

### DIFF
--- a/docs/docs/examples/github/index.mdx
+++ b/docs/docs/examples/github/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Github Repos
+title: GitHub Repos
 slug: /examples/github-repos
 description: In this example, we will fetch the repositories for a github user. This will also show the use of an ObservableFuture with an Observer.
 ---


### PR DESCRIPTION
GitHub with capitalized h instead of Github with lowercased h