### PR TITLE
feat: addition of new method to collections to observe inner collection

### DIFF
--- a/mobx/lib/src/api/observable_collections/observable_list.dart
+++ b/mobx/lib/src/api/observable_collections/observable_list.dart
@@ -42,6 +42,13 @@ class ObservableList<T>
 
   List<T> get nonObservableInner => _list;
 
+  /// An observable version of [nonObservableInner].
+  List<T> get inner {
+    _context.enforceReadPolicy(_atom);
+    _atom.reportObserved();
+    return _list;
+  }
+
   Listeners<ListChange<T>>? _listenersField;
 
   Listeners<ListChange<T>> get _listeners =>

--- a/mobx/lib/src/api/observable_collections/observable_map.dart
+++ b/mobx/lib/src/api/observable_collections/observable_map.dart
@@ -60,6 +60,13 @@ class ObservableMap<K, V>
 
   Map<K, V> get nonObservableInner => _map;
 
+  /// An observable version of [nonObservableInner].
+  Map<K, V> get inner {
+    _context.enforceReadPolicy(_atom);
+    _atom.reportObserved();
+    return _map;
+  }
+
   String get name => _atom.name;
 
   Listeners<MapChange<K, V>>? _listenersField;

--- a/mobx/lib/src/api/observable_collections/observable_set.dart
+++ b/mobx/lib/src/api/observable_collections/observable_set.dart
@@ -48,6 +48,13 @@ class ObservableSet<T>
 
   Set<T> get nonObservableInner => _set;
 
+  /// An observable version of [nonObservableInner].
+  Set<T> get inner {
+    _context.enforceReadPolicy(_atom);
+    _atom.reportObserved();
+    return _set;
+  }
+
   String get name => _atom.name;
 
   Listeners<SetChange<T>>? _listenersField;

--- a/mobx/lib/version.dart
+++ b/mobx/lib/version.dart
@@ -1,4 +1,4 @@
 // Generated via set_version.dart. !!!DO NOT MODIFY BY HAND!!!
 
 /// The current version as per `pubspec.yaml`.
-const version = '2.5.0';
+const version = '2.5.1';

--- a/mobx/pubspec.yaml
+++ b/mobx/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mobx
-version: 2.5.0
+version: 2.5.1
 description: "MobX is a library for reactively managing the state of your applications. Use the power of observables, actions, and reactions to supercharge your Dart and Flutter apps."
 
 repository: https://github.com/mobxjs/mobx.dart

--- a/mobx/test/observable_list_test.dart
+++ b/mobx/test/observable_list_test.dart
@@ -650,6 +650,7 @@ void main() {
         'any': (list) => list.any((_) => true),
         '[]': (list) => list[0],
         '+': (list) => list + [100],
+        'inner': (list) => list.inner,
       }.forEach(_templateReadTest);
 
       test('bypass observable system', () {

--- a/mobx/test/observable_map_test.dart
+++ b/mobx/test/observable_map_test.dart
@@ -100,6 +100,7 @@ void main() {
         'isEmpty': (m) => m.isEmpty,
         'isNotEmpty': (m) => m.isNotEmpty,
         'map': (m) => m.map((key, value) => MapEntry(key, value + 1)),
+        'inner': (m) => m.inner,
       }.forEach(runReadTest);
     });
 

--- a/mobx/test/observable_set_test.dart
+++ b/mobx/test/observable_set_test.dart
@@ -125,6 +125,7 @@ void main() {
         'join': (m) => m.join(', '),
         'last': (m) => m.last,
         'lastWhere': (m) => m.lastWhere((i) => i == 2),
+        'inner': (m) => m.inner,
       }.forEach(runReadTest);
     });
 


### PR DESCRIPTION
## Describe the changes proposed in this Pull Request.

This PR adds one new method to each observable collection that exposes the inner collection while triggering a observation report.

I've found the need of having such a method while working on a project and neither `nonObservableInner` or `toList()` would be appropriate. `nonObservableInner` would not report an observation and `toList()` would create a new list which for my need is unnecessary and could lead to performance problems on larger lists.

I propose the creation of a `inner` getter that exposes the inner collection while reporting the read.

## If the PR fixes a specific issue, reference the issue with **`Fixes #`**.

This PR does not closes any issues that I'm aware of.

---
## Pull Request Checklist


- [x] If the changes are being made to code, ensure the **version in `pubspec.yaml`** is updated. 
- [x] Increment the **`major`/`minor`/`patch`/`patch-count`**, depending on the complexity of change
- [x] Add the necessary **unit tests** to ensure the coverage does not drop
- [ ] Update the **Changelog** to include all changes made in this PR, organized by version
- [x] Run the **`melos run set_version` command** from the root directory
- [ ] Include the **necessary reviewers** for the PR
- [ ] Update the **docs** if there are any API changes or additions to functionality
