### PR TITLE
Update codegen to use new Element2 API from analyzer >= 7.4.0

### DIFF
--- a/mobx_codegen/CHANGELOG.md
+++ b/mobx_codegen/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.7.2
+- Update analyzer version to `>=7.4.0 < 8.0.0`
+- Update source_gen version to 3.0.0
+- Update build version to 3.0.0
+- Update build_resolvers version to 3.0.0
+
 ## 2.7.1
 - Update source_gen package to 2.0.0
 - Update analyzer version to `>=6.9.0 < 8.0.0`

--- a/mobx_codegen/lib/src/mobx_codegen_base.dart
+++ b/mobx_codegen/lib/src/mobx_codegen_base.dart
@@ -3,7 +3,7 @@
 
 import 'dart:async';
 
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type_system.dart';
 import 'package:build/build.dart';
@@ -43,7 +43,7 @@ class StoreGenerator extends Generator {
 
   Iterable<String> _generateCodeForMixinStore(
     LibraryReader library,
-    ClassElement baseClass,
+    ClassElement2 baseClass,
     TypeSystem typeSystem,
   ) sync* {
     final typeNameFinder = LibraryScopedNameFinder(library.element);
@@ -52,7 +52,7 @@ class StoreGenerator extends Generator {
       final mixedClass = otherClasses.firstWhere((c) {
         // If our base class has different type parameterization requirements than
         // the class we're evaluating provides, we know it's not a subclass.
-        if (baseClass.typeParameters.length !=
+        if (baseClass.typeParameters2.length !=
             c.supertype!.typeArguments.length) {
           return false;
         }
@@ -68,7 +68,7 @@ class StoreGenerator extends Generator {
       });
 
       yield _generateCodeFromTemplate(
-          mixedClass.name, baseClass, MixinStoreTemplate(), typeNameFinder);
+          mixedClass.name3!, baseClass, MixinStoreTemplate(), typeNameFinder);
       // ignore: avoid_catching_errors
     } on StateError {
       // ignore the case when no element is found
@@ -77,15 +77,15 @@ class StoreGenerator extends Generator {
 
   String _generateCodeFromTemplate(
     String publicTypeName,
-    ClassElement userStoreClass,
+    ClassElement2 userStoreClass,
     StoreTemplate template,
     LibraryScopedNameFinder typeNameFinder,
   ) {
     final visitor = StoreClassVisitor(
         publicTypeName, userStoreClass, template, typeNameFinder, options);
     userStoreClass
-      ..accept(visitor)
-      ..visitChildren(visitor);
+      ..accept2(visitor)
+      ..visitChildren2(visitor);
     return visitor.source;
   }
 }

--- a/mobx_codegen/lib/src/template/method_override.dart
+++ b/mobx_codegen/lib/src/template/method_override.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:mobx_codegen/src/template/comma_list.dart';
 import 'package:mobx_codegen/src/template/params.dart';
 import 'package:mobx_codegen/src/template/util.dart';
@@ -10,31 +10,32 @@ class MethodOverrideTemplate {
 
   MethodOverrideTemplate.fromElement(
     // ignore: deprecated_member_use
-    ExecutableElement method,
+    ExecutableElement2 method,
     LibraryScopedNameFinder typeNameFinder,
   ) {
     // ignore: prefer_function_declarations_over_variables, deprecated_member_use
-    final param = (ParameterElement element) => ParamTemplate(
-        name: element.name,
+    final param = (FormalParameterElement element) => ParamTemplate(
+        name: element.name3!,
         type: typeNameFinder.findParameterTypeName(element),
         defaultValue: element.defaultValueCode,
         hasRequiredKeyword: element.isRequiredNamed);
 
-    final positionalParams = method.parameters
+    final positionalParams = method.formalParameters
         .where((param) => param.isPositional && !param.isOptionalPositional)
         .toList();
 
-    final optionalParams =
-        method.parameters.where((param) => param.isOptionalPositional).toList();
+    final optionalParams = method.formalParameters
+        .where((param) => param.isOptionalPositional)
+        .toList();
 
     final namedParams =
-        method.parameters.where((param) => param.isNamed).toList();
+        method.formalParameters.where((param) => param.isNamed).toList();
 
     this
-      ..name = method.name
+      ..name = method.name3!
       ..returnType = typeNameFinder.findReturnTypeName(method)
       // ignore: deprecated_member_use
-      ..setTypeParams(method.typeParameters
+      ..setTypeParams(method.typeParameters2
           .map((type) => typeParamTemplate(type, typeNameFinder)))
       ..positionalParams = positionalParams.map(param)
       ..optionalParams = optionalParams.map(param)

--- a/mobx_codegen/lib/src/template/observable.dart
+++ b/mobx_codegen/lib/src/template/observable.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:meta/meta.dart';
 import 'package:mobx_codegen/src/template/store.dart';
 import 'package:mobx_codegen/src/utils/non_private_name_extension.dart';
@@ -24,7 +24,7 @@ class ObservableTemplate {
   final bool isReadOnly;
   final bool isLate;
   // ignore: deprecated_member_use
-  final ExecutableElement? equals;
+  final ExecutableElement2? equals;
   final bool? useDeepEquality;
 
   /// Formats the `name` from `_foo_bar` to `foo_bar`
@@ -66,7 +66,7 @@ class ObservableTemplate {
     $atomName.reportWrite(value, _${name}IsInitialized ? super.$name : null, () {
       super.$name = value;
       _${name}IsInitialized = true;
-    }${equals != null ? ', equals: ${equals!.name}' : ''});
+    }${equals != null ? ', equals: ${equals!.name3}' : ''});
   }''';
     }
 
@@ -75,7 +75,7 @@ class ObservableTemplate {
   set $name($type value) {
     $atomName.reportWrite(value, super.$name, () {
       super.$name = value;
-    }${equals != null ? ', equals: ${equals!.name}' : ''}${useDeepEquality != null ? ', useDeepEquality: $useDeepEquality' : ''});
+    }${equals != null ? ', equals: ${equals!.name3}' : ''}${useDeepEquality != null ? ', useDeepEquality: $useDeepEquality' : ''});
   }''';
   }
 

--- a/mobx_codegen/lib/src/template/util.dart
+++ b/mobx_codegen/lib/src/template/util.dart
@@ -1,5 +1,4 @@
-
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:mobx_codegen/src/template/params.dart';
 import 'package:mobx_codegen/src/type_names.dart';
@@ -21,27 +20,27 @@ class AsyncMethodChecker {
   late TypeChecker _checkStream;
 
   // ignore: deprecated_member_use
-  bool returnsFuture(MethodElement method) =>
+  bool returnsFuture(MethodElement2 method) =>
       method.returnType.isDartAsyncFuture ||
-      (method.isAsynchronous &&
-          !method.isGenerator &&
+      (method.fragments.any((fragment) => fragment.isAsynchronous) &&
+          !method.fragments.any((fragment) => fragment.isGenerator) &&
           method.returnType is DynamicType);
 
   // ignore: deprecated_member_use
-  bool returnsStream(MethodElement method) =>
+  bool returnsStream(MethodElement2 method) =>
       _checkStream.isAssignableFromType(method.returnType) ||
-      (method.isAsynchronous &&
-          method.isGenerator &&
+      (method.fragments.any((fragment) => fragment.isAsynchronous) &&
+          method.fragments.any((fragment) => fragment.isGenerator) &&
           method.returnType is DynamicType);
 }
 
 TypeParamTemplate typeParamTemplate(
   // ignore: deprecated_member_use
-  TypeParameterElement param,
+  TypeParameterElement2 param,
   LibraryScopedNameFinder typeNameFinder,
 ) =>
     TypeParamTemplate(
-        name: param.name,
+        name: param.name3!,
         bound: param.bound != null
             ? typeNameFinder.findTypeParameterBoundsTypeName(param)
             : null);

--- a/mobx_codegen/lib/src/template/util.dart
+++ b/mobx_codegen/lib/src/template/util.dart
@@ -10,7 +10,7 @@ String surroundNonEmpty(String prefix, String suffix, dynamic content) {
   return contentStr.isEmpty ? '' : '$prefix$contentStr$suffix';
 }
 
-const _streamChecker = TypeChecker.fromRuntime(Stream);
+const _streamChecker = TypeChecker.typeNamed(Stream, inSdk: true);
 
 class AsyncMethodChecker {
   AsyncMethodChecker([TypeChecker? checkStream]) {

--- a/mobx_codegen/lib/src/type_names.dart
+++ b/mobx_codegen/lib/src/type_names.dart
@@ -1,7 +1,7 @@
 // https://github.com/dart-lang/sdk/blob/main/pkg/analyzer/doc/element_model_migration_guide.md
 // ignore_for_file: deprecated_member_use
 
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:mobx_codegen/src/template/comma_list.dart';
@@ -23,53 +23,63 @@ import 'package:mobx_codegen/src/template/comma_list.dart';
 class LibraryScopedNameFinder {
   LibraryScopedNameFinder(this.library);
 
-  final LibraryElement library;
+  final LibraryElement2 library;
 
-  final Map<Element, String?> _namesByElement = {};
+  final Map<Element2, String?> _namesByElement = {};
 
-  Map<Element, String?> get namesByElement {
+  Map<Element2, String?> get namesByElement {
     // Add all of this library's type-defining elements to the name map
-    final libraryElements =
-        library.topLevelElements.whereType<TypeDefiningElement>();
+    final libraryElements = library.children2.whereType<TypeDefiningElement2>();
     for (final element in libraryElements) {
-      _namesByElement[element] = element.name;
+      _namesByElement[element] = element.name3;
     }
 
     // Reverse each import's export namespace so we can map elements to their
-    // library-local names. Note that the definedNames include a prefix if there
-    // is one.
+    // library-local names.
+    //
+    // Prior to analyzer 7.4.0, definedNames included the import prefix, but it
+    // no longer does with the new element API. This means we need to construct
+    // it manually.
 
-    for (final import in library.definingCompilationUnit.libraryImports) {
-      for (final entry in import.namespace.definedNames.entries) {
-        _namesByElement[entry.value] = entry.key;
+    final libraryImports = library.fragments
+        .map((fragment) => fragment.libraryImports2)
+        .expand((t) => t);
+
+    for (final import in libraryImports) {
+      final prefix = import.prefix2;
+      for (final entry in import.namespace.definedNames2.entries) {
+        _namesByElement[entry.value] = prefix?.name2 != null
+            // If the prefix exists, we prepend it to the name
+            ? '${prefix!.name2!}.${entry.key}'
+            // Otherwise, we just use the name
+            : entry.key;
       }
     }
 
     return _namesByElement;
   }
 
-  String findVariableTypeName(VariableElement variable) =>
+  String findVariableTypeName(VariableElement2 variable) =>
       _getDartTypeName(variable.type);
 
-  String findGetterTypeName(PropertyAccessorElement getter) {
-    assert(getter.isGetter);
+  String findGetterTypeName(GetterElement getter) {
     return findReturnTypeName(getter);
   }
 
-  String findParameterTypeName(ParameterElement parameter) =>
+  String findParameterTypeName(FormalParameterElement parameter) =>
       _getDartTypeName(parameter.type);
 
-  String findReturnTypeName(FunctionTypedElement executable) =>
+  String findReturnTypeName(FunctionTypedElement2 executable) =>
       _getDartTypeName(executable.returnType);
 
-  List<String?> findReturnTypeArgumentTypeNames(ExecutableElement executable) {
+  List<String?> findReturnTypeArgumentTypeNames(ExecutableElement2 executable) {
     final returnType = executable.returnType;
     return returnType is ParameterizedType
         ? returnType.typeArguments.map(_getDartTypeName).toList()
         : [];
   }
 
-  String? findTypeParameterBoundsTypeName(TypeParameterElement typeParameter) {
+  String? findTypeParameterBoundsTypeName(TypeParameterElement2 typeParameter) {
     assert(typeParameter.bound != null);
     return _getDartTypeName(typeParameter.bound!);
   }
@@ -78,12 +88,12 @@ class LibraryScopedNameFinder {
   ///
   /// The returned string will include import prefixes on all applicable types.
   String _getDartTypeName(DartType type) {
-    var typeElement = type.element;
+    var typeElement = type.element3;
     if (type is FunctionType) {
       // If we're dealing with a typedef, we let it undergo the standard name
       // lookup. Otherwise, we special case the function naming.
-      if (type.alias?.element is TypeAliasElement) {
-        typeElement = type.alias!.element.aliasedElement?.enclosingElement3;
+      if (type.alias?.element2 is TypeAliasElement2) {
+        typeElement = type.alias!.element2;
       } else {
         return _getFunctionTypeName(type);
       }
@@ -95,7 +105,7 @@ class LibraryScopedNameFinder {
       return type.getDisplayString(withNullability: true);
     }
 
-    return _getNamedElementTypeName(typeElement!, type);
+    return _getNamedElementTypeName(typeElement, type);
   }
 
   String _getFunctionTypeName(FunctionType type) {
@@ -120,7 +130,7 @@ class LibraryScopedNameFinder {
     return '$returnTypeName Function($parameterTypeNames)';
   }
 
-  String _getNamedElementTypeName(Element typeElement, DartType type) {
+  String _getNamedElementTypeName(Element2 typeElement, DartType type) {
     // Determine the name of the type, without type arguments.
     assert(namesByElement.containsKey(typeElement));
 

--- a/mobx_codegen/lib/version.dart
+++ b/mobx_codegen/lib/version.dart
@@ -1,4 +1,4 @@
 // Generated via set_version.dart. !!!DO NOT MODIFY BY HAND!!!
 
 /// The current version as per `pubspec.yaml`.
-const version = '2.7.1';
+const version = '2.7.2';

--- a/mobx_codegen/pubspec.yaml
+++ b/mobx_codegen/pubspec.yaml
@@ -14,17 +14,17 @@ environment:
   sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
-  analyzer: '>=6.9.0 <8.0.0'
-  build: ^2.2.1
-  build_resolvers: ^2.0.6
+  analyzer: '>=7.4.0 <8.0.0'
+  build: ^3.0.0
+  build_resolvers: ^3.0.0
   meta: ^1.3.0
   mobx: ^2.5.0
   path: ^1.8.0
-  source_gen: '>=1.2.1 <3.0.0'
+  source_gen: ^3.0.0
 
 dev_dependencies:
-  build_runner: ^2.4.9
-  build_test: ^2.1.5
+  build_runner: ^2.6.0
+  build_test: ^3.3.0
   coverage: ^1.8.0
   lints: ^5.0.0
   logging: ^1.0.2

--- a/mobx_codegen/pubspec.yaml
+++ b/mobx_codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobx_codegen
 description: Code generator for MobX that adds support for annotating your code with @observable, @computed, @action and also creating Store classes.
-version: 2.7.1
+version: 2.7.2
 
 repository: https://github.com/mobxjs/mobx.dart
 issue_tracker: https://github.com/mobxjs/mobx.dart/issues

--- a/mobx_codegen/test/data/invalid_action_multiple_output.txt
+++ b/mobx_codegen/test/data/invalid_action_multiple_output.txt
@@ -1,2 +1,2 @@
 Could not make class "Test" observable. Changes needed:
-  1. Remove @action annotation for members "lastName" and "firstName". They only apply to methods.
+  1. Remove @action annotation for members "firstName" and "lastName". They only apply to methods.

--- a/mobx_codegen/test/store_class_visitor_test.dart
+++ b/mobx_codegen/test/store_class_visitor_test.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:build/build.dart';
 import 'package:mobx_codegen/src/store_class_visitor.dart';
 import 'package:mobx_codegen/src/template/observable.dart';
@@ -9,7 +9,8 @@ import 'package:test/test.dart';
 
 class PropertyAccessorElementMock extends Fake
     // ignore: deprecated_member_use
-    implements PropertyAccessorElement {
+    implements
+        PropertyAccessorElement2 {
   PropertyAccessorElementMock(this._displayName);
 
   final String _displayName;
@@ -19,17 +20,17 @@ class PropertyAccessorElementMock extends Fake
 }
 
 // ignore: deprecated_member_use
-class ClassElementMock extends Fake implements ClassElement {
+class ClassElementMock extends Fake implements ClassElement2 {
   ClassElementMock(this._name);
 
   final String _name;
 
   @override
-  String get name => _name;
+  String get name3 => _name;
 
   @override
   // ignore: deprecated_member_use
-  List<TypeParameterElement> get typeParameters => [];
+  List<TypeParameterElement2> get typeParameters2 => [];
 }
 
 class StoreTemplateFake extends StoreTemplate {}

--- a/mobx_codegen/test/util_test.dart
+++ b/mobx_codegen/test/util_test.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:mobx_codegen/src/template/util.dart';
 import 'package:mobx_codegen/src/utils/non_private_name_extension.dart';
@@ -9,7 +9,9 @@ import 'package:test/test.dart';
 class MockTypeChecker extends Mock implements TypeChecker {}
 
 // ignore: deprecated_member_use
-class MockMethod extends Mock implements MethodElement {}
+class MockMethod extends Mock implements MethodElement2 {}
+
+class MockMethodFragment extends Mock implements MethodFragment {}
 
 class MockType extends Mock implements DartType {}
 
@@ -31,10 +33,14 @@ MockMethod mockFutureMethod({
   when(() => returnType.isDartAsyncFuture).thenReturn(returnsFuture);
   when(() => returnType.isDartAsyncFutureOr).thenReturn(returnsFutureOr);
 
+  final methodFragment = MockMethodFragment();
+  when(() => methodFragment.isGenerator).thenReturn(isGenerator);
+  when(() => methodFragment.isAsynchronous).thenReturn(isAsync);
+
   final method = MockMethod();
   when(() => method.returnType).thenReturn(returnType);
-  when(() => method.isAsynchronous).thenReturn(isAsync);
-  when(() => method.isGenerator).thenReturn(isGenerator);
+  when(() => method.fragments).thenReturn([methodFragment]);
+
   return method;
 }
 
@@ -50,10 +56,14 @@ MockMethod mockStreamMethod({
     returnType = MockType();
   }
 
+  final mockMethodFragment = MockMethodFragment();
+  when(() => mockMethodFragment.isGenerator).thenReturn(isGenerator);
+  when(() => mockMethodFragment.isAsynchronous).thenReturn(isAsync);
+
   final method = MockMethod();
   when(() => method.returnType).thenReturn(returnType);
-  when(() => method.isAsynchronous).thenReturn(isAsync);
-  when(() => method.isGenerator).thenReturn(isGenerator);
+  when(() => method.fragments).thenReturn([mockMethodFragment]);
+
   return method;
 }
 


### PR DESCRIPTION
This PR updates `mobx_codegen` to support the latest `build` and `analyzer` packages, including:
- `analyzer: 7.7.0`
- `build: 3.0.0`
- `source_gen: 3.0.0`
- `build_test: 3.3.0`

For downstream consumers with custom codegen, the version bump will allow them to migrate their own code generators away from the recently deprecated element API in `package:analyzer`. I've also done the conversion for this package, so the cut-over to analyzer 8.0.0 (which fully removes the deprecated API) should be trivial.

Note that while analyzer 8.0.0 has been released, the latest `source_gen` does not yet support it, so this is the latest analyzer version we can upgrade to.

Fixes #1049, fixes #1039.

---
## Pull Request Checklist


- [x] If the changes are being made to code, ensure the **version in `pubspec.yaml`** is updated. 
- [x] Increment the **`major`/`minor`/`patch`/`patch-count`**, depending on the complexity of change
- [x] Add the necessary **unit tests** to ensure the coverage does not drop
- [x] Update the **Changelog** to include all changes made in this PR, organized by version
- [x] Run the **`melos run set_version` command** from the root directory
- [x] Include the **necessary reviewers** for the PR
- [x] Update the **docs** if there are any API changes or additions to functionality
