### PR TITLE
docs: use pnpm instead of yarn

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,13 +6,13 @@ static website generator.
 ## Installation
 
 ```console
-yarn install
+pnpm install
 ```
 
 ## Local Development
 
 ```console
-yarn start
+pnpm start
 ```
 
 This command starts a local development server and open up a browser window.
@@ -21,7 +21,7 @@ Most changes are reflected live without having to restart the server.
 ## Build
 
 ```console
-yarn build
+pnpm build
 ```
 
 This command generates static content into the `build` directory and can be
@@ -30,7 +30,7 @@ served using any static contents hosting service.
 ## Deployment
 
 ```console
-GIT_USER=<Your GitHub username> USE_SSH=true yarn deploy
+GIT_USER=<Your GitHub username> USE_SSH=true pnpm deploy
 ```
 
 If you are using GitHub pages for hosting, this command is a convenient way to


### PR DESCRIPTION
Describe the changes proposed in this Pull Request.

It looks like we are using `pnpm` instead of `yarn` to build the docs.

https://github.com/mobxjs/mobx.dart/commit/d7dbbf57074f7db0a63273ccfb99f5ca219f0f28
https://github.com/mobxjs/mobx.dart/blob/1388bbdafca4619f51645ae83190fddd6dd127bf/docs/pnpm-lock.yaml

---
## Pull Request Checklist


- [x] If the changes are being made to code, ensure the **version in `pubspec.yaml`** is updated. 
- [x] Increment the **`major`/`minor`/`patch`/`patch-count`**, depending on the complexity of change
- [x] Add the necessary **unit tests** to ensure the coverage does not drop
- [x] Update the **Changelog** to include all changes made in this PR, organized by version
- [x] Run the **`melos run set_version` command** from the root directory
- [x] Include the **necessary reviewers** for the PR
- [x] Update the **docs** if there are any API changes or additions to functionality
