### PR TITLE
Drop unused build_resolvers dependency

### DIFF
--- a/mobx_codegen/CHANGELOG.md
+++ b/mobx_codegen/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.7.4
+- Drop build_resolvers as a dependency, which enables support for build_runner 2.8.0
+
 ## 2.7.3
 - Update analyzer version to `>=7.4.0 < 9.0.0`
 - Update source_gen version to `>=3.0.0 < 5.0.0`

--- a/mobx_codegen/lib/version.dart
+++ b/mobx_codegen/lib/version.dart
@@ -1,4 +1,4 @@
 // Generated via set_version.dart. !!!DO NOT MODIFY BY HAND!!!
 
 /// The current version as per `pubspec.yaml`.
-const version = '2.7.3';
+const version = '2.7.4';

--- a/mobx_codegen/pubspec.yaml
+++ b/mobx_codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobx_codegen
 description: Code generator for MobX that adds support for annotating your code with @observable, @computed, @action and also creating Store classes.
-version: 2.7.3
+version: 2.7.4
 
 repository: https://github.com/mobxjs/mobx.dart
 issue_tracker: https://github.com/mobxjs/mobx.dart/issues
@@ -16,7 +16,6 @@ environment:
 dependencies:
   analyzer: '>=7.4.0 < 9.0.0'
   build: '>=3.0.0 < 5.0.0'
-  build_resolvers: '>=3.0.0 < 5.0.0'
   meta: ^1.3.0
   mobx: ^2.5.0
   path: ^1.8.0


### PR DESCRIPTION
Fixes #1053.

This PR drops `build_resolvers` as a dependency, since we don't import it. See the linked issue above for context. Dropping this dependency allows us to support `build_runner: 2.8.0` without dropping support for any earlier `build_runner` versions.

---
## Pull Request Checklist

- [x] If the changes are being made to code, ensure the **version in `pubspec.yaml`** is updated. 
- [x] Increment the **`major`/`minor`/`patch`/`patch-count`**, depending on the complexity of change
- [x] Add the necessary **unit tests** to ensure the coverage does not drop
- [x] Update the **Changelog** to include all changes made in this PR, organized by version
- [x] Run the **`melos run set_version` command** from the root directory
- [x] Include the **necessary reviewers** for the PR
- [x] Update the **docs** if there are any API changes or additions to functionality
