### PR TITLE
Avoid unnecessary observable notifications of Iterable or Map fields

### DIFF
--- a/mobx/CHANGELOG.md
+++ b/mobx/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.3
+
+- Avoid unnecessary observable notifications of `@observable` `Iterable` or `Map` fields of Stores by [@amondnet](https://github.com/amondnet)
+
 ## 2.2.2
 
 - Fix [#956]((https://github.com/mobxjs/mobx.dart/issues/956)): ObservableSet` and `ObservableMap` should not notify all listeners when `observe` with fireImmediately. by [@amondnet](https://github.com/amondnet) in [#962](https://github.com/mobxjs/mobx.dart/pull/962)

--- a/mobx/CHANGELOG.md
+++ b/mobx/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.2.3
 
-- Avoid unnecessary observable notifications of `@observable` `Iterable` or `Map` fields of Stores by [@amondnet](https://github.com/amondnet)
+- Avoid unnecessary observable notifications of `@observable` `Iterable` or `Map` fields of Stores by [@amondnet](https://github.com/amondnet)  in [#951](https://github.com/mobxjs/mobx.dart/pull/951)
 
 ## 2.2.2
 

--- a/mobx/lib/src/core/atom_extensions.dart
+++ b/mobx/lib/src/core/atom_extensions.dart
@@ -1,5 +1,6 @@
-import 'package:collection/collection.dart';
 import 'package:mobx/mobx.dart';
+
+import '../utils.dart';
 
 extension AtomSpyReporter on Atom {
   void reportRead() {
@@ -10,7 +11,7 @@ extension AtomSpyReporter on Atom {
   void reportWrite<T>(T newValue, T oldValue, void Function() setNewValue,
       {EqualityComparer<T>? equals}) {
     final areEqual = equals == null
-        ? _equals(oldValue, newValue)
+        ? equatable(oldValue, newValue)
         : equals(oldValue, newValue);
 
     // Avoid unnecessary observable notifications of @observable fields of Stores
@@ -33,19 +34,3 @@ extension AtomSpyReporter on Atom {
     context.spyReport(EndedSpyEvent(type: 'observable', name: name));
   }
 }
-
-/// Determines whether [a] and [b] are equal.
-bool _equals<T>(T a, T b) {
-  if (identical(a, b)) return true;
-  if (a is Iterable || a is Map) {
-    if (!_equality.equals(a, b)) return false;
-  } else if (a.runtimeType != b.runtimeType) {
-    return false;
-  } else if (a != b) {
-    return false;
-  }
-
-  return true;
-}
-
-const DeepCollectionEquality _equality = DeepCollectionEquality();

--- a/mobx/lib/src/core/atom_extensions.dart
+++ b/mobx/lib/src/core/atom_extensions.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:mobx/mobx.dart';
 
 extension AtomSpyReporter on Atom {
@@ -8,8 +9,9 @@ extension AtomSpyReporter on Atom {
 
   void reportWrite<T>(T newValue, T oldValue, void Function() setNewValue,
       {EqualityComparer<T>? equals}) {
-    final areEqual =
-        equals == null ? oldValue == newValue : equals(oldValue, newValue);
+    final areEqual = equals == null
+        ? _equals(oldValue, newValue)
+        : equals(oldValue, newValue);
 
     // Avoid unnecessary observable notifications of @observable fields of Stores
     if (areEqual) {
@@ -31,3 +33,19 @@ extension AtomSpyReporter on Atom {
     context.spyReport(EndedSpyEvent(type: 'observable', name: name));
   }
 }
+
+/// Determines whether [a] and [b] are equal.
+bool _equals<T>(T a, T b) {
+  if (identical(a, b)) return true;
+  if (a is Iterable || a is Map) {
+    if (!_equality.equals(a, b)) return false;
+  } else if (a.runtimeType != b.runtimeType) {
+    return false;
+  } else if (a != b) {
+    return false;
+  }
+
+  return true;
+}
+
+const DeepCollectionEquality _equality = DeepCollectionEquality();

--- a/mobx/lib/src/core/atom_extensions.dart
+++ b/mobx/lib/src/core/atom_extensions.dart
@@ -10,12 +10,10 @@ extension AtomSpyReporter on Atom {
 
   void reportWrite<T>(T newValue, T oldValue, void Function() setNewValue,
       {EqualityComparer<T>? equals}) {
-    final areEqual = equals == null
-        ? equatable(oldValue, newValue)
-        : equals(oldValue, newValue);
+    final areEqual = equals ?? equatable;
 
     // Avoid unnecessary observable notifications of @observable fields of Stores
-    if (areEqual) {
+    if (areEqual(newValue, oldValue)) {
       return;
     }
 

--- a/mobx/lib/src/core/observable.dart
+++ b/mobx/lib/src/core/observable.dart
@@ -105,7 +105,7 @@ class Observable<T> extends Atom
     }
 
     final areEqual =
-        equals == null ? prepared == value : equals!(prepared, _value);
+        equals == null ? equatable(prepared, value) : equals!(prepared, _value);
 
     return (!areEqual) ? prepared : WillChangeNotification.unchanged;
   }

--- a/mobx/lib/src/utils.dart
+++ b/mobx/lib/src/utils.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:collection/collection.dart' show DeepCollectionEquality;
+
 const Duration ms = Duration(milliseconds: 1);
 
 Timer Function(void Function()) createDelayedScheduler(int delayMs) =>
@@ -20,3 +22,19 @@ mixin DebugCreationStack {
     return result;
   }();
 }
+
+/// Determines whether [a] and [b] are equal.
+bool equatable<T>(T a, T b) {
+  if (identical(a, b)) return true;
+  if (a is Iterable || a is Map) {
+    if (!_equality.equals(a, b)) return false;
+  } else if (a.runtimeType != b.runtimeType) {
+    return false;
+  } else if (a != b) {
+    return false;
+  }
+
+  return true;
+}
+
+const DeepCollectionEquality _equality = DeepCollectionEquality();

--- a/mobx/lib/version.dart
+++ b/mobx/lib/version.dart
@@ -1,4 +1,4 @@
 // Generated via set_version.dart. !!!DO NOT MODIFY BY HAND!!!
 
 /// The current version as per `pubspec.yaml`.
-const version = '2.2.2';
+const version = '2.2.3';

--- a/mobx/pubspec.yaml
+++ b/mobx/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mobx
-version: 2.2.2
+version: 2.2.3
 description: "MobX is a library for reactively managing the state of your applications. Use the power of observables, actions, and reactions to supercharge your Dart and Flutter apps."
 
 homepage: https://github.com/mobxjs/mobx.dart
@@ -10,10 +10,10 @@ environment:
 
 dependencies:
   meta: ^1.3.0
+  collection: ^1.15.0
 
 dev_dependencies:
   build_runner: ^2.0.6
-  collection: ^1.15.0
   coverage: ^1.0.1
   fake_async: ^1.2.0
   lints: ^2.0.0

--- a/mobx/test/atom_extensions_test.dart
+++ b/mobx/test/atom_extensions_test.dart
@@ -4,118 +4,118 @@ import 'package:test/test.dart';
 void main() {
   test(
       'when write to @observable field with changed value, should trigger notifications for downstream',
-      () {
-    final store = _ExampleStore();
+          () {
+        final store = _ExampleStore();
 
-    final autorunResults = <String>[];
-    autorun((_) => autorunResults.add(store.value));
+        final autorunResults = <String>[];
+        autorun((_) => autorunResults.add(store.value));
 
-    expect(autorunResults, ['first']);
+        expect(autorunResults, ['first']);
 
-    store.value = 'second';
+        store.value = 'second';
 
-    expect(autorunResults, ['first', 'second']);
-  });
+        expect(autorunResults, ['first', 'second']);
+      });
 
   // fixed by #855
   test(
       'when write to @observable field with unchanged value, should not trigger notifications for downstream',
-      () {
-    final store = _ExampleStore();
+          () {
+        final store = _ExampleStore();
 
-    final autorunResults = <String>[];
-    autorun((_) => autorunResults.add(store.value));
+        final autorunResults = <String>[];
+        autorun((_) => autorunResults.add(store.value));
 
-    expect(autorunResults, ['first']);
+        expect(autorunResults, ['first']);
 
-    store.value = store.value;
+        store.value = store.value;
 
-    expect(autorunResults, ['first']);
-  });
+        expect(autorunResults, ['first']);
+      });
 
   test(
       'when write to @alwaysNotify field with unchanged value, should trigger notifications for downstream',
-      () {
-    final store = _ExampleStore();
+          () {
+        final store = _ExampleStore();
 
-    final autorunResults = <String>[];
-    autorun((_) => autorunResults.add(store.value2));
+        final autorunResults = <String>[];
+        autorun((_) => autorunResults.add(store.value2));
 
-    expect(autorunResults, ['first']);
+        expect(autorunResults, ['first']);
 
-    store.value2 = store.value2;
+        store.value2 = store.value2;
 
-    expect(autorunResults, ['first', 'first']);
-  });
+        expect(autorunResults, ['first', 'first']);
+      });
 
   test(
       'when write to @MakeObservable(equals: "a?.length == b?.length") field with changed value and not equals, should trigger notifications for downstream',
-      () {
-    final store = _ExampleStore();
+          () {
+        final store = _ExampleStore();
 
-    final autorunResults = <String>[];
-    autorun((_) => autorunResults.add(store.value3));
+        final autorunResults = <String>[];
+        autorun((_) => autorunResults.add(store.value3));
 
-    expect(autorunResults, ['first']); // length: 5
+        expect(autorunResults, ['first']); // length: 5
 
-    // length: 5, should not trigger
-    store.value3 = 'third';
+        // length: 5, should not trigger
+        store.value3 = 'third';
 
-    expect(autorunResults, ['first']);
+        expect(autorunResults, ['first']);
 
-    // length: 6, should trigger
-    store.value3 = 'second';
+        // length: 6, should trigger
+        store.value3 = 'second';
 
-    expect(autorunResults, ['first', 'second']);
-  });
-
-  test(
-      'when write to @observable iterable field with unchanged value, should not trigger notifications for downstream',
-      () {
-    final store = _ExampleStore();
-
-    final autorunResults = <List<String>>[];
-    autorun((_) => autorunResults.add(store.list));
-
-    store.list = ['first'];
-    expect(autorunResults, [
-      ['first']
-    ]);
-
-    store.list = ['first'];
-    expect(autorunResults, [
-      ['first']
-    ]);
-
-    store.list = ['first'];
-    expect(autorunResults, [
-      ['first']
-    ]);
-  });
+        expect(autorunResults, ['first', 'second']);
+      });
 
   test(
-      'when write to @observable map field with unchanged value, should not trigger notifications for downstream',
-      () {
-    final store = _ExampleStore();
+      'when write to iterable @observable field with unchanged value, should not trigger notifications for downstream',
+          () {
+        final store = _ExampleStore();
 
-    final autorunResults = <Map<String, int>>[];
-    autorun((_) => autorunResults.add(store.map));
+        final autorunResults = <List<String>>[];
+        autorun((_) => autorunResults.add(store.list));
 
-    store.map = {'first': 1};
-    expect(autorunResults, [
-      {'first': 1}
-    ]);
+        store.list = ['first'];
+        expect(autorunResults, [
+          ['first']
+        ]);
 
-    store.map = {'first': 1};
-    expect(autorunResults, [
-      {'first': 1}
-    ]);
+        store.list = ['first'];
+        expect(autorunResults, [
+          ['first']
+        ]);
 
-    store.map = {'first': 1};
-    expect(autorunResults, [
-      {'first': 1}
-    ]);
-  });
+        store.list = ['first'];
+        expect(autorunResults, [
+          ['first']
+        ]);
+      });
+
+  test(
+      'when write to map @observable field with unchanged value, should not trigger notifications for downstream',
+          () {
+        final store = _ExampleStore();
+
+        final autorunResults = <Map<String, int>>[];
+        autorun((_) => autorunResults.add(store.map));
+
+        store.map = {'first': 1};
+        expect(autorunResults, [
+          {'first': 1}
+        ]);
+
+        store.map = {'first': 1};
+        expect(autorunResults, [
+          {'first': 1}
+        ]);
+
+        store.map = {'first': 1};
+        expect(autorunResults, [
+          {'first': 1}
+        ]);
+      });
 }
 
 class _ExampleStore = __ExampleStore with _$_ExampleStore;
@@ -159,7 +159,7 @@ mixin _$_ExampleStore on __ExampleStore, Store {
 
   // ignore: non_constant_identifier_names
   late final _$value2Atom =
-      Atom(name: '__ExampleStore.value2', context: context);
+  Atom(name: '__ExampleStore.value2', context: context);
 
   @override
   String get value2 {
@@ -176,7 +176,7 @@ mixin _$_ExampleStore on __ExampleStore, Store {
 
   // ignore: non_constant_identifier_names
   late final _$value3Atom =
-      Atom(name: '__ExampleStore.value3', context: context);
+  Atom(name: '__ExampleStore.value3', context: context);
 
   @override
   String get value3 {
@@ -189,8 +189,7 @@ mixin _$_ExampleStore on __ExampleStore, Store {
     _$value3Atom.reportWrite(value, super.value3, () {
       super.value3 = value;
     },
-        equals: (String? oldValue, String? newValue) =>
-            oldValue?.length == newValue?.length);
+        equals: _equals);
   }
 
   // ignore: non_constant_identifier_names

--- a/mobx/test/atom_extensions_test.dart
+++ b/mobx/test/atom_extensions_test.dart
@@ -53,20 +53,20 @@ void main() {
           () {
         final store = _ExampleStore();
 
-        final autorunResults = <String>[];
-        autorun((_) => autorunResults.add(store.value3));
+        final autorunResults = <int>[];
+        autorun((_) => autorunResults.add(store.value3.length));
 
-        expect(autorunResults, ['first']); // length: 5
+        expect(autorunResults, [5]); // length: 5
 
         // length: 5, should not trigger
         store.value3 = 'third';
 
-        expect(autorunResults, ['first']);
+        expect(autorunResults, [5]);
 
         // length: 6, should trigger
         store.value3 = 'second';
 
-        expect(autorunResults, ['first', 'second']);
+        expect(autorunResults, [5, 6]);
       });
 
   test(
@@ -120,7 +120,7 @@ void main() {
 
 class _ExampleStore = __ExampleStore with _$_ExampleStore;
 
-bool _equals(String? oldValue, String? newValue) => (oldValue == newValue);
+bool _equals(String? oldValue, String? newValue) => (oldValue?.length == newValue?.length);
 
 abstract class __ExampleStore with Store {
   @observable

--- a/mobx/test/atom_extensions_test.dart
+++ b/mobx/test/atom_extensions_test.dart
@@ -68,6 +68,54 @@ void main() {
 
     expect(autorunResults, ['first', 'second']);
   });
+
+  test(
+      'when write to @observable iterable field with unchanged value, should not trigger notifications for downstream',
+      () {
+    final store = _ExampleStore();
+
+    final autorunResults = <List<String>>[];
+    autorun((_) => autorunResults.add(store.list));
+
+    store.list = ['first'];
+    expect(autorunResults, [
+      ['first']
+    ]);
+
+    store.list = ['first'];
+    expect(autorunResults, [
+      ['first']
+    ]);
+
+    store.list = ['first'];
+    expect(autorunResults, [
+      ['first']
+    ]);
+  });
+
+  test(
+      'when write to @observable map field with unchanged value, should not trigger notifications for downstream',
+      () {
+    final store = _ExampleStore();
+
+    final autorunResults = <Map<String, int>>[];
+    autorun((_) => autorunResults.add(store.map));
+
+    store.map = {'first': 1};
+    expect(autorunResults, [
+      {'first': 1}
+    ]);
+
+    store.map = {'first': 1};
+    expect(autorunResults, [
+      {'first': 1}
+    ]);
+
+    store.map = {'first': 1};
+    expect(autorunResults, [
+      {'first': 1}
+    ]);
+  });
 }
 
 class _ExampleStore = __ExampleStore with _$_ExampleStore;
@@ -83,6 +131,12 @@ abstract class __ExampleStore with Store {
 
   @MakeObservable(equals: _equals)
   String value3 = 'first';
+
+  @observable
+  List<String> list = ['first'];
+
+  @observable
+  Map<String, int> map = {'first': 1};
 }
 
 // This is what typically a mobx codegen will generate.
@@ -137,5 +191,37 @@ mixin _$_ExampleStore on __ExampleStore, Store {
     },
         equals: (String? oldValue, String? newValue) =>
             oldValue?.length == newValue?.length);
+  }
+
+  // ignore: non_constant_identifier_names
+  late final _$listAtom = Atom(name: '__ExampleStore.list', context: context);
+
+  @override
+  List<String> get list {
+    _$listAtom.reportRead();
+    return super.list;
+  }
+
+  @override
+  set list(List<String> value) {
+    _$listAtom.reportWrite(value, super.list, () {
+      super.list = value;
+    });
+  }
+
+  // ignore: non_constant_identifier_names
+  late final _$mapAtom = Atom(name: '__ExampleStore.map', context: context);
+
+  @override
+  Map<String, int> get map {
+    _$mapAtom.reportRead();
+    return super.map;
+  }
+
+  @override
+  set map(Map<String, int> value) {
+    _$mapAtom.reportWrite(value, super.map, () {
+      super.map = value;
+    });
   }
 }


### PR DESCRIPTION
Describe the changes proposed in this Pull Request.

Following up on pr #844, perform deep equals if value is `Iterable` or `Map`.

---
## Pull Request Checklist


- [x] If the changes are being made to code, ensure the **version in `pubspec.yaml`** is updated. 
- [x] Increment the **`major`/`minor`/`patch`/`patch-count`**, depending on the complexity of change
- [x] Add the necessary **unit tests** to ensure the coverage does not drop
- [x] Update the **Changelog** to include all changes made in this PR, organized by version
- [x] Run the **`melos run set_version` command** from the root directory
- [x] Include the **necessary reviewers** for the PR
- [x] Update the **docs** if there are any API changes or additions to functionality
