### PR TITLE
fix(mobx): fix analyzer infos on beta channel (super parameters + collection contains)

### DIFF
--- a/mobx/CHANGELOG.md
+++ b/mobx/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.6.1
+
+ - **FIX**: use super parameters in spy event constructors to satisfy the `use_super_parameters` lint on the beta analyzer.
+
 ## 2.6.0
 
  - Upgrading sdk and Analyzer fixes

--- a/mobx/lib/src/core/spy.dart
+++ b/mobx/lib/src/core/spy.dart
@@ -62,16 +62,15 @@ class ComputedValueSpyEvent extends SpyEvent {
 }
 
 class ReactionSpyEvent extends SpyEvent {
-  ReactionSpyEvent({required String name})
-    : super._(null, type: 'reaction', name: name, isStart: true);
+  ReactionSpyEvent({required super.name})
+    : super._(null, type: 'reaction', isStart: true);
 }
 
 class ReactionErrorSpyEvent extends SpyEvent {
-  ReactionErrorSpyEvent(this.error, {required String name})
+  ReactionErrorSpyEvent(this.error, {required super.name})
     : super._(
         null,
         type: 'reaction-error',
-        name: name,
         isStart: true,
         isEnd: true,
       );
@@ -83,27 +82,26 @@ class ReactionErrorSpyEvent extends SpyEvent {
 }
 
 class ReactionDisposedSpyEvent extends SpyEvent {
-  ReactionDisposedSpyEvent({required String name})
+  ReactionDisposedSpyEvent({required super.name})
     : super._(
         null,
         type: 'reaction-dispose',
-        name: name,
         isStart: true,
         isEnd: true,
       );
 }
 
 class ActionSpyEvent extends SpyEvent {
-  ActionSpyEvent({required String name})
-    : super._(null, type: 'action', name: name, isStart: true);
+  ActionSpyEvent({required super.name})
+    : super._(null, type: 'action', isStart: true);
 }
 
 class EndedSpyEvent extends SpyEvent {
   EndedSpyEvent({
-    required String type,
-    required String name,
-    Duration? duration,
-  }) : super._(null, type: type, name: name, duration: duration, isEnd: true);
+    required super.type,
+    required super.name,
+    super.duration,
+  }) : super._(null, isEnd: true);
 }
 
 /// Utility function that only invokes the given [fn] once.

--- a/mobx/lib/version.dart
+++ b/mobx/lib/version.dart
@@ -1,4 +1,4 @@
 // Generated via set_version.dart. !!!DO NOT MODIFY BY HAND!!!
 
 /// The current version as per `pubspec.yaml`.
-const version = '2.6.0';
+const version = '2.6.1';

--- a/mobx/pubspec.yaml
+++ b/mobx/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mobx
-version: 2.6.0
+version: 2.6.1
 description: "MobX is a library for reactively managing the state of your applications. Use the power of observables, actions, and reactions to supercharge your Dart and Flutter apps."
 
 repository: https://github.com/mobxjs/mobx.dart

--- a/mobx/test/observable_list_test.dart
+++ b/mobx/test/observable_list_test.dart
@@ -656,7 +656,7 @@ void main() {
         // ignore: avoid_function_literals_in_foreach_calls
         'forEach': (list) => list.forEach((a) {}),
 
-        'contains': (list) => list.contains(null),
+        'contains': (list) => list.contains(20),
         'indexWhere': (list) => list.indexWhere((_) => true),
         'lastWhere': (list) => list.lastWhere((_) => true, orElse: () => 0),
         'lastIndexWhere': (list) => list.lastIndexWhere((_) => true),


### PR DESCRIPTION
The `build_dart_packages (mobx, beta)` CI job fails on the **beta** Dart channel because `dart analyze --fatal-warnings --fatal-infos` now reports analyzer infos that the **stable** channel does not flag yet. With `--fatal-infos`, those infos break the build (exit code 1).

This PR fixes the two infos surfaced by the newer (analyzer 13.x) beta toolchain:

**1. `use_super_parameters` in `mobx/lib/src/core/spy.dart`**

```
info - lib/src/core/spy.dart:65:3  - Parameter 'name' could be a super parameter. - use_super_parameters
info - lib/src/core/spy.dart:70:3  - Parameter 'name' could be a super parameter. - use_super_parameters
info - lib/src/core/spy.dart:86:3  - Parameter 'name' could be a super parameter. - use_super_parameters
info - lib/src/core/spy.dart:97:3  - Parameter 'name' could be a super parameter. - use_super_parameters
info - lib/src/core/spy.dart:102:3 - Parameters 'type', 'name', and 'duration' could be super parameters. - use_super_parameters
```

Convert the remaining `SpyEvent` subclass constructors to forward `name` / `type` / `duration` through super parameters (the sibling `ObservableValueSpyEvent` / `ComputedValueSpyEvent` already do this): `ReactionSpyEvent`, `ReactionErrorSpyEvent`, `ReactionDisposedSpyEvent`, `ActionSpyEvent`, `EndedSpyEvent`.

**2. `collection_methods_unrelated_type` in `mobx/test/observable_list_test.dart`**

`list.contains(null)` on an `ObservableList<int>` triggers `collection_methods_unrelated_type` on analyzer 13.1.0 (beta channel). Use a valid `int` argument instead.

Both changes are behavior-preserving (lint/refactor + test argument), independent of the analyzer v13 support work in #1078, so they are split out here against `main`.

Related to #1078.

---
## Pull Request Checklist


- [x] If the changes are being made to code, ensure the **version in `pubspec.yaml`** is updated. _(mobx: 2.6.0 → 2.6.1)_
- [x] Increment the **`major`/`minor`/`patch`/`patch-count`**, depending on the complexity of change _(patch — no behavior change)_
- [ ] Add the necessary **unit tests** to ensure the coverage does not drop _(N/A — no behavior change; only fixes an analyzer info in an existing test)_
- [x] Update the **Changelog** to include all changes made in this PR, organized by version
- [x] Run the **`melos run set_version` command** from the root directory _(`mobx/lib/version.dart` regenerated to 2.6.1)_
- [ ] Include the **necessary reviewers** for the PR
- [ ] Update the **docs** if there are any API changes or additions to functionality _(N/A — no public API change)_
