### PR TITLE
withBuildChild fix

### DIFF
--- a/docs/docs/api/observers.mdx
+++ b/docs/docs/api/observers.mdx
@@ -90,6 +90,35 @@ class _CounterExampleState extends State<CounterExample> {
 }
 ```
 
+#### Performance optimizations
+Mostly you try to make `Observer` as small as possible. But sometimes you want to exclude
+the widget subtree from being rebuilt and improve the performance.
+
+For that you can use an `Observer.withBuiltChild` constructor. It takes `builderWithChild`
+and `child` arguments and internally uses the same technique as in [AnimatedBuilder](https://api.flutter.dev/flutter/widgets/AnimatedBuilder-class.html)
+
+Here is an example:
+
+```dart
+final obsColor = Observable(Color(0xFF000000));
+
+Observer.withBuiltChild(
+  builderWithChild: (context, child) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      color: obsColor.value, // this widget will be rebuilt when obsColor changes
+      child: child,
+    );
+  },
+  child: ListView.builder( // this widget will not be rebuilt
+    itemCount: 1000,
+    itemBuilder: (context, index) {
+      return ListTile(title: Text('Item $index'));
+    },
+  ),
+)
+```
+
 ## ReactionBuilder widget
 
 If you ever ran into a need for running a reaction when a Widget loads, you most

--- a/docs/docs/api/observers.mdx
+++ b/docs/docs/api/observers.mdx
@@ -94,23 +94,24 @@ class _CounterExampleState extends State<CounterExample> {
 Mostly you try to make `Observer` as small as possible. But sometimes you want to exclude
 the widget subtree from being rebuilt and improve the performance.
 
-For that you can use an `Observer.withBuiltChild` constructor. It takes `builderWithChild`
+For that you can use an `Observer.withBuiltChild` constructor. It takes `builder`
 and `child` arguments and internally uses the same technique as in [AnimatedBuilder](https://api.flutter.dev/flutter/widgets/AnimatedBuilder-class.html)
 
-Here is an example:
+Here is a brief example:
 
 ```dart
-final obsColor = Observable(Color(0xFF000000));
+final obsColor = Observable(Colors.green);
 
 Observer.withBuiltChild(
-  builderWithChild: (context, child) {
+  builder: (context, child) {
     return Container(
       padding: const EdgeInsets.all(16),
-      color: obsColor.value, // this widget will be rebuilt when obsColor changes
+      color: obsColor.value, // this widget will be rebuilt when the color value changes
       child: child,
     );
   },
-  child: ListView.builder( // this widget will not be rebuilt
+  child: ListView.builder( // this part will not be rebuilt
+    shrinkWrap: true,
     itemCount: 1000,
     itemBuilder: (context, index) {
       return ListTile(title: Text('Item $index'));

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -3483,8 +3483,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.7:
-    resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
+  nanoid@3.3.8:
+    resolution: {integrity: sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -9615,7 +9615,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.7: {}
+  nanoid@3.3.8: {}
 
   negotiator@0.6.3: {}
 
@@ -10081,7 +10081,7 @@ snapshots:
 
   postcss@8.4.38:
     dependencies:
-      nanoid: 3.3.7
+      nanoid: 3.3.8
       picocolors: 1.0.0
       source-map-js: 1.2.0
 

--- a/flutter_mobx/CHANGELOG.md
+++ b/flutter_mobx/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.2
+
+- fix: removed runtime asserts and nullables from `Observer.withBuiltChild` - [@subzero911](https://github.com/subzero911)
+
 ## 2.2.1+1
 
 - Analyzer fixes

--- a/flutter_mobx/lib/src/observer.dart
+++ b/flutter_mobx/lib/src/observer.dart
@@ -23,31 +23,24 @@ class Observer extends StatelessObserverWidget {
     required this.builder,
     super.name,
     super.warnWhenNoObservables,
-  })  : debugConstructingStackFrame = debugFindConstructingStackFrame(),
-        builderWithChild = null,
-        child = null,
-        assert(builder != null);
+  }) : debugConstructingStackFrame = debugFindConstructingStackFrame();
 
   /// Observer which excludes the child branch from being rebuilt
+  ///
+  /// - [builderWithChild] is a builder function with a child widget as a parameter;
+  ///
+  /// - [child] is the widget to pass to the [builderWithChild] function.
   // ignore: prefer_const_constructors_in_immutables
   Observer.withBuiltChild({
     super.key,
-    required this.builderWithChild,
-    required this.child,
+    required Widget Function(BuildContext, Widget) builderWithChild,
+    required Widget child,
     super.name,
     super.warnWhenNoObservables,
   })  : debugConstructingStackFrame = debugFindConstructingStackFrame(),
-        builder = null,
-        assert(builderWithChild != null && child != null);
+        builder = ((context) => builderWithChild(context, child));
 
-  /// regular builder, suitable for most cases
-  final WidgetBuilder? builder;
-
-  /// builder function with child parameter
-  final TransitionBuilder? builderWithChild;
-
-  /// The child widget to pass to the [builderWithChild].
-  final Widget? child;
+  final WidgetBuilder builder;
 
   /// The stack frame pointing to the source that constructed this instance.
   final String? debugConstructingStackFrame;
@@ -60,8 +53,7 @@ class Observer extends StatelessObserverWidget {
           : '');
 
   @override
-  Widget build(BuildContext context) =>
-      builderWithChild?.call(context, child) ?? builder!.call(context);
+  Widget build(BuildContext context) => builder.call(context);
 
   /// Matches constructor stack frames, in both VM and web environments.
   static final _constructorStackFramePattern = RegExp(r'\bnew\b');

--- a/flutter_mobx/lib/src/observer.dart
+++ b/flutter_mobx/lib/src/observer.dart
@@ -27,18 +27,18 @@ class Observer extends StatelessObserverWidget {
 
   /// Observer which excludes the child branch from being rebuilt
   ///
-  /// - [builderWithChild] is a builder function with a child widget as a parameter;
+  /// - [builder] is a builder function with a child widget as a parameter;
   ///
-  /// - [child] is the widget to pass to the [builderWithChild] function.
+  /// - [child] is the widget to pass to the [builder] function.
   // ignore: prefer_const_constructors_in_immutables
   Observer.withBuiltChild({
     super.key,
-    required Widget Function(BuildContext, Widget) builderWithChild,
+    required Widget Function(BuildContext, Widget) builder,
     required Widget child,
     super.name,
     super.warnWhenNoObservables,
   })  : debugConstructingStackFrame = debugFindConstructingStackFrame(),
-        builder = ((context) => builderWithChild(context, child));
+        builder = ((context) => builder(context, child));
 
   final WidgetBuilder builder;
 

--- a/flutter_mobx/lib/version.dart
+++ b/flutter_mobx/lib/version.dart
@@ -1,4 +1,4 @@
 // Generated via set_version.dart. !!!DO NOT MODIFY BY HAND!!!
 
 /// The current version as per `pubspec.yaml`.
-const version = '2.2.1+1';
+const version = '2.2.2';

--- a/flutter_mobx/pubspec.yaml
+++ b/flutter_mobx/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_mobx
 description:
   Flutter integration for MobX. It provides a set of Observer widgets that automatically rebuild
   when the tracked observables change.
-version: 2.2.1+1
+version: 2.2.2
 
 repository: https://github.com/mobxjs/mobx.dart
 issue_tracker: https://github.com/mobxjs/mobx.dart/issues

--- a/flutter_mobx/test/flutter_mobx_test.dart
+++ b/flutter_mobx/test/flutter_mobx_test.dart
@@ -69,7 +69,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Observer.withBuiltChild(
-          builderWithChild: (context, child) {
+          builder: (context, child) {
             return Column(
               children: [
                 ElevatedButton(

--- a/flutter_mobx/test/flutter_mobx_test.dart
+++ b/flutter_mobx/test/flutter_mobx_test.dart
@@ -76,7 +76,7 @@ void main() {
                     onPressed: () => message.value = 'Clicked',
                     child: Container()),
                 Text(message.value, key: key1),
-                child!,
+                child,
                 Builder(builder: (context) {
                   return Text(message.value, key: key3);
                 }),

--- a/mobx_codegen/analysis_options.yaml
+++ b/mobx_codegen/analysis_options.yaml
@@ -1,8 +1,6 @@
 include: package:lints/recommended.yaml
 
 analyzer:
-  errors:
-    unused_element: ignore
   exclude:
     - test/data/**.dart
     - test/*.g.dart

--- a/mobx_codegen/test/generator_usage_test.dart
+++ b/mobx_codegen/test/generator_usage_test.dart
@@ -9,6 +9,7 @@ class TestStore = _TestStore with _$TestStore;
 bool customEquals(String? oldValue, String? newValue) => oldValue != newValue;
 
 abstract class _TestStore with Store {
+  // ignore: unused_element
   _TestStore(this.field1, {this.field2});
 
   @observable

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,4 +4,4 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dev_dependencies:
-  melos: ^5.2.1
+  melos: ^6.2.0


### PR DESCRIPTION
I fixed Observer.withBuiltChild constructor.
I removed runtime asserts and unneeded nullables. So now it's neat.

I also added an example to the docs.

---
## Pull Request Checklist


- [x] If the changes are being made to code, ensure the **version in `pubspec.yaml`** is updated. 
- [x] Increment the **`major`/`minor`/`patch`/`patch-count`**, depending on the complexity of change
- [x] Add the necessary **unit tests** to ensure the coverage does not drop
- [x] Update the **Changelog** to include all changes made in this PR, organized by version
- [x] Run the **`melos run set_version` command** from the root directory
- [x] Include the **necessary reviewers** for the PR
- [x] Update the **docs** if there are any API changes or additions to functionality
