### PR TITLE
Observer.optimized

### DIFF
--- a/flutter_mobx/CHANGELOG.md
+++ b/flutter_mobx/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.2.0
+ - `Observer` is updated with new optional `child` parameter, so you can exclude child branch from re-render. - [@subzero911](https://github.com/subzero911) \
+   You should provide either `builder` or both `builderWithChild` and `child`:
+   ```dart
+   Observer.optimized(
+     builderWithChild: (context, child) => FooWidget(foo: foo, child: child),
+     child: BarWidget(), // is not rebuilt
+   ),
+   ``` 
+
 ## 2.1.1
 
 - refactor: export `MultiReactionBuilder` from `flutter_mobx.dart` by [@amondnet](https://github.com/amondnet)

--- a/flutter_mobx/CHANGELOG.md
+++ b/flutter_mobx/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## 2.2.0
- - `Observer` is updated with new optional `child` parameter, so you can exclude child branch from re-render. - [@subzero911](https://github.com/subzero911) \
-   You should provide either `builder` or both `builderWithChild` and `child`:
+ - `Observer` is updated with the new `Observer.optimized` constructor, so you can exclude child branch from the re-rendering. - [@subzero911](https://github.com/subzero911) \
+   In case if you use `Builder.optimized`, you should provide two parameters: `builderOptimized` and `child`:
    ```dart
    Observer.optimized(
-     builderWithChild: (context, child) => FooWidget(foo: foo, child: child),
+     builderOptimized: (context, child) => FooWidget(foo: foo, child: child),
      child: BarWidget(), // is not rebuilt
    ),
    ``` 

--- a/flutter_mobx/CHANGELOG.md
+++ b/flutter_mobx/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## 2.2.0
- - `Observer` is updated with the new `Observer.optimized` constructor, so you can exclude child branch from the re-rendering. - [@subzero911](https://github.com/subzero911) \
-   In case if you use `Builder.optimized`, you should provide two parameters: `builderOptimized` and `child`:
+ - `Observer` is updated with the new `Observer.withChild` constructor, so you can exclude child branch from the re-rendering. - [@subzero911](https://github.com/subzero911) \
+   In case if you use `Builder.withChild`, you should provide two parameters: `builderWithChild` and `child`:
    ```dart
-   Observer.optimized(
-     builderOptimized: (context, child) => FooWidget(foo: foo, child: child),
+   Observer.withChild(
+     builderWithChild: (context, child) => FooWidget(foo: foo, child: child),
      child: BarWidget(), // is not rebuilt
    ),
    ``` 

--- a/flutter_mobx/lib/src/observer.dart
+++ b/flutter_mobx/lib/src/observer.dart
@@ -26,6 +26,7 @@ class Observer extends StatelessObserverWidget {
   })  : debugConstructingStackFrame = debugFindConstructingStackFrame(),
         builderOptimized = null,
         child = null,
+        assert(builder != null),
         super(
           key: key,
           name: name,
@@ -42,6 +43,7 @@ class Observer extends StatelessObserverWidget {
     bool? warnWhenNoObservables,
   })  : debugConstructingStackFrame = debugFindConstructingStackFrame(),
         builder = null,
+        assert(builderOptimized != null && child != null),
         super(
           key: key,
           name: name,

--- a/flutter_mobx/lib/src/observer.dart
+++ b/flutter_mobx/lib/src/observer.dart
@@ -61,7 +61,11 @@ class Observer extends StatelessObserverWidget {
   final String? debugConstructingStackFrame;
 
   @override
-  String getName() => super.getName() + (debugConstructingStackFrame != null ? '\n$debugConstructingStackFrame' : '');
+  String getName() =>
+    super.getName() + 
+    (debugConstructingStackFrame != null
+      ? '\n$debugConstructingStackFrame'
+      : '');
 
   @override
   Widget build(BuildContext context) => builderOptimized?.call(context, child) ?? builder!.call(context);
@@ -92,10 +96,16 @@ class Observer extends StatelessObserverWidget {
             // regex)
             .skip(3)
             // Search for the first non-constructor frame
-            .firstWhere((frame) => !_constructorStackFramePattern.hasMatch(frame), orElse: () => '');
+            .firstWhere(
+              (frame) => 
+                !_constructorStackFramePattern.hasMatch(frame),
+                orElse: () => '');
 
-        final stackFrameCore = _stackFrameCleanUpPattern.firstMatch(rawStackFrame)?.group(1);
-        final cleanedStackFrame = stackFrameCore == null ? null : 'Observer constructed from: $stackFrameCore';
+        final stackFrameCore =
+          _stackFrameCleanUpPattern.firstMatch(rawStackFrame)?.group(1);
+        final cleanedStackFrame = stackFrameCore == null
+          ? null
+          : 'Observer constructed from: $stackFrameCore';
 
         stackFrame = cleanedStackFrame;
       }

--- a/flutter_mobx/lib/src/observer.dart
+++ b/flutter_mobx/lib/src/observer.dart
@@ -24,7 +24,7 @@ class Observer extends StatelessObserverWidget {
     String? name,
     bool? warnWhenNoObservables,
   })  : debugConstructingStackFrame = debugFindConstructingStackFrame(),
-        builderOptimized = null,
+        builderWithChild = null,
         child = null,
         assert(builder != null),
         super(
@@ -35,15 +35,15 @@ class Observer extends StatelessObserverWidget {
 
   /// Observer which excludes the child branch
   // ignore: prefer_const_constructors_in_immutables
-  Observer.optimized({
+  Observer.withChild({
     Key? key,
-    required this.builderOptimized,
+    required this.builderWithChild,
     required this.child,
     String? name,
     bool? warnWhenNoObservables,
   })  : debugConstructingStackFrame = debugFindConstructingStackFrame(),
         builder = null,
-        assert(builderOptimized != null && child != null),
+        assert(builderWithChild != null && child != null),
         super(
           key: key,
           name: name,
@@ -52,9 +52,9 @@ class Observer extends StatelessObserverWidget {
 
   final WidgetBuilder? builder;
 
-  final TransitionBuilder? builderOptimized;
+  final TransitionBuilder? builderWithChild;
 
-  /// The child widget to pass to the [builderOptimized].
+  /// The child widget to pass to the [builderWithChild].
   final Widget? child;
 
   /// The stack frame pointing to the source that constructed this instance.
@@ -68,7 +68,7 @@ class Observer extends StatelessObserverWidget {
       : '');
 
   @override
-  Widget build(BuildContext context) => builderOptimized?.call(context, child) ?? builder!.call(context);
+  Widget build(BuildContext context) => builderWithChild?.call(context, child) ?? builder!.call(context);
 
   /// Matches constructor stack frames, in both VM and web environments.
   static final _constructorStackFramePattern = RegExp(r'\bnew\b');

--- a/flutter_mobx/lib/src/observer.dart
+++ b/flutter_mobx/lib/src/observer.dart
@@ -52,10 +52,9 @@ class Observer extends StatelessObserverWidget {
 
   final WidgetBuilder? builder;
 
-  /// A builder that builds a widget given a child.
   final TransitionBuilder? builderOptimized;
 
-  /// The child widget to pass to the [builderWithChild].
+  /// The child widget to pass to the [builderOptimized].
   final Widget? child;
 
   /// The stack frame pointing to the source that constructed this instance.

--- a/flutter_mobx/lib/version.dart
+++ b/flutter_mobx/lib/version.dart
@@ -1,4 +1,4 @@
 // Generated via set_version.dart. !!!DO NOT MODIFY BY HAND!!!
 
 /// The current version as per `pubspec.yaml`.
-const version = '2.1.1';
+const version = '2.2.0';

--- a/flutter_mobx/pubspec.yaml
+++ b/flutter_mobx/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_mobx
 description:
   Flutter integration for MobX. It provides a set of Observer widgets that automatically rebuild
   when the tracked observables change.
-version: 2.1.1
+version: 2.2.0
 
 homepage: https://github.com/mobxjs/mobx.dart
 issue_tracker: https://github.com/mobxjs/mobx.dart/issues

--- a/flutter_mobx/test/flutter_mobx_test.dart
+++ b/flutter_mobx/test/flutter_mobx_test.dart
@@ -59,7 +59,7 @@ void main() {
     expect(renderCount, equals(1));
   });
 
-  testWidgets("Observer.optimized's child doesn't re-render", (tester) async {
+  testWidgets("Observer.withChild's child doesn't re-render", (tester) async {
     final message = Observable('Click');
      final key1 = UniqueKey();
      final key2 = UniqueKey();

--- a/flutter_mobx/test/flutter_mobx_test.dart
+++ b/flutter_mobx/test/flutter_mobx_test.dart
@@ -67,8 +67,8 @@ void main() {
 
      await tester.pumpWidget(
        MaterialApp(
-         home: Observer.optimized(
-           builderOptimized: (context, child) {          
+         home: Observer.withChild(
+           builderWithChild: (context, child) {          
              return Column(
                children: [
                  ElevatedButton(onPressed: () => message.value = 'Clicked', child: Container()),

--- a/flutter_mobx/test/flutter_mobx_test.dart
+++ b/flutter_mobx/test/flutter_mobx_test.dart
@@ -59,6 +59,47 @@ void main() {
     expect(renderCount, equals(1));
   });
 
+  testWidgets("Observer.optimized's child doesn't re-render", (tester) async {
+    final message = Observable('Click');
+     final key1 = UniqueKey();
+     final key2 = UniqueKey();
+     final key3 = UniqueKey();
+
+     await tester.pumpWidget(
+       MaterialApp(
+         home: Observer.optimized(
+           builderOptimized: (context, child) {          
+             return Column(
+               children: [
+                 ElevatedButton(onPressed: () => message.value = 'Clicked', child: Container()),
+                 Text(message.value, key: key1),
+                 child!,
+                 Builder(
+                   builder: (context) {
+                     return Text(message.value, key: key3); 
+                   }
+                 ),
+               ],
+             );
+           },
+           child: Text(message.value, key: key2),
+         ),
+       ),
+     );    
+
+     expect(tester.widget<Text>(find.byKey(key1)).data, equals('Click'));
+     expect(tester.widget<Text>(find.byKey(key2)).data, equals('Click'));
+     expect(tester.widget<Text>(find.byKey(key3)).data, equals('Click'));
+
+     await tester.tap(find.byType(ElevatedButton));
+     expect(message.value, equals('Clicked'));
+
+     await tester.pump();
+     expect(tester.widget<Text>(find.byKey(key1)).data, equals('Clicked')); // Observer rebuilt the Text1
+     expect(tester.widget<Text>(find.byKey(key2)).data, equals('Click')); // child Text2 did not change
+     expect(tester.widget<Text>(find.byKey(key3)).data, equals('Clicked')); // Builder does not preserve from rebuild
+  });
+
   testWidgets('Observer build should call reaction.track', (tester) async {
     final mock = MockReaction();
     when(() => mock.hasObservables).thenReturn(true);


### PR DESCRIPTION
I already did a PR https://github.com/mobxjs/mobx.dart/pull/909 but I accidentally deleted the forked repo.
So I made it again and a little bit better.

Mostly you try to make Observer as small as possible. But sometimes you'll want to exclude the widget subtree from re-render and improve the performance.

Real world examples:
1) You have a colored Container with some heavy widgets inside (like `ListView` with `shrinkWrap: true`).
You want to change the color by Observable, but don't want to rebuild the whole ListView.
2) You have some fancy animation driven by Observable. You want to animate the widget and want to preserve its children from being rebuilt.

I introduce the new `Observer.optimized` which allows you to exclude the `child` branch.
Usage:
   ```dart
   Observer.optimized(
     builderOptimized: (context, child) => FooWidget(foo: foo, child: child),
     child: BarWidget(), // is not rebuilt
   ),
   ``` 

Solves https://github.com/mobxjs/mobx.dart/issues/551

@amondnet @fzyzcjy 

---
## Pull Request Checklist


- [x] If the changes are being made to code, ensure the **version in `pubspec.yaml`** is updated. 
- [x] Increment the **`major`/`minor`/`patch`/`patch-count`**, depending on the complexity of change
- [x] Add the necessary **unit tests** to ensure the coverage does not drop
- [x] Update the **Changelog** to include all changes made in this PR, organized by version
- [x] Run the **`melos run set_version` command** from the root directory
- [x] Include the **necessary reviewers** for the PR
- [x] Update the **docs** if there are any API changes or additions to functionality
