### PR TITLE
Update analyzer to >=7.4.0 <9.0.0 and bump related packages

### DIFF
--- a/mobx_codegen/CHANGELOG.md
+++ b/mobx_codegen/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 2.7.2
+- Update analyzer version to 8.1.1
+- Update source_gen version to 4.0.1
+- Update build version to 4.0.0
+
+## 2.7.2
 - Update analyzer version to `>=7.4.0 < 8.0.0`
 - Update source_gen version to 3.0.0
 - Update build version to 3.0.0

--- a/mobx_codegen/CHANGELOG.md
+++ b/mobx_codegen/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 2.7.3
-- Update analyzer version to 8.1.1
-- Update source_gen version to 4.0.1
-- Update build version to 4.0.0
+- Update analyzer version to `>=7.4.0 < 9.0.0`
+- Update source_gen version to `>=3.0.0 < 5.0.0`
+- Update build version to `>=3.0.0 < 5.0.0`
+- Update build_resolvers version to `>=3.0.0 < 5.0.0`
 
 ## 2.7.2
 - Update analyzer version to `>=7.4.0 < 8.0.0`

--- a/mobx_codegen/CHANGELOG.md
+++ b/mobx_codegen/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.7.2
+## 2.7.3
 - Update analyzer version to 8.1.1
 - Update source_gen version to 4.0.1
 - Update build version to 4.0.0

--- a/mobx_codegen/lib/src/mobx_codegen_base.dart
+++ b/mobx_codegen/lib/src/mobx_codegen_base.dart
@@ -1,8 +1,10 @@
 // https://github.com/dart-lang/sdk/blob/main/pkg/analyzer/doc/element_model_migration_guide.md
 
+// ignore_for_file: deprecated_member_use
+
 import 'dart:async';
 
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type_system.dart';
 import 'package:build/build.dart';
@@ -42,7 +44,7 @@ class StoreGenerator extends Generator {
 
   Iterable<String> _generateCodeForMixinStore(
     LibraryReader library,
-    ClassElement baseClass,
+    ClassElement2 baseClass,
     TypeSystem typeSystem,
   ) sync* {
     final typeNameFinder = LibraryScopedNameFinder(library.element);
@@ -51,7 +53,7 @@ class StoreGenerator extends Generator {
       final mixedClass = otherClasses.firstWhere((c) {
         // If our base class has different type parameterization requirements than
         // the class we're evaluating provides, we know it's not a subclass.
-        if (baseClass.typeParameters.length !=
+        if (baseClass.typeParameters2.length !=
             c.supertype!.typeArguments.length) {
           return false;
         }
@@ -67,7 +69,7 @@ class StoreGenerator extends Generator {
       });
 
       yield _generateCodeFromTemplate(
-          mixedClass.name!, baseClass, MixinStoreTemplate(), typeNameFinder);
+          mixedClass.name3!, baseClass, MixinStoreTemplate(), typeNameFinder);
       // ignore: avoid_catching_errors
     } on StateError {
       // ignore the case when no element is found
@@ -76,15 +78,15 @@ class StoreGenerator extends Generator {
 
   String _generateCodeFromTemplate(
     String publicTypeName,
-    ClassElement userStoreClass,
+    ClassElement2 userStoreClass,
     StoreTemplate template,
     LibraryScopedNameFinder typeNameFinder,
   ) {
     final visitor = StoreClassVisitor(
         publicTypeName, userStoreClass, template, typeNameFinder, options);
     userStoreClass
-      ..accept(visitor)
-      ..visitChildren(visitor);
+      ..accept2(visitor)
+      ..visitChildren2(visitor);
     return visitor.source;
   }
 }

--- a/mobx_codegen/lib/src/mobx_codegen_base.dart
+++ b/mobx_codegen/lib/src/mobx_codegen_base.dart
@@ -1,9 +1,8 @@
 // https://github.com/dart-lang/sdk/blob/main/pkg/analyzer/doc/element_model_migration_guide.md
-// ignore_for_file: deprecated_member_use
 
 import 'dart:async';
 
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type_system.dart';
 import 'package:build/build.dart';
@@ -43,7 +42,7 @@ class StoreGenerator extends Generator {
 
   Iterable<String> _generateCodeForMixinStore(
     LibraryReader library,
-    ClassElement2 baseClass,
+    ClassElement baseClass,
     TypeSystem typeSystem,
   ) sync* {
     final typeNameFinder = LibraryScopedNameFinder(library.element);
@@ -52,7 +51,7 @@ class StoreGenerator extends Generator {
       final mixedClass = otherClasses.firstWhere((c) {
         // If our base class has different type parameterization requirements than
         // the class we're evaluating provides, we know it's not a subclass.
-        if (baseClass.typeParameters2.length !=
+        if (baseClass.typeParameters.length !=
             c.supertype!.typeArguments.length) {
           return false;
         }
@@ -68,7 +67,7 @@ class StoreGenerator extends Generator {
       });
 
       yield _generateCodeFromTemplate(
-          mixedClass.name3!, baseClass, MixinStoreTemplate(), typeNameFinder);
+          mixedClass.name!, baseClass, MixinStoreTemplate(), typeNameFinder);
       // ignore: avoid_catching_errors
     } on StateError {
       // ignore the case when no element is found
@@ -77,15 +76,15 @@ class StoreGenerator extends Generator {
 
   String _generateCodeFromTemplate(
     String publicTypeName,
-    ClassElement2 userStoreClass,
+    ClassElement userStoreClass,
     StoreTemplate template,
     LibraryScopedNameFinder typeNameFinder,
   ) {
     final visitor = StoreClassVisitor(
         publicTypeName, userStoreClass, template, typeNameFinder, options);
     userStoreClass
-      ..accept2(visitor)
-      ..visitChildren2(visitor);
+      ..accept(visitor)
+      ..visitChildren(visitor);
     return visitor.source;
   }
 }

--- a/mobx_codegen/lib/src/store_class_visitor.dart
+++ b/mobx_codegen/lib/src/store_class_visitor.dart
@@ -1,7 +1,6 @@
 // https://github.com/dart-lang/sdk/blob/main/pkg/analyzer/doc/element_model_migration_guide.md
-// ignore_for_file: deprecated_member_use
 
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/visitor2.dart';
 import 'package:build/build.dart';
 import 'package:meta/meta.dart';
@@ -26,25 +25,28 @@ import 'package:source_gen/source_gen.dart';
 class StoreClassVisitor extends SimpleElementVisitor2 {
   StoreClassVisitor(
     String publicTypeName,
-    ClassElement2 userClass,
+    ClassElement userClass,
     StoreTemplate template,
     this.typeNameFinder,
     this.options,
   ) : errors = StoreClassCodegenErrors(publicTypeName) {
     _storeTemplate = template
-      ..typeParams.templates.addAll(userClass.typeParameters2
+      ..typeParams.templates.addAll(userClass.typeParameters
           .map((type) => typeParamTemplate(type, typeNameFinder)))
       ..typeArgs.templates.addAll(
-          userClass.typeParameters2.map((t) => t.name3).whereType<String>())
-      ..parentTypeName = userClass.name3!
+          userClass.typeParameters.map((t) => t.name).whereType<String>())
+      ..parentTypeName = userClass.name!
       ..publicTypeName = publicTypeName;
   }
 
-  final _observableChecker = const TypeChecker.fromRuntime(MakeObservable);
+  final _observableChecker =
+      const TypeChecker.typeNamed(MakeObservable, inPackage: 'mobx');
 
-  final _computedChecker = const TypeChecker.fromRuntime(ComputedMethod);
+  final _computedChecker =
+      const TypeChecker.typeNamed(ComputedMethod, inPackage: 'mobx');
 
-  final _actionChecker = const TypeChecker.fromRuntime(MakeAction);
+  final _actionChecker =
+      const TypeChecker.typeNamed(MakeAction, inPackage: 'mobx');
 
   final _asyncChecker = AsyncMethodChecker();
 
@@ -57,7 +59,7 @@ class StoreClassVisitor extends SimpleElementVisitor2 {
   final StoreClassCodegenErrors errors;
 
   @visibleForTesting
-  final publicSettersCache = <PropertyAccessorElement2>[];
+  final publicSettersCache = <PropertyAccessorElement>[];
 
   String get source {
     validate();
@@ -69,24 +71,24 @@ class StoreClassVisitor extends SimpleElementVisitor2 {
   }
 
   @override
-  void visitClassElement(ClassElement2 element) {
+  void visitClassElement(ClassElement element) {
     if (isMixinStoreClass(element)) {
       errors.nonAbstractStoreMixinDeclarations
-          .addIf(!element.isAbstract, element.name3!);
+          .addIf(!element.isAbstract, element.name!);
     }
     // if the class is annotated to generate toString() method we add the information to the _storeTemplate
     _storeTemplate.generateToString = hasGeneratedToString(options, element);
   }
 
   @override
-  void visitFieldElement(FieldElement2 element) {
+  void visitFieldElement(FieldElement element) {
     if (_computedChecker.hasAnnotationOfExact(element)) {
-      errors.invalidComputedAnnotations.addIf(true, element.name3!);
+      errors.invalidComputedAnnotations.addIf(true, element.name!);
       return;
     }
 
     if (_actionChecker.hasAnnotationOfExact(element)) {
-      errors.invalidActionAnnotations.addIf(true, element.name3!);
+      errors.invalidActionAnnotations.addIf(true, element.name!);
       return;
     }
 
@@ -100,9 +102,9 @@ class StoreClassVisitor extends SimpleElementVisitor2 {
 
     final template = ObservableTemplate(
       storeTemplate: _storeTemplate,
-      atomName: '_\$${element.name3}Atom',
+      atomName: '_\$${element.name}Atom',
       type: typeNameFinder.findVariableTypeName(element),
-      name: element.name3!,
+      name: element.name!,
       isPrivate: element.isPrivate,
       isReadOnly: _isObservableReadOnly(element),
       isLate: element.isLate,
@@ -113,28 +115,28 @@ class StoreClassVisitor extends SimpleElementVisitor2 {
     return;
   }
 
-  bool _isObservableReadOnly(FieldElement2 element) =>
+  bool _isObservableReadOnly(FieldElement element) =>
       _observableChecker
           .firstAnnotationOfExact(element)
           ?.getField('readOnly')
           ?.toBoolValue() ??
       false;
 
-  ExecutableElement2? _getEquals(FieldElement2 element) => _observableChecker
+  ExecutableElement? _getEquals(FieldElement element) => _observableChecker
       .firstAnnotationOfExact(element)
       ?.getField('equals')
-      ?.toFunctionValue2();
+      ?.toFunctionValue();
 
-  bool _fieldIsNotValid(FieldElement2 element) => _any([
-        errors.staticObservables.addIf(element.isStatic, element.name3!),
-        errors.finalObservables.addIf(element.isFinal, element.name3!),
+  bool _fieldIsNotValid(FieldElement element) => _any([
+        errors.staticObservables.addIf(element.isStatic, element.name!),
+        errors.finalObservables.addIf(element.isFinal, element.name!),
         errors.invalidReadOnlyAnnotations.addIf(
-          _isObservableReadOnly(element) && element.setter2!.isPublic,
-          element.name3!,
+          _isObservableReadOnly(element) && element.setter!.isPublic,
+          element.name!,
         ),
       ]);
 
-  bool? _isComputedKeepAlive(Element2 element) => _computedChecker
+  bool? _isComputedKeepAlive(Element element) => _computedChecker
       .firstAnnotationOfExact(element)
       ?.getField('keepAlive')
       ?.toBoolValue();
@@ -147,18 +149,18 @@ class StoreClassVisitor extends SimpleElementVisitor2 {
   void visitSetterElement(SetterElement element) =>
       visitPropertyAccessorElement(element);
 
-  void visitPropertyAccessorElement(PropertyAccessorElement2 element) {
+  void visitPropertyAccessorElement(PropertyAccessorElement element) {
     if (element is SetterElement && element.isPublic) {
       publicSettersCache.add(element);
     }
 
     if (_observableChecker.hasAnnotationOfExact(element)) {
-      errors.invalidObservableAnnotations.addIf(true, element.name3!);
+      errors.invalidObservableAnnotations.addIf(true, element.name!);
       return;
     }
 
     if (_actionChecker.hasAnnotationOfExact(element)) {
-      errors.invalidActionAnnotations.addIf(true, element.name3!);
+      errors.invalidActionAnnotations.addIf(true, element.name!);
       return;
     }
 
@@ -168,9 +170,9 @@ class StoreClassVisitor extends SimpleElementVisitor2 {
     }
 
     final template = ComputedTemplate(
-        computedName: '_\$${element.name3}Computed',
+        computedName: '_\$${element.name}Computed',
         storeTemplate: _storeTemplate,
-        name: element.name3!,
+        name: element.name!,
         type: typeNameFinder.findGetterTypeName(element),
         isPrivate: element.isPrivate,
         isKeepAlive: _isComputedKeepAlive(element));
@@ -180,9 +182,9 @@ class StoreClassVisitor extends SimpleElementVisitor2 {
   }
 
   @override
-  void visitMethodElement(MethodElement2 element) {
+  void visitMethodElement(MethodElement element) {
     if (_computedChecker.hasAnnotationOfExact(element)) {
-      errors.invalidComputedAnnotations.addIf(true, element.name3!);
+      errors.invalidComputedAnnotations.addIf(true, element.name!);
       return;
     }
 
@@ -196,9 +198,9 @@ class StoreClassVisitor extends SimpleElementVisitor2 {
           storeTemplate: _storeTemplate,
           isObservable: _observableChecker.hasAnnotationOfExact(element),
           method: MethodOverrideTemplate.fromElement(element, typeNameFinder),
-          hasProtected: element.metadata2.hasProtected,
-          hasVisibleForOverriding: element.metadata2.hasVisibleForOverriding,
-          hasVisibleForTesting: element.metadata2.hasVisibleForTesting,
+          hasProtected: element.metadata.hasProtected,
+          hasVisibleForOverriding: element.metadata.hasVisibleForOverriding,
+          hasVisibleForTesting: element.metadata.hasVisibleForTesting,
         );
 
         _storeTemplate.asyncActions.add(template);
@@ -206,9 +208,9 @@ class StoreClassVisitor extends SimpleElementVisitor2 {
         final template = ActionTemplate(
           storeTemplate: _storeTemplate,
           method: MethodOverrideTemplate.fromElement(element, typeNameFinder),
-          hasProtected: element.metadata2.hasProtected,
-          hasVisibleForOverriding: element.metadata2.hasVisibleForOverriding,
-          hasVisibleForTesting: element.metadata2.hasVisibleForTesting,
+          hasProtected: element.metadata.hasProtected,
+          hasVisibleForOverriding: element.metadata.hasVisibleForOverriding,
+          hasVisibleForTesting: element.metadata.hasVisibleForTesting,
         );
 
         _storeTemplate.actions.add(template);
@@ -221,18 +223,18 @@ class StoreClassVisitor extends SimpleElementVisitor2 {
       if (_asyncChecker.returnsFuture(element)) {
         final template = ObservableFutureTemplate(
           method: MethodOverrideTemplate.fromElement(element, typeNameFinder),
-          hasProtected: element.metadata2.hasProtected,
-          hasVisibleForOverriding: element.metadata2.hasVisibleForOverriding,
-          hasVisibleForTesting: element.metadata2.hasVisibleForTesting,
+          hasProtected: element.metadata.hasProtected,
+          hasVisibleForOverriding: element.metadata.hasVisibleForOverriding,
+          hasVisibleForTesting: element.metadata.hasVisibleForTesting,
         );
 
         _storeTemplate.observableFutures.add(template);
       } else if (_asyncChecker.returnsStream(element)) {
         final template = ObservableStreamTemplate(
           method: MethodOverrideTemplate.fromElement(element, typeNameFinder),
-          hasProtected: element.metadata2.hasProtected,
-          hasVisibleForOverriding: element.metadata2.hasVisibleForOverriding,
-          hasVisibleForTesting: element.metadata2.hasVisibleForTesting,
+          hasProtected: element.metadata.hasProtected,
+          hasVisibleForOverriding: element.metadata.hasVisibleForOverriding,
+          hasVisibleForTesting: element.metadata.hasVisibleForTesting,
         );
 
         _storeTemplate.observableStreams.add(template);
@@ -242,20 +244,20 @@ class StoreClassVisitor extends SimpleElementVisitor2 {
     return;
   }
 
-  bool _asyncObservableIsNotValid(MethodElement2 method) => _any([
-        errors.staticMethods.addIf(method.isStatic, method.name3!),
+  bool _asyncObservableIsNotValid(MethodElement method) => _any([
+        errors.staticMethods.addIf(method.isStatic, method.name!),
         errors.nonAsyncMethods.addIf(
             !_asyncChecker.returnsFuture(method) &&
                 !_asyncChecker.returnsStream(method),
-            method.name3!),
+            method.name!),
       ]);
 
-  bool _actionIsNotValid(MethodElement2 element) => _any([
-        errors.staticMethods.addIf(element.isStatic, element.name3!),
+  bool _actionIsNotValid(MethodElement element) => _any([
+        errors.staticMethods.addIf(element.isStatic, element.name!),
         errors.asyncGeneratorActions.addIf(
           element.fragments.any((fragment) => fragment.isAsynchronous) &&
               element.fragments.any((fragment) => fragment.isGenerator),
-          element.name3!,
+          element.name!,
         ),
       ]);
 
@@ -270,7 +272,7 @@ class StoreClassVisitor extends SimpleElementVisitor2 {
   }
 
   bool _isInvalidPublicSetterOnReadOnlyObservable(
-          PropertyAccessorElement2 publicSetter) =>
+          PropertyAccessorElement publicSetter) =>
       _storeTemplate.observables.templates.any(
         (template) =>
             template.name.nonPrivateName == publicSetter.displayName &&
@@ -278,17 +280,18 @@ class StoreClassVisitor extends SimpleElementVisitor2 {
       );
 }
 
-const _storeMixinChecker = TypeChecker.fromRuntime(Store);
-const _toStringAnnotationChecker = TypeChecker.fromRuntime(StoreConfig);
+const _storeMixinChecker = TypeChecker.typeNamed(Store, inPackage: 'mobx');
+const _toStringAnnotationChecker =
+    TypeChecker.typeNamed(StoreConfig, inPackage: 'mobx');
 
-bool isMixinStoreClass(ClassElement2 classElement) =>
+bool isMixinStoreClass(ClassElement classElement) =>
     classElement.mixins.any(_storeMixinChecker.isExactlyType);
 
 // Checks if the class as a toString annotation
-bool isStoreConfigAnnotatedStoreClass(ClassElement2 classElement) =>
+bool isStoreConfigAnnotatedStoreClass(ClassElement classElement) =>
     _toStringAnnotationChecker.hasAnnotationOfExact(classElement);
 
-bool hasGeneratedToString(BuilderOptions options, ClassElement2? classElement) {
+bool hasGeneratedToString(BuilderOptions options, ClassElement? classElement) {
   const fieldKey = 'hasToString';
 
   if (classElement != null && isStoreConfigAnnotatedStoreClass(classElement)) {

--- a/mobx_codegen/lib/src/store_class_visitor.dart
+++ b/mobx_codegen/lib/src/store_class_visitor.dart
@@ -1,6 +1,8 @@
 // https://github.com/dart-lang/sdk/blob/main/pkg/analyzer/doc/element_model_migration_guide.md
 
-import 'package:analyzer/dart/element/element.dart';
+// ignore_for_file: deprecated_member_use
+
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/visitor2.dart';
 import 'package:build/build.dart';
 import 'package:meta/meta.dart';
@@ -25,17 +27,17 @@ import 'package:source_gen/source_gen.dart';
 class StoreClassVisitor extends SimpleElementVisitor2 {
   StoreClassVisitor(
     String publicTypeName,
-    ClassElement userClass,
+    ClassElement2 userClass,
     StoreTemplate template,
     this.typeNameFinder,
     this.options,
   ) : errors = StoreClassCodegenErrors(publicTypeName) {
     _storeTemplate = template
-      ..typeParams.templates.addAll(userClass.typeParameters
+      ..typeParams.templates.addAll(userClass.typeParameters2
           .map((type) => typeParamTemplate(type, typeNameFinder)))
       ..typeArgs.templates.addAll(
-          userClass.typeParameters.map((t) => t.name).whereType<String>())
-      ..parentTypeName = userClass.name!
+          userClass.typeParameters2.map((t) => t.name3).whereType<String>())
+      ..parentTypeName = userClass.name3!
       ..publicTypeName = publicTypeName;
   }
 
@@ -59,7 +61,7 @@ class StoreClassVisitor extends SimpleElementVisitor2 {
   final StoreClassCodegenErrors errors;
 
   @visibleForTesting
-  final publicSettersCache = <PropertyAccessorElement>[];
+  final publicSettersCache = <PropertyAccessorElement2>[];
 
   String get source {
     validate();
@@ -71,24 +73,24 @@ class StoreClassVisitor extends SimpleElementVisitor2 {
   }
 
   @override
-  void visitClassElement(ClassElement element) {
+  void visitClassElement(ClassElement2 element) {
     if (isMixinStoreClass(element)) {
       errors.nonAbstractStoreMixinDeclarations
-          .addIf(!element.isAbstract, element.name!);
+          .addIf(!element.isAbstract, element.name3!);
     }
     // if the class is annotated to generate toString() method we add the information to the _storeTemplate
     _storeTemplate.generateToString = hasGeneratedToString(options, element);
   }
 
   @override
-  void visitFieldElement(FieldElement element) {
+  void visitFieldElement(FieldElement2 element) {
     if (_computedChecker.hasAnnotationOfExact(element)) {
-      errors.invalidComputedAnnotations.addIf(true, element.name!);
+      errors.invalidComputedAnnotations.addIf(true, element.name3!);
       return;
     }
 
     if (_actionChecker.hasAnnotationOfExact(element)) {
-      errors.invalidActionAnnotations.addIf(true, element.name!);
+      errors.invalidActionAnnotations.addIf(true, element.name3!);
       return;
     }
 
@@ -102,9 +104,9 @@ class StoreClassVisitor extends SimpleElementVisitor2 {
 
     final template = ObservableTemplate(
       storeTemplate: _storeTemplate,
-      atomName: '_\$${element.name}Atom',
+      atomName: '_\$${element.name3}Atom',
       type: typeNameFinder.findVariableTypeName(element),
-      name: element.name!,
+      name: element.name3!,
       isPrivate: element.isPrivate,
       isReadOnly: _isObservableReadOnly(element),
       isLate: element.isLate,
@@ -115,28 +117,28 @@ class StoreClassVisitor extends SimpleElementVisitor2 {
     return;
   }
 
-  bool _isObservableReadOnly(FieldElement element) =>
+  bool _isObservableReadOnly(FieldElement2 element) =>
       _observableChecker
           .firstAnnotationOfExact(element)
           ?.getField('readOnly')
           ?.toBoolValue() ??
       false;
 
-  ExecutableElement? _getEquals(FieldElement element) => _observableChecker
+  ExecutableElement2? _getEquals(FieldElement2 element) => _observableChecker
       .firstAnnotationOfExact(element)
       ?.getField('equals')
-      ?.toFunctionValue();
+      ?.toFunctionValue2();
 
-  bool _fieldIsNotValid(FieldElement element) => _any([
-        errors.staticObservables.addIf(element.isStatic, element.name!),
-        errors.finalObservables.addIf(element.isFinal, element.name!),
+  bool _fieldIsNotValid(FieldElement2 element) => _any([
+        errors.staticObservables.addIf(element.isStatic, element.name3!),
+        errors.finalObservables.addIf(element.isFinal, element.name3!),
         errors.invalidReadOnlyAnnotations.addIf(
-          _isObservableReadOnly(element) && element.setter!.isPublic,
-          element.name!,
+          _isObservableReadOnly(element) && element.setter2!.isPublic,
+          element.name3!,
         ),
       ]);
 
-  bool? _isComputedKeepAlive(Element element) => _computedChecker
+  bool? _isComputedKeepAlive(Element2 element) => _computedChecker
       .firstAnnotationOfExact(element)
       ?.getField('keepAlive')
       ?.toBoolValue();
@@ -149,18 +151,18 @@ class StoreClassVisitor extends SimpleElementVisitor2 {
   void visitSetterElement(SetterElement element) =>
       visitPropertyAccessorElement(element);
 
-  void visitPropertyAccessorElement(PropertyAccessorElement element) {
+  void visitPropertyAccessorElement(PropertyAccessorElement2 element) {
     if (element is SetterElement && element.isPublic) {
       publicSettersCache.add(element);
     }
 
     if (_observableChecker.hasAnnotationOfExact(element)) {
-      errors.invalidObservableAnnotations.addIf(true, element.name!);
+      errors.invalidObservableAnnotations.addIf(true, element.name3!);
       return;
     }
 
     if (_actionChecker.hasAnnotationOfExact(element)) {
-      errors.invalidActionAnnotations.addIf(true, element.name!);
+      errors.invalidActionAnnotations.addIf(true, element.name3!);
       return;
     }
 
@@ -170,9 +172,9 @@ class StoreClassVisitor extends SimpleElementVisitor2 {
     }
 
     final template = ComputedTemplate(
-        computedName: '_\$${element.name}Computed',
+        computedName: '_\$${element.name3}Computed',
         storeTemplate: _storeTemplate,
-        name: element.name!,
+        name: element.name3!,
         type: typeNameFinder.findGetterTypeName(element),
         isPrivate: element.isPrivate,
         isKeepAlive: _isComputedKeepAlive(element));
@@ -182,9 +184,9 @@ class StoreClassVisitor extends SimpleElementVisitor2 {
   }
 
   @override
-  void visitMethodElement(MethodElement element) {
+  void visitMethodElement(MethodElement2 element) {
     if (_computedChecker.hasAnnotationOfExact(element)) {
-      errors.invalidComputedAnnotations.addIf(true, element.name!);
+      errors.invalidComputedAnnotations.addIf(true, element.name3!);
       return;
     }
 
@@ -198,9 +200,9 @@ class StoreClassVisitor extends SimpleElementVisitor2 {
           storeTemplate: _storeTemplate,
           isObservable: _observableChecker.hasAnnotationOfExact(element),
           method: MethodOverrideTemplate.fromElement(element, typeNameFinder),
-          hasProtected: element.metadata.hasProtected,
-          hasVisibleForOverriding: element.metadata.hasVisibleForOverriding,
-          hasVisibleForTesting: element.metadata.hasVisibleForTesting,
+          hasProtected: element.metadata2.hasProtected,
+          hasVisibleForOverriding: element.metadata2.hasVisibleForOverriding,
+          hasVisibleForTesting: element.metadata2.hasVisibleForTesting,
         );
 
         _storeTemplate.asyncActions.add(template);
@@ -208,9 +210,9 @@ class StoreClassVisitor extends SimpleElementVisitor2 {
         final template = ActionTemplate(
           storeTemplate: _storeTemplate,
           method: MethodOverrideTemplate.fromElement(element, typeNameFinder),
-          hasProtected: element.metadata.hasProtected,
-          hasVisibleForOverriding: element.metadata.hasVisibleForOverriding,
-          hasVisibleForTesting: element.metadata.hasVisibleForTesting,
+          hasProtected: element.metadata2.hasProtected,
+          hasVisibleForOverriding: element.metadata2.hasVisibleForOverriding,
+          hasVisibleForTesting: element.metadata2.hasVisibleForTesting,
         );
 
         _storeTemplate.actions.add(template);
@@ -223,18 +225,18 @@ class StoreClassVisitor extends SimpleElementVisitor2 {
       if (_asyncChecker.returnsFuture(element)) {
         final template = ObservableFutureTemplate(
           method: MethodOverrideTemplate.fromElement(element, typeNameFinder),
-          hasProtected: element.metadata.hasProtected,
-          hasVisibleForOverriding: element.metadata.hasVisibleForOverriding,
-          hasVisibleForTesting: element.metadata.hasVisibleForTesting,
+          hasProtected: element.metadata2.hasProtected,
+          hasVisibleForOverriding: element.metadata2.hasVisibleForOverriding,
+          hasVisibleForTesting: element.metadata2.hasVisibleForTesting,
         );
 
         _storeTemplate.observableFutures.add(template);
       } else if (_asyncChecker.returnsStream(element)) {
         final template = ObservableStreamTemplate(
           method: MethodOverrideTemplate.fromElement(element, typeNameFinder),
-          hasProtected: element.metadata.hasProtected,
-          hasVisibleForOverriding: element.metadata.hasVisibleForOverriding,
-          hasVisibleForTesting: element.metadata.hasVisibleForTesting,
+          hasProtected: element.metadata2.hasProtected,
+          hasVisibleForOverriding: element.metadata2.hasVisibleForOverriding,
+          hasVisibleForTesting: element.metadata2.hasVisibleForTesting,
         );
 
         _storeTemplate.observableStreams.add(template);
@@ -244,20 +246,20 @@ class StoreClassVisitor extends SimpleElementVisitor2 {
     return;
   }
 
-  bool _asyncObservableIsNotValid(MethodElement method) => _any([
-        errors.staticMethods.addIf(method.isStatic, method.name!),
+  bool _asyncObservableIsNotValid(MethodElement2 method) => _any([
+        errors.staticMethods.addIf(method.isStatic, method.name3!),
         errors.nonAsyncMethods.addIf(
             !_asyncChecker.returnsFuture(method) &&
                 !_asyncChecker.returnsStream(method),
-            method.name!),
+            method.name3!),
       ]);
 
-  bool _actionIsNotValid(MethodElement element) => _any([
-        errors.staticMethods.addIf(element.isStatic, element.name!),
+  bool _actionIsNotValid(MethodElement2 element) => _any([
+        errors.staticMethods.addIf(element.isStatic, element.name3!),
         errors.asyncGeneratorActions.addIf(
           element.fragments.any((fragment) => fragment.isAsynchronous) &&
               element.fragments.any((fragment) => fragment.isGenerator),
-          element.name!,
+          element.name3!,
         ),
       ]);
 
@@ -272,7 +274,7 @@ class StoreClassVisitor extends SimpleElementVisitor2 {
   }
 
   bool _isInvalidPublicSetterOnReadOnlyObservable(
-          PropertyAccessorElement publicSetter) =>
+          PropertyAccessorElement2 publicSetter) =>
       _storeTemplate.observables.templates.any(
         (template) =>
             template.name.nonPrivateName == publicSetter.displayName &&
@@ -284,14 +286,14 @@ const _storeMixinChecker = TypeChecker.typeNamed(Store, inPackage: 'mobx');
 const _toStringAnnotationChecker =
     TypeChecker.typeNamed(StoreConfig, inPackage: 'mobx');
 
-bool isMixinStoreClass(ClassElement classElement) =>
+bool isMixinStoreClass(ClassElement2 classElement) =>
     classElement.mixins.any(_storeMixinChecker.isExactlyType);
 
 // Checks if the class as a toString annotation
-bool isStoreConfigAnnotatedStoreClass(ClassElement classElement) =>
+bool isStoreConfigAnnotatedStoreClass(ClassElement2 classElement) =>
     _toStringAnnotationChecker.hasAnnotationOfExact(classElement);
 
-bool hasGeneratedToString(BuilderOptions options, ClassElement? classElement) {
+bool hasGeneratedToString(BuilderOptions options, ClassElement2? classElement) {
   const fieldKey = 'hasToString';
 
   if (classElement != null && isStoreConfigAnnotatedStoreClass(classElement)) {

--- a/mobx_codegen/lib/src/template/method_override.dart
+++ b/mobx_codegen/lib/src/template/method_override.dart
@@ -1,4 +1,6 @@
-import 'package:analyzer/dart/element/element.dart';
+// ignore_for_file: deprecated_member_use
+
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:mobx_codegen/src/template/comma_list.dart';
 import 'package:mobx_codegen/src/template/params.dart';
 import 'package:mobx_codegen/src/template/util.dart';
@@ -9,12 +11,12 @@ class MethodOverrideTemplate {
   MethodOverrideTemplate();
 
   MethodOverrideTemplate.fromElement(
-    ExecutableElement method,
+    ExecutableElement2 method,
     LibraryScopedNameFinder typeNameFinder,
   ) {
     // ignore: prefer_function_declarations_over_variables
     final param = (FormalParameterElement element) => ParamTemplate(
-        name: element.name!,
+        name: element.name3!,
         type: typeNameFinder.findParameterTypeName(element),
         defaultValue: element.defaultValueCode,
         hasRequiredKeyword: element.isRequiredNamed);
@@ -31,9 +33,9 @@ class MethodOverrideTemplate {
         method.formalParameters.where((param) => param.isNamed).toList();
 
     this
-      ..name = method.name!
+      ..name = method.name3!
       ..returnType = typeNameFinder.findReturnTypeName(method)
-      ..setTypeParams(method.typeParameters
+      ..setTypeParams(method.typeParameters2
           .map((type) => typeParamTemplate(type, typeNameFinder)))
       ..positionalParams = positionalParams.map(param)
       ..optionalParams = optionalParams.map(param)

--- a/mobx_codegen/lib/src/template/method_override.dart
+++ b/mobx_codegen/lib/src/template/method_override.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:mobx_codegen/src/template/comma_list.dart';
 import 'package:mobx_codegen/src/template/params.dart';
 import 'package:mobx_codegen/src/template/util.dart';
@@ -9,13 +9,12 @@ class MethodOverrideTemplate {
   MethodOverrideTemplate();
 
   MethodOverrideTemplate.fromElement(
-    // ignore: deprecated_member_use
-    ExecutableElement2 method,
+    ExecutableElement method,
     LibraryScopedNameFinder typeNameFinder,
   ) {
-    // ignore: prefer_function_declarations_over_variables, deprecated_member_use
+    // ignore: prefer_function_declarations_over_variables
     final param = (FormalParameterElement element) => ParamTemplate(
-        name: element.name3!,
+        name: element.name!,
         type: typeNameFinder.findParameterTypeName(element),
         defaultValue: element.defaultValueCode,
         hasRequiredKeyword: element.isRequiredNamed);
@@ -32,10 +31,9 @@ class MethodOverrideTemplate {
         method.formalParameters.where((param) => param.isNamed).toList();
 
     this
-      ..name = method.name3!
+      ..name = method.name!
       ..returnType = typeNameFinder.findReturnTypeName(method)
-      // ignore: deprecated_member_use
-      ..setTypeParams(method.typeParameters2
+      ..setTypeParams(method.typeParameters
           .map((type) => typeParamTemplate(type, typeNameFinder)))
       ..positionalParams = positionalParams.map(param)
       ..optionalParams = optionalParams.map(param)

--- a/mobx_codegen/lib/src/template/observable.dart
+++ b/mobx_codegen/lib/src/template/observable.dart
@@ -1,4 +1,6 @@
-import 'package:analyzer/dart/element/element.dart';
+// ignore_for_file: deprecated_member_use
+
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:meta/meta.dart';
 import 'package:mobx_codegen/src/template/store.dart';
 import 'package:mobx_codegen/src/utils/non_private_name_extension.dart';
@@ -23,7 +25,7 @@ class ObservableTemplate {
   final bool isPrivate;
   final bool isReadOnly;
   final bool isLate;
-  final ExecutableElement? equals;
+  final ExecutableElement2? equals;
   final bool? useDeepEquality;
 
   /// Formats the `name` from `_foo_bar` to `foo_bar`
@@ -65,7 +67,7 @@ class ObservableTemplate {
     $atomName.reportWrite(value, _${name}IsInitialized ? super.$name : null, () {
       super.$name = value;
       _${name}IsInitialized = true;
-    }${equals != null ? ', equals: ${equals!.name}' : ''});
+    }${equals != null ? ', equals: ${equals!.name3}' : ''});
   }''';
     }
 
@@ -74,7 +76,7 @@ class ObservableTemplate {
   set $name($type value) {
     $atomName.reportWrite(value, super.$name, () {
       super.$name = value;
-    }${equals != null ? ', equals: ${equals!.name}' : ''}${useDeepEquality != null ? ', useDeepEquality: $useDeepEquality' : ''});
+    }${equals != null ? ', equals: ${equals!.name3}' : ''}${useDeepEquality != null ? ', useDeepEquality: $useDeepEquality' : ''});
   }''';
   }
 

--- a/mobx_codegen/lib/src/template/observable.dart
+++ b/mobx_codegen/lib/src/template/observable.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:meta/meta.dart';
 import 'package:mobx_codegen/src/template/store.dart';
 import 'package:mobx_codegen/src/utils/non_private_name_extension.dart';
@@ -23,8 +23,7 @@ class ObservableTemplate {
   final bool isPrivate;
   final bool isReadOnly;
   final bool isLate;
-  // ignore: deprecated_member_use
-  final ExecutableElement2? equals;
+  final ExecutableElement? equals;
   final bool? useDeepEquality;
 
   /// Formats the `name` from `_foo_bar` to `foo_bar`
@@ -66,7 +65,7 @@ class ObservableTemplate {
     $atomName.reportWrite(value, _${name}IsInitialized ? super.$name : null, () {
       super.$name = value;
       _${name}IsInitialized = true;
-    }${equals != null ? ', equals: ${equals!.name3}' : ''});
+    }${equals != null ? ', equals: ${equals!.name}' : ''});
   }''';
     }
 
@@ -75,7 +74,7 @@ class ObservableTemplate {
   set $name($type value) {
     $atomName.reportWrite(value, super.$name, () {
       super.$name = value;
-    }${equals != null ? ', equals: ${equals!.name3}' : ''}${useDeepEquality != null ? ', useDeepEquality: $useDeepEquality' : ''});
+    }${equals != null ? ', equals: ${equals!.name}' : ''}${useDeepEquality != null ? ', useDeepEquality: $useDeepEquality' : ''});
   }''';
   }
 

--- a/mobx_codegen/lib/src/template/util.dart
+++ b/mobx_codegen/lib/src/template/util.dart
@@ -1,4 +1,6 @@
-import 'package:analyzer/dart/element/element.dart';
+// ignore_for_file: deprecated_member_use
+
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:mobx_codegen/src/template/params.dart';
 import 'package:mobx_codegen/src/type_names.dart';
@@ -19,13 +21,13 @@ class AsyncMethodChecker {
 
   late TypeChecker _checkStream;
 
-  bool returnsFuture(MethodElement method) =>
+  bool returnsFuture(MethodElement2 method) =>
       method.returnType.isDartAsyncFuture ||
       (method.fragments.any((fragment) => fragment.isAsynchronous) &&
           !method.fragments.any((fragment) => fragment.isGenerator) &&
           method.returnType is DynamicType);
 
-  bool returnsStream(MethodElement method) =>
+  bool returnsStream(MethodElement2 method) =>
       _checkStream.isAssignableFromType(method.returnType) ||
       (method.fragments.any((fragment) => fragment.isAsynchronous) &&
           method.fragments.any((fragment) => fragment.isGenerator) &&
@@ -33,11 +35,11 @@ class AsyncMethodChecker {
 }
 
 TypeParamTemplate typeParamTemplate(
-  TypeParameterElement param,
+  TypeParameterElement2 param,
   LibraryScopedNameFinder typeNameFinder,
 ) =>
     TypeParamTemplate(
-        name: param.name!,
+        name: param.name3!,
         bound: param.bound != null
             ? typeNameFinder.findTypeParameterBoundsTypeName(param)
             : null);

--- a/mobx_codegen/lib/src/template/util.dart
+++ b/mobx_codegen/lib/src/template/util.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:mobx_codegen/src/template/params.dart';
 import 'package:mobx_codegen/src/type_names.dart';
@@ -19,15 +19,13 @@ class AsyncMethodChecker {
 
   late TypeChecker _checkStream;
 
-  // ignore: deprecated_member_use
-  bool returnsFuture(MethodElement2 method) =>
+  bool returnsFuture(MethodElement method) =>
       method.returnType.isDartAsyncFuture ||
       (method.fragments.any((fragment) => fragment.isAsynchronous) &&
           !method.fragments.any((fragment) => fragment.isGenerator) &&
           method.returnType is DynamicType);
 
-  // ignore: deprecated_member_use
-  bool returnsStream(MethodElement2 method) =>
+  bool returnsStream(MethodElement method) =>
       _checkStream.isAssignableFromType(method.returnType) ||
       (method.fragments.any((fragment) => fragment.isAsynchronous) &&
           method.fragments.any((fragment) => fragment.isGenerator) &&
@@ -35,12 +33,11 @@ class AsyncMethodChecker {
 }
 
 TypeParamTemplate typeParamTemplate(
-  // ignore: deprecated_member_use
-  TypeParameterElement2 param,
+  TypeParameterElement param,
   LibraryScopedNameFinder typeNameFinder,
 ) =>
     TypeParamTemplate(
-        name: param.name3!,
+        name: param.name!,
         bound: param.bound != null
             ? typeNameFinder.findTypeParameterBoundsTypeName(param)
             : null);

--- a/mobx_codegen/lib/src/type_names.dart
+++ b/mobx_codegen/lib/src/type_names.dart
@@ -1,6 +1,8 @@
 // https://github.com/dart-lang/sdk/blob/main/pkg/analyzer/doc/element_model_migration_guide.md
 
-import 'package:analyzer/dart/element/element.dart';
+// ignore_for_file: deprecated_member_use
+
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:mobx_codegen/src/template/comma_list.dart';
@@ -22,15 +24,15 @@ import 'package:mobx_codegen/src/template/comma_list.dart';
 class LibraryScopedNameFinder {
   LibraryScopedNameFinder(this.library);
 
-  final LibraryElement library;
+  final LibraryElement2 library;
 
-  final Map<Element, String?> _namesByElement = {};
+  final Map<Element2, String?> _namesByElement = {};
 
-  Map<Element, String?> get namesByElement {
+  Map<Element2, String?> get namesByElement {
     // Add all of this library's type-defining elements to the name map
-    final libraryElements = library.children.whereType<TypeDefiningElement>();
+    final libraryElements = library.children2.whereType<TypeDefiningElement2>();
     for (final element in libraryElements) {
-      _namesByElement[element] = element.name;
+      _namesByElement[element] = element.name3;
     }
 
     // Reverse each import's export namespace so we can map elements to their
@@ -41,15 +43,15 @@ class LibraryScopedNameFinder {
     // it manually.
 
     final libraryImports = library.fragments
-        .map((fragment) => fragment.libraryImports)
+        .map((fragment) => fragment.libraryImports2)
         .expand((t) => t);
 
     for (final import in libraryImports) {
-      final prefix = import.prefix;
+      final prefix = import.prefix2;
       for (final entry in import.namespace.definedNames2.entries) {
-        _namesByElement[entry.value] = prefix?.name != null
+        _namesByElement[entry.value] = prefix?.name2 != null
             // If the prefix exists, we prepend it to the name
-            ? '${prefix!.name!}.${entry.key}'
+            ? '${prefix!.name2!}.${entry.key}'
             // Otherwise, we just use the name
             : entry.key;
       }
@@ -58,7 +60,7 @@ class LibraryScopedNameFinder {
     return _namesByElement;
   }
 
-  String findVariableTypeName(VariableElement variable) =>
+  String findVariableTypeName(VariableElement2 variable) =>
       _getDartTypeName(variable.type);
 
   String findGetterTypeName(GetterElement getter) {
@@ -68,17 +70,17 @@ class LibraryScopedNameFinder {
   String findParameterTypeName(FormalParameterElement parameter) =>
       _getDartTypeName(parameter.type);
 
-  String findReturnTypeName(FunctionTypedElement executable) =>
+  String findReturnTypeName(FunctionTypedElement2 executable) =>
       _getDartTypeName(executable.returnType);
 
-  List<String?> findReturnTypeArgumentTypeNames(ExecutableElement executable) {
+  List<String?> findReturnTypeArgumentTypeNames(ExecutableElement2 executable) {
     final returnType = executable.returnType;
     return returnType is ParameterizedType
         ? returnType.typeArguments.map(_getDartTypeName).toList()
         : [];
   }
 
-  String? findTypeParameterBoundsTypeName(TypeParameterElement typeParameter) {
+  String? findTypeParameterBoundsTypeName(TypeParameterElement2 typeParameter) {
     assert(typeParameter.bound != null);
     return _getDartTypeName(typeParameter.bound!);
   }
@@ -87,12 +89,12 @@ class LibraryScopedNameFinder {
   ///
   /// The returned string will include import prefixes on all applicable types.
   String _getDartTypeName(DartType type) {
-    var typeElement = type.element;
+    var typeElement = type.element3;
     if (type is FunctionType) {
       // If we're dealing with a typedef, we let it undergo the standard name
       // lookup. Otherwise, we special case the function naming.
-      if (type.alias?.element is TypeAliasElement) {
-        typeElement = type.alias!.element;
+      if (type.alias?.element2 is TypeAliasElement2) {
+        typeElement = type.alias!.element2;
       } else {
         return _getFunctionTypeName(type);
       }
@@ -101,7 +103,6 @@ class LibraryScopedNameFinder {
         typeElement == null ||
             // This is a bare type param, like "T"
             type is TypeParameterType) {
-      // ignore: deprecated_member_use
       return type.getDisplayString(withNullability: true);
     }
 
@@ -130,7 +131,7 @@ class LibraryScopedNameFinder {
     return '$returnTypeName Function($parameterTypeNames)';
   }
 
-  String _getNamedElementTypeName(Element typeElement, DartType type) {
+  String _getNamedElementTypeName(Element2 typeElement, DartType type) {
     // Determine the name of the type, without type arguments.
     assert(namesByElement.containsKey(typeElement));
 

--- a/mobx_codegen/lib/version.dart
+++ b/mobx_codegen/lib/version.dart
@@ -1,4 +1,4 @@
 // Generated via set_version.dart. !!!DO NOT MODIFY BY HAND!!!
 
 /// The current version as per `pubspec.yaml`.
-const version = '2.7.2';
+const version = '2.7.3';

--- a/mobx_codegen/pubspec.yaml
+++ b/mobx_codegen/pubspec.yaml
@@ -14,16 +14,16 @@ environment:
   sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
-  analyzer: ^8.1.1
-  build: ^4.0.0
-  build_resolvers: ^3.0.4
+  analyzer: '>=7.4.0 < 9.0.0'
+  build: '>=3.0.0 < 5.0.0'
+  build_resolvers: '>=3.0.0 < 5.0.0'
   meta: ^1.3.0
   mobx: ^2.5.0
   path: ^1.8.0
-  source_gen: ^4.0.1
+  source_gen: '>=3.0.0 < 5.0.0'
 
 dev_dependencies:
-  build_runner: ^2.7.2
+  build_runner: ^2.6.0
   build_test: ^3.3.0
   coverage: ^1.8.0
   lints: ^5.0.0

--- a/mobx_codegen/pubspec.yaml
+++ b/mobx_codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobx_codegen
 description: Code generator for MobX that adds support for annotating your code with @observable, @computed, @action and also creating Store classes.
-version: 2.7.2
+version: 2.7.3
 
 repository: https://github.com/mobxjs/mobx.dart
 issue_tracker: https://github.com/mobxjs/mobx.dart/issues
@@ -14,16 +14,16 @@ environment:
   sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
-  analyzer: '>=7.4.0 <8.0.0'
-  build: ^3.0.0
-  build_resolvers: ^3.0.0
+  analyzer: ^8.1.1
+  build: ^4.0.0
+  build_resolvers: ^3.0.4
   meta: ^1.3.0
   mobx: ^2.5.0
   path: ^1.8.0
-  source_gen: ^3.0.0
+  source_gen: ^4.0.1
 
 dev_dependencies:
-  build_runner: ^2.6.0
+  build_runner: ^2.7.2
   build_test: ^3.3.0
   coverage: ^1.8.0
   lints: ^5.0.0

--- a/mobx_codegen/test/store_class_visitor_test.dart
+++ b/mobx_codegen/test/store_class_visitor_test.dart
@@ -1,4 +1,6 @@
-import 'package:analyzer/dart/element/element.dart';
+// ignore_for_file: deprecated_member_use
+
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:build/build.dart';
 import 'package:mobx_codegen/src/store_class_visitor.dart';
 import 'package:mobx_codegen/src/template/observable.dart';
@@ -8,7 +10,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 class PropertyAccessorElementMock extends Fake
-    implements PropertyAccessorElement {
+    implements PropertyAccessorElement2 {
   PropertyAccessorElementMock(this._displayName);
 
   final String _displayName;
@@ -17,16 +19,16 @@ class PropertyAccessorElementMock extends Fake
   String get displayName => _displayName;
 }
 
-class ClassElementMock extends Fake implements ClassElement {
+class ClassElementMock extends Fake implements ClassElement2 {
   ClassElementMock(this._name);
 
   final String _name;
 
   @override
-  String get name => _name;
+  String get name3 => _name;
 
   @override
-  List<TypeParameterElement> get typeParameters => [];
+  List<TypeParameterElement2> get typeParameters2 => [];
 }
 
 class StoreTemplateFake extends StoreTemplate {}

--- a/mobx_codegen/test/store_class_visitor_test.dart
+++ b/mobx_codegen/test/store_class_visitor_test.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 import 'package:mobx_codegen/src/store_class_visitor.dart';
 import 'package:mobx_codegen/src/template/observable.dart';
@@ -8,9 +8,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 class PropertyAccessorElementMock extends Fake
-    // ignore: deprecated_member_use
-    implements
-        PropertyAccessorElement2 {
+    implements PropertyAccessorElement {
   PropertyAccessorElementMock(this._displayName);
 
   final String _displayName;
@@ -19,18 +17,16 @@ class PropertyAccessorElementMock extends Fake
   String get displayName => _displayName;
 }
 
-// ignore: deprecated_member_use
-class ClassElementMock extends Fake implements ClassElement2 {
+class ClassElementMock extends Fake implements ClassElement {
   ClassElementMock(this._name);
 
   final String _name;
 
   @override
-  String get name3 => _name;
+  String get name => _name;
 
   @override
-  // ignore: deprecated_member_use
-  List<TypeParameterElement2> get typeParameters2 => [];
+  List<TypeParameterElement> get typeParameters => [];
 }
 
 class StoreTemplateFake extends StoreTemplate {}

--- a/mobx_codegen/test/util_test.dart
+++ b/mobx_codegen/test/util_test.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:mobx_codegen/src/template/util.dart';
 import 'package:mobx_codegen/src/utils/non_private_name_extension.dart';
@@ -8,8 +8,7 @@ import 'package:test/test.dart';
 
 class MockTypeChecker extends Mock implements TypeChecker {}
 
-// ignore: deprecated_member_use
-class MockMethod extends Mock implements MethodElement2 {}
+class MockMethod extends Mock implements MethodElement {}
 
 class MockMethodFragment extends Mock implements MethodFragment {}
 

--- a/mobx_codegen/test/util_test.dart
+++ b/mobx_codegen/test/util_test.dart
@@ -1,4 +1,6 @@
-import 'package:analyzer/dart/element/element.dart';
+// ignore_for_file: deprecated_member_use
+
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:mobx_codegen/src/template/util.dart';
 import 'package:mobx_codegen/src/utils/non_private_name_extension.dart';
@@ -8,7 +10,7 @@ import 'package:test/test.dart';
 
 class MockTypeChecker extends Mock implements TypeChecker {}
 
-class MockMethod extends Mock implements MethodElement {}
+class MockMethod extends Mock implements MethodElement2 {}
 
 class MockMethodFragment extends Mock implements MethodFragment {}
 

--- a/mobx_examples/lib/clock/clock.dart
+++ b/mobx_examples/lib/clock/clock.dart
@@ -32,7 +32,7 @@ class Clock {
     print('Clock stopped ticking');
   }
 
-  void _onTick(_) {
+  void _onTick(dynamic _) {
     _atom.reportChanged();
   }
 }


### PR DESCRIPTION
This PR updates `mobx_codegen` to use `analyzer: '>=7.4.0 < 9.0.0'`, and also upgrades some related packages. `analyzer >= 8.0.0` removes the old `Element` v1 API, and deprecates the v2 names (e.g. `ClassElement2`).

~This PR also resolves associated deprecations, and removes all deprecation ignore comments except for one, which is unrelated to this change as far as I can tell.~

Deprecation changes have been reverted, see discussion below.

---
## Pull Request Checklist

- [x] If the changes are being made to code, ensure the **version in `pubspec.yaml`** is updated. 
- [x] Increment the **`major`/`minor`/`patch`/`patch-count`**, depending on the complexity of change
- [x] Add the necessary **unit tests** to ensure the coverage does not drop
- [x] Update the **Changelog** to include all changes made in this PR, organized by version
- [x] Run the **`melos run set_version` command** from the root directory
- [x] Include the **necessary reviewers** for the PR
- [x] Update the **docs** if there are any API changes or additions to functionality
