### PR TITLE
chore: prepare mobx_codegen v2.7.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2026-01-08
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`mobx_codegen` - `v2.7.6`](#mobx_codegen---v276)
+
+---
+
+#### `mobx_codegen` - `v2.7.6`
+
+ - **FEAT**: Add support for analyzer 9.0.0 by migrating to the Element API (from deprecated Element2 API) (#1065)
+ - **FEAT**: require `analyzer: ^9.0.0` (#1065)
+
 ## 2025-12-28
 
 ### Changes

--- a/mobx_codegen/pubspec.yaml
+++ b/mobx_codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobx_codegen
 description: Code generator for MobX that adds support for annotating your code with @observable, @computed, @action and also creating Store classes.
-version: 2.7.5
+version: 2.7.6
 
 repository: https://github.com/mobxjs/mobx.dart
 issue_tracker: https://github.com/mobxjs/mobx.dart/issues


### PR DESCRIPTION
## Description

This PR updates the `mobx_codegen` package version to `2.7.6`.

PR #1065 introduced important changes (analyzer 9.0.0 support and Element API migration), but the package version in `pubspec.yaml` wasn't updated. This caused the publish workflow to not detect any changes and skip publishing the new version to pub.dev.

This PR fixes that by:
- Ensuring the version in `pubspec.yaml` is set to `2.7.6` (matching the CHANGELOG)
- Running `melos run set_version` to update `lib/version.dart`

---
## Pull Request Checklist

- [x] If the changes are being made to code, ensure the **version in `pubspec.yaml`** is updated. 
- [x] Increment the **`major`/`minor`/`patch`/`patch-count`**, depending on the complexity of change
- [ ] Add the necessary **unit tests** to ensure the coverage does not drop
- [x] Update the **Changelog** to include all changes made in this PR, organized by version
- [x] Run the **`melos run set_version` command** from the root directory
- [ ] Include the **necessary reviewers** for the PR
- [ ] Update the **docs** if there are any API changes or additions to functionality