### PR TITLE
feat: add scheduler option to autorun and reaction

### DIFF
--- a/mobx/CHANGELOG.md
+++ b/mobx/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.0
+
+- Add `scheduler` to `reaction` and `autorun` to allow customizing the scheduler used to schedule the reaction. By [@amondnet]((https://github.com/amondnet).
+
 ## 2.3.3+1 - 2.3.3+2
 
 - Analyzer fixes

--- a/mobx/lib/version.dart
+++ b/mobx/lib/version.dart
@@ -1,4 +1,4 @@
 // Generated via set_version.dart. !!!DO NOT MODIFY BY HAND!!!
 
 /// The current version as per `pubspec.yaml`.
-const version = '2.3.3+2';
+const version = '2.4.0';

--- a/mobx/pubspec.yaml
+++ b/mobx/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mobx
-version: 2.3.3+2
+version: 2.4.0
 description: "MobX is a library for reactively managing the state of your applications. Use the power of observables, actions, and reactions to supercharge your Dart and Flutter apps."
 
 repository: https://github.com/mobxjs/mobx.dart

--- a/mobx/test/autorun_test.dart
+++ b/mobx/test/autorun_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:fake_async/fake_async.dart';
 import 'package:mobx/mobx.dart';
 import 'package:mocktail/mocktail.dart' as mock;
@@ -82,6 +84,38 @@ void main() {
           value = x.value + 1;
         }, delay: delayMs)
             .call;
+
+        async.elapse(const Duration(milliseconds: 2500));
+
+        expect(value, 0); // autorun() should not have executed at this time
+
+        async.elapse(const Duration(milliseconds: 2500));
+
+        expect(value, 11); // autorun() should have executed
+
+        x.value = 100;
+
+        expect(value, 11); // should still retain the last value
+        async.elapse(const Duration(milliseconds: delayMs));
+        expect(value, 101); // should change now
+      });
+
+      dispose();
+    });
+
+    test('with custom scheduler', () {
+      late Function dispose;
+      const delayMs = 5000;
+
+      final x = Observable(10);
+      var value = 0;
+
+      fakeAsync((async) {
+        dispose = autorun((_) {
+          value = x.value + 1;
+        }, scheduler: (f) {
+          return Timer(const Duration(milliseconds: delayMs), f);
+        }).call;
 
         async.elapse(const Duration(milliseconds: 2500));
 


### PR DESCRIPTION
Describe the changes proposed in this Pull Request.

Add `scheduler` to `reaction` and `autorun` to allow customizing the scheduler used to schedule the reaction.

https://mobx.js.org/reactions.html#scheduler-_autorun-reaction_

---
## Pull Request Checklist


- [x] If the changes are being made to code, ensure the **version in `pubspec.yaml`** is updated. 
- [x] Increment the **`major`/`minor`/`patch`/`patch-count`**, depending on the complexity of change
- [x] Add the necessary **unit tests** to ensure the coverage does not drop
- [x] Update the **Changelog** to include all changes made in this PR, organized by version
- [x] Run the **`melos run set_version` command** from the root directory
- [x] Include the **necessary reviewers** for the PR
- [x] Update the **docs** if there are any API changes or additions to functionality
